### PR TITLE
Addition to debugging docs; fix bug in plot_performance.jl

### DIFF
--- a/debug_test/README.md
+++ b/debug_test/README.md
@@ -36,11 +36,6 @@ are undefined behaviour though, and so can also cause anything up to segfaults.
 The provided debugging routines can help to pin down where either of these
 errors happen.
 
-The cheapest test is `@debug_loop_type_region` (activated at `--debug 1` or
-higher). This checks that all loop macros used follow the correct
-`begin_*_region()` function, which should ensure that the array accesses are
-correct most of the time.
-
 The `@debug_shared_array` macro (activated at `--debug 2` or
 higher) counts all reads and writes to shared arrays by each process, and
 checks at each `_block_synchronize()` call whether either pattern has occurred
@@ -91,3 +86,7 @@ Suggested debugging strategy for race conditions is:
   ```
   moments.evolve_upar && _block_synchronize()
   ```
+
+You can find out what loop type is currently active by looking at
+`loop_ranges[].parallel_dims`. This variable is a Tuple containing Symbols for
+each dimension currently being parallelized.

--- a/performance-tests/plot_performance.jl
+++ b/performance-tests/plot_performance.jl
@@ -346,6 +346,11 @@ function plot_strong_scaling_history(prefix, machine=nothing; show=false, save=t
     for (filename, nproc) ∈ zip(filenames, nprocs)
         data = load_run(filename)
         split_data = split_machines(data, remove_duplicates=true)
+
+        if !(machine ∈ keys(split_data))
+            # `machine` has no dat for this nproc, so skip
+            continue
+        end
         machine_data = split_data[machine]
 
         if ntests < 0
@@ -374,7 +379,7 @@ function plot_strong_scaling_history(prefix, machine=nothing; show=false, save=t
                            legend=false, size=(2400, 400))
     function add_plot(commit; linewidth=1, show_ideal=false)
         to_plot = Array{Union{Float64,Missing},3}(undef, 4, ntests, length(nprocs))
-        for (i, nproc) in enumerate(nprocs)
+        for (i, nproc) in enumerate(keys(data_for_nproc))
             data = data_for_nproc[nproc]
             if commit ∈ keys(data)
                 to_plot[:,:,i] .= data[commit]


### PR DESCRIPTION
Update debugging docs: remove reference to `@debug_loop_type_region` that was removed in #45; mention that the current 'loop type region' can be identified by looking at `loop_ranges[].parallel_dims`.

Fix bug in `plot_performance.jl` that caused an error when results for a machine did not contain entries for every nproc present in the database.