### PR TITLE
Fix loop macro documentation

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ To get more output on what tests were successful, an option `--verbose` (or `-v`
         * 1\. If there is just a single nested loop, then for example
             ```
             @s_z_loop is iz begin
-                for izpa in 1:vpa.n
+                for ivpa in 1:vpa.n
                     f[ivpa,iz,is] = ...
                 end
             end

--- a/util/print-macros.jl
+++ b/util/print-macros.jl
@@ -21,7 +21,7 @@ function print_macros()
         macro_name = string("@", dims_string(dims), "_loop")
         macro_example = """
             $macro_name $(join(iteration_vars, " ")) begin
-                foo[$(join(iteration_vars, ","))] = something
+                foo[$(join(reverse(iteration_vars), ","))] = something
             end
         """
         println("```")


### PR DESCRIPTION
When used to index the example array, the indices printed by `util/print-macros.jl` were in the reverse of the correct order.

Also fix typo in `README.md`.