### PR TITLE
Use begin_s_region() for moment updates

### DIFF
--- a/src/continuity.jl
+++ b/src/continuity.jl
@@ -9,11 +9,9 @@ using ..looping
 function continuity_equation!(dens_out, fvec_in, moments, composition, vpa, z, dt, spectral)
     # use the continuity equation dn/dt + d(n*upar)/dz to update the density n
     # for each species
-    @s_z_loop_s is begin
-        if 1 ∈ loop_ranges[].s_z_range_z
-            @views continuity_equation_single_species!(dens_out[:,is],
-                fvec_in.density[:,is], fvec_in.upar[:,is], z, dt, spectral)
-        end
+    @s_loop is begin
+        @views continuity_equation_single_species!(dens_out[:,is],
+            fvec_in.density[:,is], fvec_in.upar[:,is], z, dt, spectral)
     end
 end
 # use the continuity equation dn/dt + d(n*upar)/dz to update the density n

--- a/src/energy_equation.jl
+++ b/src/energy_equation.jl
@@ -6,11 +6,9 @@ using ..calculus: derivative!
 using ..looping
 
 function energy_equation!(ppar, fvec, moments, collisions, z, dt, spectral, composition)
-    @s_z_loop_s is begin
-        if 1 ∈ loop_ranges[].s_z_range_z
-            @views energy_equation_noCX!(ppar[:,is], fvec.upar[:,is], fvec.ppar[:,is],
-                                         moments.qpar[:,is], dt, z, spectral)
-        end
+    @s_loop is begin
+        @views energy_equation_noCX!(ppar[:,is], fvec.upar[:,is], fvec.ppar[:,is],
+                                     moments.qpar[:,is], dt, z, spectral)
     end
     # add in contribution due to charge exchange
     if composition.n_neutral_species > 0 && abs(collisions.charge_exchange) > 0.0
@@ -33,17 +31,15 @@ function energy_equation_noCX!(ppar_out, upar, ppar, qpar, dt, z, spectral)
     @. ppar_out -= 3.0*dt*ppar*z.scratch
 end
 function energy_equation_CX!(ppar_out, dens, ppar, composition, CX_frequency, dt)
-    @s_z_loop_s is begin
-        if 1 ∈ loop_ranges[].s_z_range_z
-            if is ∈ composition.ion_species_range
-                for isp ∈ composition.neutral_species_range
-                    @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
-                end
+    @s_loop is begin
+        if is ∈ composition.ion_species_range
+            for isp ∈ composition.neutral_species_range
+                @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
             end
-            if is ∈ composition.neutral_species_range
-                for isp ∈ composition.ion_species_range
-                    @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
-                end
+        end
+        if is ∈ composition.neutral_species_range
+            for isp ∈ composition.ion_species_range
+                @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
             end
         end
     end


### PR DESCRIPTION
When @mrhardman and I were talking earlier, we were puzzled by this construction
https://github.com/mabarnes/moment_kinetics/blob/74e16e935304ade85fcd46c2071c0185864ab5d4/src/time_advance.jl#L665-L669

The motivation for it was that the moment updates in `continuity_equation!()`, etc., need to take z-derivatives, so they can only parallelize over species. This was being done by using `@s_z_loop_s`, and then `if 1 in loop_ranges[].s_z_loop_z`, in order to avoid changing the loop type.

It seems clearer to instead completely separate the part of euler_time_advance!() that updates the distribution function (by moving the boundary condition application from the bottom of euler_time_advance!() to the end of the distribution function update), and then use `begin_s_region(no_synchronize=true)` before the moment update, which can then use `@s_loop`. It is possible to use the `no_synchronize=true` argument to skip the _block_synchronize() call at that point because before it only the distribution function is updated and after it only the moments are updated, so there is no possibility of a race condition.