### PR TITLE
Fix long tests in CI

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -26,22 +26,6 @@ jobs:
         # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
         # in order to pass customised arguments to `Pkg.test()`
         #
-        # Occasionally, there are rather large delays (> a few hours)
-        # between the time a package is registered in General and
-        # propagated to pkg.julialang.org.  We can avoid this by manually
-        # cloning ~/.julia/registries/General/ in Julia 1.5 and later.
-        # See:
-        # * https://github.com/JuliaLang/Pkg.jl/issues/2011
-        # * https://github.com/JuliaRegistries/General/issues/16777
-        # * https://github.com/JuliaPackaging/PkgServer.jl/issues/60
-      - run: julia --color=yes "$GITHUB_ACTION_PATH"/add_general_registry.jl
-        shell: bash
-        env:
-          # We set `JULIA_PKG_SERVER` only for this step to enforce
-          # `Pkg.Registry.add` to use Git.  This way, Pkg.jl can send
-          # the request metadata to pkg.julialang.org when installing
-          # packages via `Pkg.test`.
-          JULIA_PKG_SERVER: ""
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --inline=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = :true, force_latest_compatible_version = :auto, test_args=["--long"])'
+          julia --check-bounds=yes --color=yes --depwarn=yes --inline=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = :true, test_args=["--long"])'
         shell: bash


### PR DESCRIPTION
Skip a workaround used by the 'julia-runtest' action for the case when the Julia 'General Registry' is not perfectly up to date - requires a file from that action, so rather than copying the file just skip as it doesn't seem to be too important. Also remove `force_latest_compatible_version` argument to `Pkg.test()` which caused an error.