### PR TITLE
Add link to the documentation webpage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Getting started
 
+The full documentation is online at [https://mabarnes.github.io/moment_kinetics](https://mabarnes.github.io/moment_kinetics).
+
 ## Basics
 0) Ensure that the Julia version is >= 1.7.0 by doing
     ```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ if get(ENV, "CI", nothing) == "true"
     # See "Hosting Documentation" and deploydocs() in the Documenter manual
     # for more information.
     deploydocs(
-        repo = "github.com/mabarnes/moment_kinetics"
+        repo = "github.com/mabarnes/moment_kinetics",
+        push_preview = true,
     )
 end


### PR DESCRIPTION
Makes it easier to find from the github.com repo.

The link also appears on the 'Getting started' page of the docs, because that page is a copy of the top-level README.md. Possibly mildly confusing, but I think having the info in both places is useful, and having a link in a slightly odd place is better than duplicating the documentation. It would be nicer if Markdown had a way to include one file in another file, but it doesn't - downside of a 'minimal' documentation syntax.