### PR TITLE
Fix uniform-grid integration weights and FD derivatives on more than 1 element

### DIFF
--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -54,6 +54,10 @@ function upwind_first_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				df[igrid[i],ielement[i]] = (f[i+1]-f[i])/del[i+1]
             end
         end
+        # fill in points at start of elements, in case we are using more than one
+        for j ∈ 2:ielement[end]
+            df[1, j] = df[end, j-1]
+        end
 		i = 1
 		if adv_fac[i] < 0
 			if bc == "periodic"
@@ -171,6 +175,10 @@ function upwind_second_order!(df, f, del, adv_fac, bc, igrid, ielement)
 			df[igrid[n],ielement[n]] =  (3*f[n]-4*f[n-1]+f[n-2])/(2*del[n-1])
 		end
 	end
+        # fill in points at start of elements, in case we are using more than one
+        for j ∈ 2:ielement[end]
+            df[1, j] = df[end, j-1]
+        end
 	return nothing
 end
 function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
@@ -245,6 +253,10 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 			df[igrid[n],ielement[n]] =  (2*tmp1+3*f[n]-6*f[n-1]+f[n-2])/(6*del[n-1])
 		end
 	#end
+        # fill in points at start of elements, in case we are using more than one
+        for j ∈ 2:ielement[end]
+            df[1, j] = df[end, j-1]
+        end
 	return nothing
 end
 # take the derivative of input function f and return as df
@@ -256,6 +268,10 @@ function centered_second_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 	for i ∈ 2:n-1
 		df[igrid[i],ielement[i]] = 0.5*(f[i+1]-f[i-1])/del[i]
 	end
+        # fill in points at start of elements, in case we are using more than one
+        for j ∈ 2:ielement[end]
+            df[1, j] = df[end, j-1]
+        end
 	# use BCs to treat boundary points
 	if bc == "periodic"
 		i = 1
@@ -287,6 +303,10 @@ function centered_second_order!(df::Array{mk_float,1}, f, del, bc, igrid, ieleme
 	for i ∈ 2:n-1
 		df[i] = 0.5*(f[i+1]-f[i-1])/del[i]
 	end
+        # fill in points at start of elements, in case we are using more than one
+        for j ∈ 2:ielement[end]
+            df[1, j] = df[end, j-1]
+        end
 	# use BCs to treat boundary points
 	if bc == "periodic"
 		i = 1
@@ -353,6 +373,10 @@ function centered_fourth_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 		i = n-1
 		df[igrid[i],ielement[i]] = (8.0*(f[i+1]-f[i-1])+f[i-2])/(12.0*del[i])
 	end
+        # fill in points at start of elements, in case we are using more than one
+        for j ∈ 2:ielement[end]
+            df[1, j] = df[end, j-1]
+        end
 end
 
 

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -43,13 +43,11 @@ function composite_simpson_weights(grid)
     if n > 5
         if mod(n,2) == 0
             wgts[4] += c1
-        end
-        for i ∈ 5:n-1
-            if mod(i,2) == 0
-                wgts[i] = c3
-            else
-                wgts[i] = c2
-            end
+            wgts[5:2:n-1] .= c2
+            wgts[6:2:n-1] .= c3
+        else
+            wgts[5:2:n-1] .= c3
+            wgts[6:2:n-1] .= c2
         end
     end
     return wgts

--- a/test/calculus_tests.jl
+++ b/test/calculus_tests.jl
@@ -7,14 +7,18 @@ using moment_kinetics.coordinates: define_coordinate
 using moment_kinetics.chebyshev: setup_chebyshev_pseudospectral
 using moment_kinetics.calculus: derivative!, integral
 
+fd_fake_setup(x) = return false
+
 @testset "calculus" begin
-    @testset "fundamental theorem of calculus" begin
+    @testset "fundamental theorem of calculus" for (discretization, setup_func) ∈
+            (("finite_difference", fd_fake_setup),
+             ("chebyshev_pseudospectral", setup_chebyshev_pseudospectral))
+
         etol = 1.0e-15
         # define inputs needed for the test
         ngrid = 5
         nelement = 2
         L = 6.0
-        discretization = "chebyshev_pseudospectral"
         bc = "periodic"
         # fd_option and adv_input not actually used so given values unimportant
         fd_option = ""
@@ -26,7 +30,7 @@ using moment_kinetics.calculus: derivative!, integral
         x = define_coordinate(input)
         # create arrays needed for Chebyshev pseudospectral treatment in x
         # and create the plans for the forward and backward fast Chebyshev transforms
-        spectral = setup_chebyshev_pseudospectral(x)
+        spectral = setup_func(x)
         # create array for the function f(x) to be differentiated/integrated
         f = Array{Float64,1}(undef, x.n)
         # create array for the derivative df/dx

--- a/test/calculus_tests.jl
+++ b/test/calculus_tests.jl
@@ -9,15 +9,23 @@ using moment_kinetics.calculus: derivative!, integral
 
 fd_fake_setup(x) = return false
 
-@testset "calculus" begin
-    @testset "fundamental theorem of calculus" for (discretization, setup_func) ∈
+@testset "fundamental theorem of calculus" begin
+    @testset "$discretization $ngrid $nelement" for (discretization, setup_func) ∈
             (("finite_difference", fd_fake_setup),
-             ("chebyshev_pseudospectral", setup_chebyshev_pseudospectral))
+             ("chebyshev_pseudospectral", setup_chebyshev_pseudospectral)),
+            ngrid ∈ (5,6,7,8,9,10), nelement ∈ (1, 2, 3, 4, 5)
+
+        if discretization == "finite_difference" && (ngrid - 1) * nelement % 2 == 1
+            # When the total number of points (counting the periodically identified end
+            # points a a single point) is odd, we have to use Simpson's 3/8 rule for
+            # integration for one set of points at the beginning of the array, which
+            # breaks the symmetry that makes integration of the derivative exact, so
+            # this test would fail
+            continue
+        end
 
         etol = 1.0e-15
         # define inputs needed for the test
-        ngrid = 5
-        nelement = 2
         L = 6.0
         bc = "periodic"
         # fd_option and adv_input not actually used so given values unimportant

--- a/test/calculus_tests.jl
+++ b/test/calculus_tests.jl
@@ -59,6 +59,6 @@ fd_fake_setup(x) = return false
         #end
 
         # Test that error intdf is less than the specified error tolerance etol
-        @test intdf < etol
+        @test abs(intdf) < etol
     end
 end


### PR DESCRIPTION
Found a small bug in the 'finite difference' integration weights. For grids with an odd number of points, the weights for points 5 and upward were the wrong way around. Found by adding a finite difference variant to the calculus unit test (which I did while looking to copy the pattern for a test of an interpolation function).

The difference:
```
previously weights were: h/3, 4h/3, 2h/3, 4h/3, 4h/3, 2h/3, 4h/3, ...
weights should be      : h/3, 4h/3, 2h/3, 4h/3, 2h/3, 4h/3, 2h/3, ...