### PR TITLE
Macro expansion examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,3 +27,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+
+[compat]
+julia = "1.7.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # moment_kinetics
-0) Ensure that the Julia version is >= 1.6.1 by doing
+0) Ensure that the Julia version is >= 1.7.0 by doing
     ```
     $ julia --version
     ```

--- a/README.md
+++ b/README.md
@@ -164,6 +164,24 @@ To get more output on what tests were successful, an option `--verbose` (or `-v`
             end
             ```
             The dimensions in the prefix before `_loop_` again give the dimensions that are looped over in the nested loop. The dimension in the suffix after `_loop_` indicates which particular dimension the macro loops over. The argument before `begin` is the name of the loop variables.
+        * To help show how these macros work, a script is provided that print a set of examples where the loop macros are expanded. It can be run from the Julia REPL
+            ```
+            $ julia --project
+                           _
+               _       _ _(_)_     |  Documentation: https://docs.julialang.org
+              (_)     | (_) (_)    |
+               _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
+              | | | | | | |/ _` |  |
+              | | |_| | | | (_| |  |  Version 1.7.0 (2021-11-30)
+             _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
+            |__/                   |
+
+            julia> include("util/print-macros.jl")
+            ```
+            or on the command line
+            ```
+            $ julia --project util/print-macros.jl
+            ```
     * The ranges used are stored in a `LoopRanges` struct in the `Ref` variable `loop_ranges` (which is exported by the `looping` module). Occasionally it is useful to access the range directly. For example the range looped over by the macro `@s_z_loop_s` is `loop_ranges[].s_z_range_s` (same prefix/suffix meanings as the macro).
             * The square brackets `[]` are needed because `loop_ranges` is a reference to a `LoopRanges` object `Ref{LoopRanges}` (a bit like a pointer) - it allows `loop_ranges` to be a `const` variable, so its type is always known at compile time, but the actual `LoopRanges` can be set/modified at run-time.
     * It is also possible to run a block of code in serial (on just the rank-0 member of each block of processes) by wrapping it in a `@serial_region` macro. This is mostly useful for initialization or file I/O where performance is not critical. For example

--- a/util/print-macros.jl
+++ b/util/print-macros.jl
@@ -1,0 +1,62 @@
+module PrintMacros
+"""
+This script prints expanded version of auto-generated macros.
+Intended to help developers see what the macros are doing.
+"""
+
+export print_macros
+
+using moment_kinetics.looping
+using moment_kinetics.looping: dimension_combinations, dims_string
+
+function print_macros()
+    println("Here is a set of examples of expanding the macros defined in the `looping` module")
+    println()
+
+    # Print combined nested loop macros
+    for dims ∈ dimension_combinations
+        println()
+
+        iteration_vars = Tuple(string("i", d) for d ∈ dims)
+        macro_name = string("@", dims_string(dims), "_loop")
+        macro_example = """
+            $macro_name $(join(iteration_vars, " ")) begin
+                foo[$(join(iteration_vars, ","))] = something
+            end
+        """
+        println("```")
+        println(macro_example)
+        println("```")
+        println("expands to:")
+        println("```")
+        println(eval(Meta.parse("@macroexpand $macro_example")))
+        println("```")
+    end
+
+    # Print single-level loop macros
+    for dims ∈ dimension_combinations
+        for d ∈ dims
+            println()
+
+            iteration_var = string("i", d)
+            macro_name = string("@", dims_string(dims), "_loop_", d)
+            macro_example = """
+                $macro_name $(iteration_var) begin
+                    foo[$(iteration_var)] = something
+                end
+            """
+            println("```")
+            println(macro_example)
+            println("```")
+            println("expands to:")
+            println("```")
+            println(eval(Meta.parse("@macroexpand $macro_example")))
+            println("```")
+        end
+    end
+end
+
+end # PrintMacros
+
+using .PrintMacros
+print_macros()


### PR DESCRIPTION
Adds a script that prints all the loop macros created in the `looping` module along with macro-expansions of an example call.

We talked about writing to a file. Could do that easily if people prefer, but having got this far just printing to stdout seemed like a reasonable thing to do: not being saved to a file it's clear that the output is just output and can't be edited to change the code, etc.

Also includes a commit bumping the required Julia version to 1.7.0. Also adds the version requirement to the `Project.toml`, which I'd hoped would result in nicer error messages if someone tries to use a too-old version of Julia, but unfortunately this seems not to be the case: https://discourse.julialang.org/t/strange-error-for-unsupported-julia-version/74489