### PR TITLE
Simplify loop macros - loop_ranges[] depends on region

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,29 +141,33 @@ To get more output on what tests were successful, an option `--verbose` (or `-v`
         * Recommended option is to use [tmpi](https://github.com/Azrael3000/tmpi). This utility (it's a bash script that uses `tmux`) starts an mpi program with each process in a separate pane in a single terminal, and mirrors input to all processes simultaneously (which is normally what you want, there are also commands to 'zoom in' on a single process).
         * Another 'low-tech' possibilty is to use something like `mpirun -np 4 xterm -e julia --project`, but that will start each process in a separate xterm and you would have to enter commands separately in each one. Occasionally useful for debugging when nothing else is available.
     * There is no restriction on the number of processes or number of grid points, although load-balancing may be affected - if there are only very few points per process, and a small fraction of processes have an extra grid point (e.g. splitting 5 points over 4 processes, so 3 process have 1 point but 1 process has 2 points), many processes will spend time waiting for the few with an extra point.
-    * Parallelism is implemented through macros that get the local ranges of points that each process should handle. The inner-most level of nested loops is typically not parallelized, to allow efficient FFTs for derivatives, etc. There are two types of loop macros:
-        * 1\. If there is just a single nested loop, then for example
-            ```
-            @s_z_loop is iz begin
-                for ivpa in 1:vpa.n
-                    f[ivpa,iz,is] = ...
-                end
+    * Parallelism is implemented through macros that get the local ranges of points that each process should handle. The inner-most level of nested loops is typically not parallelized, to allow efficient FFTs for derivatives, etc. A loop over one (possibly parallelized) dimension can be written as, for example,
+        ```
+        @loop_s is begin
+            f[is] = ...
+        end
+        ```
+        These macros can be nested as needed for relatively complex loops
+        ```
+        @loop_s is begin
+            some_setup(is)
+            @loop_z iz begin
+                @views do_something(f[:,iz,is])
             end
-            ```
-            The dimensions in the prefix before `_loop` give the dimensions that are looped over by the macro, the arguments before `begin` are the names of the loop variables, in the same order as the dimensions in the prefix; the first dimension/loop-variable corresponds to the outermost nested loop, etc.
-        * 2\. For more complex loops, a separate macro can be used for each level, for example
-            ```
-            @s_z_loop_s is begin
-                some_setup(is)
-                @s_z_loop_z iz begin
-                    @views do_something(f[:,iz,is])
-                end
-                @s_z_loop_z iz begin
-                    @views do_something_else(f[:,iz,is])
-                end
+            @loop_z iz begin
+                @views do_something_else(f[:,iz,is])
             end
-            ```
-            The dimensions in the prefix before `_loop_` again give the dimensions that are looped over in the nested loop. The dimension in the suffix after `_loop_` indicates which particular dimension the macro loops over. The argument before `begin` is the name of the loop variables.
+        end
+        ```
+        Simpler nested loops can (optionally) be written more compactly
+        ```
+        @loop_s_z_vpa is iz ivpa begin
+            f[ivpa,iz,is] = ...
+        end
+        ```
+        Which dimensions are actually parallelized by these macros is controlled by the 'region' that the code is currently in, as set by the `begin_<dims>_region()` functions, which <dims> are the dimensions that will be parallelized in the following region. For example, after calling `begin_s_z_region()` loop over species and z will be divided up over the processes in a 'block' (currently there is only one block, which contains the whole grid and all the processes being used, as we have not yet implemented distributed-memory parallelism). Every process will loop over all points in the remaining dimensions.
+        * In a region after `begin_serial_region()`, the rank 0 process in each block will loop over all points in every dimension, and all other ranks will not loop over any.
+        * Inside serial regions, the macro `@serial_region` can also be used to wrap blocks of code so that they only run on rank 0 of the block. This is useful for example to allow the use of array-broadcast expressions during initialization where performance is not critical.
         * To help show how these macros work, a script is provided that print a set of examples where the loop macros are expanded. It can be run from the Julia REPL
             ```
             $ julia --project

--- a/src/charge_exchange.jl
+++ b/src/charge_exchange.jl
@@ -8,7 +8,7 @@ function charge_exchange_collisions!(f_out, fvec_in, moments, composition, vpa, 
                                      charge_exchange_frequency, dt)
 
     if moments.evolve_density
-        @s_z_loop_s is begin
+        @loop_s is begin
             # apply CX collisions to all ion species
             if is ∈ composition.ion_species_range
                 # for each ion species, obtain affect of charge exchange collisions
@@ -16,7 +16,7 @@ function charge_exchange_collisions!(f_out, fvec_in, moments, composition, vpa, 
                 for isp ∈ composition.neutral_species_range
                     #cxfac = dt*charge_exchange_frequency[is,isp]
                     #cxfac = dt*charge_exchange_frequency
-                    @s_z_loop_z iz begin
+                    @loop_z iz begin
                         for ivpa ∈ 1:vpa.n
                             f_out[ivpa,iz,is] +=
                             dt*charge_exchange_frequency*fvec_in.density[iz,isp]*
@@ -31,7 +31,7 @@ function charge_exchange_collisions!(f_out, fvec_in, moments, composition, vpa, 
                 # with all of the ion species
                 for isp ∈ composition.ion_species_range
                     #cxfac = dt*charge_exchange_frequency
-                    @s_z_loop_z iz begin
+                    @loop_z iz begin
                         for ivpa ∈ 1:vpa.n
                             f_out[ivpa,iz,is] +=
                             dt*charge_exchange_frequency*fvec_in.density[iz,isp]*
@@ -42,7 +42,7 @@ function charge_exchange_collisions!(f_out, fvec_in, moments, composition, vpa, 
             end
         end
     else
-        @s_z_loop_s is begin
+        @loop_s is begin
             # apply CX collisions to all ion species
             if is ∈ composition.ion_species_range
                 # for each ion species, obtain affect of charge exchange collisions
@@ -50,7 +50,7 @@ function charge_exchange_collisions!(f_out, fvec_in, moments, composition, vpa, 
                 for isp ∈ composition.neutral_species_range
                     #cxfac = dt*charge_exchange_frequency[is,isp]
                     #cxfac = dt*charge_exchange_frequency
-                    @s_z_loop_z iz begin
+                    @loop_z iz begin
                         for ivpa ∈ 1:vpa.n
                             f_out[ivpa,iz,is] +=
                                 dt*charge_exchange_frequency*(
@@ -66,7 +66,7 @@ function charge_exchange_collisions!(f_out, fvec_in, moments, composition, vpa, 
                 # with all of the ion species
                 for isp ∈ composition.ion_species_range
                     #cxfac = dt*charge_exchange_frequency
-                    @s_z_loop_z iz begin
+                    @loop_z iz begin
                         for ivpa ∈ 1:vpa.n
                             f_out[ivpa,iz,is] +=
                                 dt*charge_exchange_frequency*(

--- a/src/continuity.jl
+++ b/src/continuity.jl
@@ -9,11 +9,9 @@ using ..looping
 function continuity_equation!(dens_out, fvec_in, moments, composition, vpa, z, dt, spectral)
     # use the continuity equation dn/dt + d(n*upar)/dz to update the density n
     # for each species
-    @s_z_loop_s is begin
-        if 1 ∈ loop_ranges[].s_z_range_z
-            @views continuity_equation_single_species!(dens_out[:,is],
-                fvec_in.density[:,is], fvec_in.upar[:,is], z, dt, spectral)
-        end
+    @s_loop is begin
+        @views continuity_equation_single_species!(dens_out[:,is],
+            fvec_in.density[:,is], fvec_in.upar[:,is], z, dt, spectral)
     end
 end
 # use the continuity equation dn/dt + d(n*upar)/dz to update the density n

--- a/src/continuity.jl
+++ b/src/continuity.jl
@@ -9,7 +9,7 @@ using ..looping
 function continuity_equation!(dens_out, fvec_in, moments, composition, vpa, z, dt, spectral)
     # use the continuity equation dn/dt + d(n*upar)/dz to update the density n
     # for each species
-    @s_loop is begin
+    @loop_s is begin
         @views continuity_equation_single_species!(dens_out[:,is],
             fvec_in.density[:,is], fvec_in.upar[:,is], z, dt, spectral)
     end

--- a/src/debugging.jl
+++ b/src/debugging.jl
@@ -18,7 +18,6 @@ module debugging
 macronames = [
               ("debug_initialize_NaN", 1),
               ("debug_error_stop_all", 1),
-              ("debug_loop_type_region", 1),
               ("debug_block_synchronize", 2),
               ("debug_shared_array", 2),
               ("debug_shared_array_allocate", 3),
@@ -70,16 +69,6 @@ for (macroname, minlevel) ∈ macronames
     end
 
     eval(macro_block)
-end
-
-@debug_loop_type_region begin
-    # Add checks that loop macros are used within the correct 'parallel region'. Helps
-    # ensure the `begin_*_region()` functions were called in the right places.
-    #
-    # Define this variable in `debugging` so that it can be imported in both
-    # communication.jl and looping.jl
-    const current_loop_region_type = Ref("serial")
-    export current_loop_region_type
 end
 
 end # debugging

--- a/src/em_fields.jl
+++ b/src/em_fields.jl
@@ -51,12 +51,12 @@ function update_phi!(fields, fvec, z, composition)
        # though synchronization is needed here.
        _block_synchronize()
     end
-    if 1 ∈ loop_ranges[].s_z_range_s
-        @s_z_loop_z iz begin
+    if 1 ∈ loop_ranges[].s
+        @loop_z iz begin
             z.scratch[iz] = fvec.density[iz,1]
         end
         @inbounds for is ∈ 2:composition.n_ion_species
-            @s_z_loop_z iz begin
+            @loop_z iz begin
                 z.scratch[iz] += fvec.density[iz,is]
             end
         end
@@ -82,7 +82,7 @@ function update_phi!(fields, fvec, z, composition)
         end
 
         if composition.electron_physics ∈ (boltzmann_electron_response, boltzmann_electron_response_with_simple_sheath)
-            @s_z_loop_z iz begin
+            @loop_z iz begin
                 fields.phi[iz] = composition.T_e * log(z.scratch[iz] / N_e)
             end
             # if fields.force_phi

--- a/src/energy_equation.jl
+++ b/src/energy_equation.jl
@@ -6,7 +6,7 @@ using ..calculus: derivative!
 using ..looping
 
 function energy_equation!(ppar, fvec, moments, collisions, z, dt, spectral, composition)
-    @s_loop is begin
+    @loop_s is begin
         @views energy_equation_noCX!(ppar[:,is], fvec.upar[:,is], fvec.ppar[:,is],
                                      moments.qpar[:,is], dt, z, spectral)
     end
@@ -31,7 +31,7 @@ function energy_equation_noCX!(ppar_out, upar, ppar, qpar, dt, z, spectral)
     @. ppar_out -= 3.0*dt*ppar*z.scratch
 end
 function energy_equation_CX!(ppar_out, dens, ppar, composition, CX_frequency, dt)
-    @s_loop is begin
+    @loop_s is begin
         if is ∈ composition.ion_species_range
             for isp ∈ composition.neutral_species_range
                 @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])

--- a/src/energy_equation.jl
+++ b/src/energy_equation.jl
@@ -6,11 +6,9 @@ using ..calculus: derivative!
 using ..looping
 
 function energy_equation!(ppar, fvec, moments, collisions, z, dt, spectral, composition)
-    @s_z_loop_s is begin
-        if 1 ∈ loop_ranges[].s_z_range_z
-            @views energy_equation_noCX!(ppar[:,is], fvec.upar[:,is], fvec.ppar[:,is],
-                                         moments.qpar[:,is], dt, z, spectral)
-        end
+    @s_loop is begin
+        @views energy_equation_noCX!(ppar[:,is], fvec.upar[:,is], fvec.ppar[:,is],
+                                     moments.qpar[:,is], dt, z, spectral)
     end
     # add in contribution due to charge exchange
     if composition.n_neutral_species > 0 && abs(collisions.charge_exchange) > 0.0
@@ -33,17 +31,15 @@ function energy_equation_noCX!(ppar_out, upar, ppar, qpar, dt, z, spectral)
     @. ppar_out -= 3.0*dt*ppar*z.scratch
 end
 function energy_equation_CX!(ppar_out, dens, ppar, composition, CX_frequency, dt)
-    @s_z_loop_s is begin
-        if 1 ∈ loop_ranges[].s_z_range_z
-            if is ∈ composition.ion_species_range
-                for isp ∈ composition.neutral_species_range
-                    @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
-                end
+    @s_loop is begin
+        if is ∈ composition.ion_species_range
+            for isp ∈ composition.neutral_species_range
+                @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
             end
-            if is ∈ composition.neutral_species_range
-                for isp ∈ composition.ion_species_range
-                    @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
-                end
+        end
+        if is ∈ composition.neutral_species_range
+            for isp ∈ composition.ion_species_range
+                @views @. ppar_out[:,is] -= dt*CX_frequency*(dens[:,isp]*ppar[:,is]-dens[:,is]*ppar[:,isp])
             end
         end
     end

--- a/src/force_balance.jl
+++ b/src/force_balance.jl
@@ -10,7 +10,7 @@ using ..looping
 # to update the parallel particle flux dens*upar for each species
 function force_balance!(pflx, fvec, fields, collisions, vpa, z, dt, spectral, composition)
     # account for momentum flux contribution to force balance
-    @s_loop is begin
+    @loop_s is begin
         @views force_balance_flux_species!(pflx[:,is], fvec.density[:,is], fvec.upar[:,is], fvec.ppar[:,is], z, dt, spectral)
         if is ∈ composition.ion_species_range
             # account for parallel electric field contribution to force balance
@@ -51,7 +51,7 @@ function force_balance_Epar_species!(pflx, phi, dens, z, dt, spectral)
 end
 
 function force_balance_CX!(pflx, dens, upar, CX_frequency, composition, z, dt)
-    @s_loop is begin
+    @loop_s is begin
         # include contribution to ion acceleration due to collisional friction with neutrals
         if is ∈ composition.ion_species_range
             for isp ∈ composition.neutral_species_range

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -212,7 +212,7 @@ function init_pdf_over_density!(pdf, spec, vpa, z, vth, upar, vpa_norm_fac, evol
     return nothing
 end
 function enforce_boundary_conditions!(f, vpa_bc, z_bc, vpa, z, vpa_adv::T1, z_adv::T2, composition) where {T1, T2}
-    @s_z_loop is iz begin
+    @loop_s_z is iz begin
         # enforce the vpa BC
         @views enforce_vpa_boundary_condition_local!(f[:,iz,is], vpa_bc, vpa_adv[is].upwind_idx[iz],
                                                      vpa_adv[is].downwind_idx[iz])
@@ -231,13 +231,13 @@ function enforce_z_boundary_condition!(f, bc::String, adv::T, vpa, composition) 
     # 'constant' BC is time-independent f at upwind boundary
     # and constant f beyond boundary
     if bc == "constant"
-        @s_vpa_loop is ivpa begin
+        @loop_s_vpa is ivpa begin
             upwind_idx = adv[ivpa,is].upwind_idx[]
             f[ivpa,upwind_idx,is] = density_offset * exp(-(vpa.grid[ivpa]/vpawidth)^2) / sqrt(pi)
         end
     # 'periodic' BC enforces periodicity by taking the average of the boundary points
     elseif bc == "periodic"
-        @s_vpa_loop is ivpa begin
+        @loop_s_vpa is ivpa begin
             downwind_idx = adv[is].downwind_idx[ivpa]
             upwind_idx = adv[is].upwind_idx[ivpa]
             f[ivpa,downwind_idx,is] = 0.5*(f[ivpa,upwind_idx,is]+f[ivpa,downwind_idx,is])
@@ -245,10 +245,10 @@ function enforce_z_boundary_condition!(f, bc::String, adv::T, vpa, composition) 
         end
     # 'wall' BC enforces wall boundary conditions
     elseif bc == "wall"
-        @s_vpa_loop_s is begin
+        @loop_s is begin
             # zero incoming BC for ions, as they recombine at the wall
             if is ∈ composition.ion_species_range
-                @s_vpa_loop_vpa ivpa begin
+                @loop_vpa ivpa begin
                     # no parallel BC should be enforced for vpa = 0
                     if abs(vpa.grid[ivpa]) > zero
                         upwind_idx = adv[is].upwind_idx[ivpa]

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -16,9 +16,9 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
         # resolution, which then causes crashes due to overshoots giving
         # negative f??
         width = 0.5
-        @s_z_loop_s is begin
+        @loop_s is begin
             if is ∈ composition.ion_species_range
-                @s_z_loop_z iz begin
+                @loop_z iz begin
                     for ivpa ∈ 1:vpa.n
                         f_out[ivpa,iz,is] += dt*collisions.ionization/width*exp(-(vpa.grid[ivpa]/width)^2)
                     end
@@ -26,13 +26,13 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
             end
         end
     else
-        @s_z_loop_s is begin
+        @loop_s is begin
             # apply ionization collisions to all ion species
             if is ∈ composition.ion_species_range
                 # for each ion species, obtain affect of charge exchange collisions
                 # with all of the neutral species
                 for isp ∈ composition.neutral_species_range
-                    @s_z_loop_z iz begin
+                    @loop_z iz begin
                         for ivpa ∈ 1:vpa.n
                             #NB: used quasineutrality to replace electron density with ion density
                             f_out[ivpa,iz,is] += dt*collisions.ionization*fvec_in.pdf[ivpa,iz,isp]*fvec_in.density[iz,is]
@@ -45,7 +45,7 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
                 # for each neutral species, obtain affect of ionization collisions
                 # with all of the ion species
                 for isp ∈ composition.ion_species_range
-                    @s_z_loop_z iz begin
+                    @loop_z iz begin
                         for ivpa ∈ 1:vpa.n
                             f_out[ivpa,iz,is] -= dt*collisions.ionization*fvec_in.pdf[ivpa,iz,is]*fvec_in.density[iz,isp]
                         end

--- a/src/looping.jl
+++ b/src/looping.jl
@@ -10,11 +10,6 @@ using ..type_definitions: mk_int
 using Combinatorics
 using Primes
 
-@debug_loop_type_region using ..debugging: current_loop_region_type
-
-# Export this to make sure it is available in every scope that imports looping
-export @debug_loop_type_region
-
 const all_dimensions = (:s, :z, :vpa)
 const dimension_combinations = Tuple(Tuple(c) for c in combinations(all_dimensions))
 
@@ -28,48 +23,37 @@ function dims_string(dims::Tuple)
     return result
 end
 
-"""
-Construct names for the loop range variables
-
-Arguments
----------
-dims : Tuple
-    Tuple of dimension names (all given as `Symbol`s)
-
-Returns
--------
-Dict{Symbol,Symbol}
-    Dict whose keys are the dimension names, and values are the loop range
-    names
-"""
-function loop_range_names(dims::Tuple)
-    result = Dict{Symbol,Symbol}()
-    loop_prefix = "$(dims_string(dims))_range_"
-    for d ∈ dims
-        result[d] = Symbol(string(loop_prefix, d))
-    end
-    return result
-end
-
 # Create struct to store ranges for loops over all combinations of dimensions
 LoopRanges_body = quote
+    parallel_dims::Tuple{Vararg{Symbol}}
     rank0::Bool
 end
-setup_loop_ranges_arguments = [:( rank0=(block_rank==0) )]
-for dims ∈ dimension_combinations
-    global LoopRanges_body, setup_loop_ranges_arguments
-    range_names = loop_range_names(dims)
-    for dim ∈ dims
-        LoopRanges_body = quote
-            $LoopRanges_body;
-            $(range_names[dim])::UnitRange{mk_int}
-        end
-        # best_ranges is a local variable created in setup_loop_ranges()
-        push!(setup_loop_ranges_arguments,
-              :( $(range_names[dim])=best_ranges[$dims][$(QuoteNode(dim))] ))
+for dim ∈ all_dimensions
+    global LoopRanges_body
+    LoopRanges_body = quote
+        $LoopRanges_body;
+        $dim::UnitRange{mk_int}
     end
 end
 eval(quote
+         """
+         LoopRanges structs contain information on which points should be included on
+         this process in loops over shared-memory arrays.
+
+         Members
+         -------
+         parallel_dims::Tuple{Vararg{Symbol}}
+                Indicates which dimensions are (or might be) parallelized when using
+                this LoopRanges. Provided for information for developers, to make it
+                easier to tell (when using a Debugger, or printing debug informatino)
+                which LoopRanges instance is active in looping.loop_ranges at any point
+                in the code.
+         rank0::Bool
+                Is this process the one with rank 0 in the 'block' which work in
+                parallel on shared memory arrays.
+         <d>::UnitRange{mk_int}
+                Loop ranges for each dimension <d> in looping.all_dimensions.
+         """
          Base.@kwdef struct LoopRanges
              $LoopRanges_body
          end
@@ -185,9 +169,19 @@ end
 Find the ranges for loop variables that optimize load balance for a certain block_size
 """
 function get_best_ranges(block_rank, block_size, dims, dim_sizes)
+    # Find ranges for 'dims', which should be parallelized
     ranges = get_best_ranges_from_sizes(block_rank, block_size,
                                         (dim_sizes[d] for d ∈ dims))
-    return Dict(d=>r for (d,r) ∈ zip(dims, ranges))
+    result = Dict(d=>r for (d,r) ∈ zip(dims, ranges))
+
+    # Iterate over all points in ranges not being parallelized
+    for d in all_dimensions
+        if !(d in dims)
+            result[d] = 1:dim_sizes[d]
+        end
+    end
+
+    return result
 end
 function get_best_ranges_from_sizes(block_rank, block_size, dim_sizes_list)
     splits = get_splits(block_size, length(dim_sizes_list))
@@ -225,6 +219,10 @@ end
 const loop_ranges = Ref{LoopRanges}()
 export loop_ranges
 
+# module variable used to store LoopRanges that are swapped into the loop_ranges
+# variable in begin_*_region() functions
+const loop_ranges_store = Dict{Tuple{Vararg{Symbol}}, LoopRanges}()
+
 #Create ranges for loops with different combinations of variables
 #
 #Arguments
@@ -233,14 +231,27 @@ export loop_ranges
 #`n` is an integer giving the size of the dimension.
 eval(quote
          function setup_loop_ranges!(block_rank, block_size; dim_sizes...)
-             @debug_loop_type_region current_loop_region_type[] = "serial"
-             best_ranges = Dict()
-             for dims ∈ dimension_combinations
-                 best_ranges[dims] = get_best_ranges(block_rank, block_size,
-                                                     dims, dim_sizes)
+             rank0 = (block_rank == 0)
+
+             # Use empty tuple for serial region
+             if rank0
+                 loop_ranges_store[()] = LoopRanges(;
+                     parallel_dims=(), rank0=rank0,
+                     Dict(d=>1:n for (d,n) in dim_sizes)...)
+             else
+                 loop_ranges_store[()] = LoopRanges(;
+                     parallel_dims=(), rank0=rank0,
+                     Dict(d=>1:0 for (d,_) in dim_sizes)...)
              end
 
-             loop_ranges[] = LoopRanges($(setup_loop_ranges_arguments...))
+             for dims ∈ dimension_combinations
+                 loop_ranges_store[dims] = LoopRanges(;
+                     parallel_dims=dims, rank0 = rank0,
+                     get_best_ranges(block_rank, block_size, dims, dim_sizes)...)
+             end
+
+             loop_ranges[] = loop_ranges_store[()]
+
              return nothing
          end
      end)
@@ -252,39 +263,15 @@ for dims ∈ dimension_combinations
     # Create an expression-function/macro combination for each level of the
     # loop
     dims_symb = Symbol(dims_string(dims))
-    dims_symb_string = string(dims_symb)
-    range_names = loop_range_names(dims)
     range_exprs =
-        Tuple(:( loop_ranges[].$(range_names[dim]) )
+        Tuple(:( loop_ranges[].$dim )
               for dim in dims)
     range_exprs = Tuple(Expr(:quote, r) for r in range_exprs)
-    for (dim, range_expr) ∈ zip(dims, range_exprs)
-        macro_name = Symbol(dims_symb, :_loop_, dim)
-        macro_at_name = Symbol("@", macro_name)
-        one_level_expr = quote
-            macro $macro_name(iteration_var, expr)
-                this_range = $range_expr
-                return quote
-                    @debug_loop_type_region begin
-                        if current_loop_region_type[] != $$dims_symb_string
-                            error("Called loop of type $($$dims_symb_string) in region of "
-                                  * "type $(current_loop_region_type[])")
-                        end
-                    end
-                    for $(esc(iteration_var)) = $this_range
-                        $(esc(expr))
-                    end
-                end
-            end
-            export $macro_at_name
-        end
-        eval(one_level_expr)
-    end
 
     # Create a macro for the nested loop
     # Copy style from Base.Cartesian.@nloops code
-    nested_macro_name =  Symbol(dims_symb, :_loop)
-    nested_macro_body_name =  Symbol(dims_symb, :_loop_body)
+    nested_macro_name = Symbol(:loop_, dims_symb)
+    nested_macro_body_name = Symbol(:loop_body_, dims_symb)
     iteration_vars = Tuple(Symbol(:i, x) for x ∈ 1:length(dims))
 
     macro_body_expr = quote
@@ -299,15 +286,7 @@ for dims ∈ dimension_combinations
                     end
                 end
             end
-            return quote
-                @debug_loop_type_region begin
-                    if current_loop_region_type[] != $$dims_symb_string
-                        error("Called loop of type $($$dims_symb_string) in region of type "
-                              * "$(current_loop_region_type[])")
-                    end
-                end
-                $ex
-            end
+            return ex
         end
     end
     eval(macro_body_expr)
@@ -322,20 +301,14 @@ for dims ∈ dimension_combinations
     end
     eval(macro_expr)
 
-    # Create a function for beginning loops of type 'dims'
+    # Create a function for beginning regions where 'dims' are parallelized
     sync_name = Symbol(:begin_, dims_symb, :_region)
     eval(quote
              function $sync_name(; no_synchronize::Bool=false)
-                 @debug_loop_type_region begin
-                     if current_loop_region_type[] == $dims_symb_string
-                         error("Called $($sync_name)(), but already in region of type "
-                               * "$(current_loop_region_type[]).")
-                     end
-                     current_loop_region_type[] = $dims_symb_string
-                 end
                  if !no_synchronize
                      _block_synchronize()
                  end
+                 loop_ranges[] = loop_ranges_store[$dims]
              end
              export $sync_name
          end)
@@ -346,13 +319,6 @@ Run a block of code on only rank-0 of each block
 """
 macro serial_region(blk)
     return quote
-        @debug_loop_type_region begin
-            if current_loop_region_type[] != "serial"
-                error("Called loop of type serial in region of type "
-                      * "$(current_loop_region_type[])")
-            end
-            current_loop_region_type[] = "serial"
-        end
         if loop_ranges[].rank0
             $(esc(blk))
         end
@@ -360,15 +326,10 @@ macro serial_region(blk)
 end
 export @serial_region
 function begin_serial_region(; no_synchronize::Bool=false)
-    @debug_loop_type_region begin
-        if current_loop_region_type[] == "serial"
-            error("Called begin_serial_region(), but already in region of type serial.")
-        end
-        current_loop_region_type[] = "serial"
-    end
     if !no_synchronize
         _block_synchronize()
     end
+    loop_ranges[] = loop_ranges_store[()]
 end
 export begin_serial_region
 

--- a/src/source_terms.jl
+++ b/src/source_terms.jl
@@ -10,7 +10,7 @@ function source_terms!(pdf_out, fvec_in, moments, vpa, z, dt, spectral, composit
     # and use them to update the pdf
     #n_species = size(pdf_out,3)
     if moments.evolve_ppar
-        @s_z_loop_s is begin
+        @loop_s is begin
             @views source_terms_evolve_ppar!(pdf_out[:,:,is], fvec_in.pdf[:,:,is],
                                              fvec_in.density[:,is], fvec_in.upar[:,is], fvec_in.ppar[:,is],
                                              moments.vth[:,is], moments.qpar[:,is], z, dt, spectral)
@@ -21,7 +21,7 @@ function source_terms!(pdf_out, fvec_in, moments, vpa, z, dt, spectral, composit
                                                 CX_frequency, dt, z)
         end
     elseif moments.evolve_density
-        @s_z_loop_s is begin
+        @loop_s is begin
             @views source_terms_evolve_density!(pdf_out[:,:,is], fvec_in.pdf[:,:,is],
                                                 fvec_in.density[:,is], fvec_in.upar[:,is], z, dt, spectral)
         end
@@ -36,7 +36,7 @@ function source_terms_evolve_density!(pdf_out, pdf_in, dens, upar, z, dt, spectr
     #derivative!(z.scratch, z.scratch, z, -upar, spectral)
     # update the density
     nvpa = size(pdf_out, 1)
-    @s_z_loop_z iz begin
+    @loop_z iz begin
         for ivpa ∈ 1:nvpa
             pdf_out[ivpa,iz] += pdf_in[ivpa,iz]*z.scratch[iz]
         end
@@ -58,7 +58,7 @@ function source_terms_evolve_ppar!(pdf_out, pdf_in, dens, upar, ppar, vth, qpar,
     @. z.scratch -= 0.5*dt*z.scratch2/ppar
 
     nvpa = size(pdf_out, 1)
-    @s_z_loop_z iz begin
+    @loop_z iz begin
         for ivpa ∈ 1:nvpa
             pdf_out[ivpa,iz] += pdf_in[ivpa,iz]*z.scratch[iz]
         end
@@ -66,10 +66,10 @@ function source_terms_evolve_ppar!(pdf_out, pdf_in, dens, upar, ppar, vth, qpar,
     return nothing
 end
 function source_terms_evolve_ppar_CX!(pdf_out, pdf_in, dens, ppar, composition, CX_frequency, dt, z)
-    @s_z_loop_s is begin
+    @loop_s is begin
         if is ∈ composition.ion_species_range
             for isp ∈ composition.neutral_species_range
-                @s_z_loop_z iz begin
+                @loop_z iz begin
                     @views @. pdf_out[:,iz,is] -= 0.5*dt*pdf_in[:,iz,is]*CX_frequency *
                     (dens[iz,isp]*ppar[iz,is]-dens[iz,is]*ppar[iz,isp])/ppar[iz,is]
                 end
@@ -77,7 +77,7 @@ function source_terms_evolve_ppar_CX!(pdf_out, pdf_in, dens, ppar, composition, 
         end
         if is ∈ composition.neutral_species_range
             for isp ∈ composition.ion_species_range
-                @s_z_loop_z iz begin
+                @loop_z iz begin
                     @views @. pdf_out[:,iz,is] -= 0.5*dt*pdf_in[:,iz,is]*CX_frequency *
                     (dens[iz,isp]*ppar[iz,is]-dens[iz,is]*ppar[iz,isp])/ppar[iz,is]
                 end

--- a/util/print-macros.jl
+++ b/util/print-macros.jl
@@ -13,12 +13,12 @@ function print_macros()
     println("Here is a set of examples of expanding the macros defined in the `looping` module")
     println()
 
-    # Print combined nested loop macros
+    # Print loop macros
     for dims ∈ dimension_combinations
         println()
 
         iteration_vars = Tuple(string("i", d) for d ∈ dims)
-        macro_name = string("@", dims_string(dims), "_loop")
+        macro_name = string("@loop_", dims_string(dims))
         macro_example = """
             $macro_name $(join(iteration_vars, " ")) begin
                 foo[$(join(reverse(iteration_vars), ","))] = something
@@ -31,28 +31,6 @@ function print_macros()
         println("```")
         println(eval(Meta.parse("@macroexpand $macro_example")))
         println("```")
-    end
-
-    # Print single-level loop macros
-    for dims ∈ dimension_combinations
-        for d ∈ dims
-            println()
-
-            iteration_var = string("i", d)
-            macro_name = string("@", dims_string(dims), "_loop_", d)
-            macro_example = """
-                $macro_name $(iteration_var) begin
-                    foo[$(iteration_var)] = something
-                end
-            """
-            println("```")
-            println(macro_example)
-            println("```")
-            println("expands to:")
-            println("```")
-            println(eval(Meta.parse("@macroexpand $macro_example")))
-            println("```")
-        end
     end
 end
 


### PR DESCRIPTION
`loop_ranges[]` contains ranges for loops over each of the dimensions (`LoopRanges` is a simpler struct than before). The `LoopRanges` instance in `loop_ranges[]` is swapped out for the appropriate new one in the `begin_*_region()` functions. That means the loop macros no longer need to know what kind of region they are in, as they just get ranges from `loop_ranges[]`, so there are fewer macros: now just `@loop_<dims>` which can loop over any combination of `<dims>`.