### PR TITLE
version that supports evolve_density = true with 'wall' BC and ionization collisions

### DIFF
--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -30,14 +30,14 @@ end
 creates the normalised pdf and the velocity-space moments and populates them
 with a self-consistent initial condition
 """
-function init_pdf_and_moments(vpa, z, r, composition, species, n_rk_stages, evolve_moments)
+function init_pdf_and_moments(vpa, z, r, composition, species, n_rk_stages, evolve_moments, ionization)
     # define the n_species variable for convenience
     n_species = composition.n_species
     # create the 'moments' struct that contains various v-space moments and other
     # information related to these moments.
     # the time-dependent entries are not initialised.
     
-    moments = create_moments(z.n, r.n, n_species, evolve_moments)
+    moments = create_moments(z.n, r.n, n_species, evolve_moments, ionization, z.bc)
     @serial_region begin
         # initialise the density profile
         init_density!(moments.dens, z, r, species, n_species)

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -246,20 +246,20 @@ end
 enforce boundary conditions in vpa and z on the evolved pdf;
 also enforce boundary conditions in z on all separately evolved velocity space moments of the pdf
 """
-function enforce_boundary_conditions!(fvec_out, vpa_bc, z_bc, vpa, z, r, vpa_adv::T1, z_adv::T2, composition) where {T1, T2}
+function enforce_boundary_conditions!(fvec_out, fvec_in, moments, vpa_bc, z_bc, vpa, z, r, vpa_adv::T1, z_adv::T2, composition) where {T1, T2}
     @loop_s_r_z is ir iz begin
         # enforce the vpa BC
         @views enforce_vpa_boundary_condition_local!(fvec_out.pdf[:,iz,ir,is], vpa_bc, vpa_adv[is].upwind_idx[iz,ir],
                                                      vpa_adv[is].downwind_idx[iz,ir])
     end
     begin_s_r_vpa_region()
-    @views enforce_z_boundary_condition!(fvec_out.pdf, z_bc, z_adv, vpa, r, composition)
+    @views enforce_z_boundary_condition!(fvec_out.pdf, fvec_in.density, moments, z_bc, z_adv, vpa, r, composition)
 end
 
 """
 enforce boundary conditions on f in z
 """
-function enforce_z_boundary_condition!(f, bc::String, adv::T, vpa, r, composition) where T
+function enforce_z_boundary_condition!(f, density, moments, bc::String, adv::T, vpa, r, composition) where T
     # define n_species variable for convenience
     n_species = composition.n_species
     # define nvpa variable for convenience
@@ -310,15 +310,31 @@ function enforce_z_boundary_condition!(f, bc::String, adv::T, vpa, r, compositio
                     wall_flux_L = 0.0
                     # include the contribution to the wall fluxes due to species with index 'is'
                     for is ∈ 1:composition.n_ion_species
-                            @views wall_flux_0 += (sqrt(composition.mn_over_mi) *
-                                                   integrate_over_negative_vpa(abs.(vpa.grid) .* f[:,1,ir,is], vpa.grid, vpa.wgts, vpa.scratch))
-                            @views wall_flux_L += (sqrt(composition.mn_over_mi) *
-                                                   integrate_over_positive_vpa(abs.(vpa.grid) .* f[:,end,ir,is], vpa.grid, vpa.wgts, vpa.scratch))
+		        normfac_0 = sqrt(composition.mn_over_mi)
+                        normfac_L = normfac_0
+                        # account for extra normalisation factors if evolving density separately from pdf
+                        if moments.evolve_density
+                            normfac_0 = normfac_0*density[1,ir,is]
+                            normfac_L = normfac_L*density[end,ir,is]
+                        end
+                        @views wall_flux_0 += (normfac_0 *
+                                               integrate_over_negative_vpa(abs.(vpa.grid) .* f[:,1,ir,is], vpa.grid, vpa.wgts, vpa.scratch))
+                        @views wall_flux_L += (normfac_L *
+                                               integrate_over_positive_vpa(abs.(vpa.grid) .* f[:,end,ir,is], vpa.grid, vpa.wgts, vpa.scratch))
                     end
                     for isn ∈ 1:composition.n_neutral_species
-                            is = isn + composition.n_ion_species
-                            @views wall_flux_0 += integrate_over_negative_vpa(abs.(vpa.grid) .* f[:,1,ir,is], vpa.grid, vpa.wgts, vpa.scratch)
-                            @views wall_flux_L += integrate_over_positive_vpa(abs.(vpa.grid) .* f[:,end,ir,is], vpa.grid, vpa.wgts, vpa.scratch)
+                        is = isn + composition.n_ion_species
+                        normfac_0 = 1.0
+                        normfac_L = 1.0
+                        # account for extra normalisation factors if evolving density separately from pdf
+                        if moments.evolve_density
+                            normfac_0 = normfac_0*density[1,ir,is]
+                            normfac_L = normfac_L*density[end,ir,is]
+                        end
+                        @views wall_flux_0 += (normfac_0 *
+                                               integrate_over_negative_vpa(abs.(vpa.grid) .* f[:,1,ir,is], vpa.grid, vpa.wgts, vpa.scratch))
+                        @views wall_flux_L += (normfac_L *
+                                               integrate_over_positive_vpa(abs.(vpa.grid) .* f[:,end,ir,is], vpa.grid, vpa.wgts, vpa.scratch))
                     end
                     # NB: need to generalise to more than one ion species
                     # get the Knudsen cosine distribution
@@ -331,13 +347,19 @@ function enforce_z_boundary_condition!(f, bc::String, adv::T, vpa, r, compositio
                     @. vpa.scratch /= tmp
                     for isn ∈ 1:composition.n_neutral_species
                         is = isn + composition.n_ion_species
+                        normfac_0 = 1.0
+                        normfac_L = 1.0
+                        if moments.evolve_density
+                            normfac_0 = 1.0 / density[1,ir,is]
+                            normfac_L = 1.0 / density[end,ir,is]
+                        end
                         for ivpa ∈ 1:nvpa
                             # no parallel BC should be enforced for vpa = 0
                             if abs(vpa.grid[ivpa]) > zero
                                 if adv[is].upwind_idx[ivpa,ir] == 1
-                                    f[ivpa,1,ir,is] = wall_flux_0 * vpa.scratch[ivpa]
+                                    f[ivpa,1,ir,is] = wall_flux_0 * vpa.scratch[ivpa] * normfac_0
                                 else
-                                    f[ivpa,end,ir,is] = wall_flux_L * vpa.scratch[ivpa]
+                                    f[ivpa,end,ir,is] = wall_flux_L * vpa.scratch[ivpa] * normfac_L
                                 end
                             end
                         end

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -243,15 +243,17 @@ function init_pdf_over_density!(pdf, spec, vpa, z, vth, upar, vpa_norm_fac, evol
 end
 
 """
+enforce boundary conditions in vpa and z on the evolved pdf;
+also enforce boundary conditions in z on all separately evolved velocity space moments of the pdf
 """
-function enforce_boundary_conditions!(f, vpa_bc, z_bc, vpa, z, r, vpa_adv::T1, z_adv::T2, composition) where {T1, T2}
+function enforce_boundary_conditions!(fvec_out, vpa_bc, z_bc, vpa, z, r, vpa_adv::T1, z_adv::T2, composition) where {T1, T2}
     @loop_s_r_z is ir iz begin
         # enforce the vpa BC
-        @views enforce_vpa_boundary_condition_local!(f[:,iz,ir,is], vpa_bc, vpa_adv[is].upwind_idx[iz,ir],
+        @views enforce_vpa_boundary_condition_local!(fvec_out.pdf[:,iz,ir,is], vpa_bc, vpa_adv[is].upwind_idx[iz,ir],
                                                      vpa_adv[is].downwind_idx[iz,ir])
     end
     begin_s_r_vpa_region()
-    @views enforce_z_boundary_condition!(f, z_bc, z_adv, vpa, r, composition)
+    @views enforce_z_boundary_condition!(fvec_out.pdf, z_bc, z_adv, vpa, r, composition)
 end
 
 """

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -12,7 +12,7 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
         n_neutral_species, vpa, z, r, composition, collisions, nz, dt)
 
     if moments.evolve_density
-		@loop_s is begin
+        @loop_s is begin
             # apply ionization collisions to all ion species
             if is ∈ composition.ion_species_range
                 # for each ion species, obtain affect of charge exchange collisions

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -26,7 +26,7 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
                 end
             end
             # when working with the normalised distribution (pdf_unnorm / density),
-			# the ionisation collisions drop out of the neutral kinetic equation
+            # the ionisation collisions drop out of the neutral kinetic equation
         end
     elseif collisions.constant_ionization_rate
         # Oddly the test in test/harrisonthompson.jl matches the analytical

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -15,7 +15,7 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
         @loop_s is begin
             # apply ionization collisions to all ion species
             if is ∈ composition.ion_species_range
-                # for each ion species, obtain affect of charge exchange collisions
+                # for each ion species, obtain effect of charge exchange collisions
                 # with all of the neutral species
                 for isp ∈ composition.neutral_species_range
                     @loop_r_z_vpa ir iz ivpa begin

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -142,7 +142,8 @@ function setup_moment_kinetics(input_dict::Dict)
                                z=z.n, vpa=vpa.n)
     # initialize f(z,vpa) and the lowest three v-space moments (density(z), upar(z) and ppar(z)),
     # each of which may be evolved separately depending on input choices.
-    pdf, moments = init_pdf_and_moments(vpa, z, r, composition, species, t_input.n_rk_stages, evolve_moments)
+    pdf, moments = init_pdf_and_moments(vpa, z, r, composition, species, t_input.n_rk_stages,
+    	 	   			evolve_moments, collisions.ionization)
     # initialize time variable
     code_time = 0.
     # create arrays and do other work needed to setup

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -16,6 +16,7 @@ using ..velocity_moments: update_moments!, reset_moments_status!
 using ..velocity_moments: enforce_moment_constraints!
 using ..velocity_moments: update_density!, update_upar!, update_ppar!, update_qpar!
 using ..initial_conditions: enforce_z_boundary_condition!, enforce_boundary_conditions!
+using ..initial_conditions: enforce_z_boundary_condition_moments!
 using ..initial_conditions: enforce_vpa_boundary_condition!
 using ..advection: setup_advection, update_boundary_indices!
 using ..z_advection: update_speed_z!, z_advection!
@@ -139,6 +140,9 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
     end
     # enforce prescribed boundary condition in z on the distribution function f
     @views enforce_z_boundary_condition!(pdf.unnorm, moments.dens, moments, z.bc, z_advect, vpa, r, composition)
+    # enforce prescribed boundary condition in z on the velocity space moments of f
+    @views enforce_z_boundary_condition_moments!(moments.dens, moments, z.bc)
+    
     if z.bc != "wall" || composition.n_neutral_species == 0
         begin_serial_region()
     end

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -105,7 +105,7 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
         advance = advance_info(true, true, advance_cx, advance_ionization, advance_sources,
                                advance_continuity, advance_force_balance, advance_energy, rk_coefs)
     end
-    
+
     # create structure r_advect whose members are the arrays needed to compute
     # the advection term(s) appearing in the split part of the GK equation dealing
     # with advection in r
@@ -122,8 +122,8 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
     # enforce prescribed boundary condition in r on the distribution function f
     # PLACEHOLDER
     #@views enforce_r_boundary_condition!(pdf.unnorm, r.bc, r_advect, vpa, z, composition)
-    
-    
+
+
     # create structure z_advect whose members are the arrays needed to compute
     # the advection term(s) appearing in the split part of the GK equation dealing
     # with advection in z
@@ -142,7 +142,7 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
     if z.bc != "wall" || composition.n_neutral_species == 0
         begin_serial_region()
     end
-    
+
     # create an array of structs containing scratch arrays for the pdf and low-order moments
     # that may be evolved separately via fluid equations
     scratch = setup_scratch_arrays(moments, pdf.norm, t_input.n_rk_stages)
@@ -490,12 +490,12 @@ end
 
 """
 """
-function time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z, r, 
+function time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z, r,
     vpa_spectral, z_spectral, r_spectral, moments, fields, vpa_advect, z_advect, r_advect,
     vpa_SL, z_SL, r_SL, composition, collisions, advance, scratch_dummy_sr, istep)
 
     if t_input.n_rk_stages > 1
-        ssp_rk!(pdf, scratch, t, t_input, vpa, z, r, 
+        ssp_rk!(pdf, scratch, t, t_input, vpa, z, r,
             vpa_spectral, z_spectral, r_spectral, moments, fields, vpa_advect, z_advect, r_advect,
             vpa_SL, z_SL, r_SL, composition, collisions, advance,  scratch_dummy_sr, istep)
     else
@@ -574,7 +574,7 @@ end
 
 """
 """
-function ssp_rk!(pdf, scratch, t, t_input, vpa, z, r, 
+function ssp_rk!(pdf, scratch, t, t_input, vpa, z, r,
     vpa_spectral, z_spectral, r_spectral, moments, fields, vpa_advect, z_advect, r_advect,
     vpa_SL, z_SL, r_SL, composition, collisions, advance, scratch_dummy_sr, istep)
 
@@ -642,23 +642,23 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     # vpa_advection! advances the 1D advection equation in vpa.
     # only charged species have a force accelerating them in vpa;
     # however, neutral species do have non-zero d(wpa)/dt, so there is advection in wpa
-    
+
     if advance.vpa_advection
         vpa_advection!(fvec_out.pdf, fvec_in, pdf.norm, fields, moments,
             vpa_SL, vpa_advect, vpa, z, r, use_semi_lagrange, dt, t,
             vpa_spectral, z_spectral, composition, collisions.charge_exchange, istage)
     end
-    
+
     # z_advection! advances 1D advection equation in z
     # apply z-advection operation to all species (charged and neutral)
-    
+
     if advance.z_advection
         begin_s_r_vpa_region()
         z_advection!(fvec_out.pdf, fvec_in, pdf.norm, moments, z_SL, z_advect, z, vpa, r,
             use_semi_lagrange, dt, t, z_spectral, composition, istage)
         begin_s_r_z_region()
     end
-    
+
     if advance.source_terms
         source_terms!(fvec_out.pdf, fvec_in, moments, vpa, z, r, dt, z_spectral,
                       composition, collisions.charge_exchange)
@@ -685,7 +685,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     begin_s_r_region(no_synchronize=true)
     if advance.continuity
         continuity_equation!(fvec_out.density, fvec_in, moments, composition, vpa, z, r,
-                             dt, z_spectral)
+                             dt, z_spectral, collisions.ionization)
     end
     if advance.force_balance
         # fvec_out.upar is over-written in force_balance! and contains the particle flux

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -675,7 +675,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     # enforce boundary conditions in z and vpa on the distribution function
     # NB: probably need to do the same for the evolved moments
-    enforce_boundary_conditions!(fvec_out.pdf, vpa.bc, z.bc, vpa, z, r, vpa_advect, z_advect, composition)
+    enforce_boundary_conditions!(fvec_out, vpa.bc, z.bc, vpa, z, r, vpa_advect, z_advect, composition)
     # End of advance fo distribution function
 
     # Start advancing moments

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -138,7 +138,7 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
         update_boundary_indices!(z_advect[is], loop_ranges[].vpa, loop_ranges[].r)
     end
     # enforce prescribed boundary condition in z on the distribution function f
-    @views enforce_z_boundary_condition!(pdf.unnorm, z.bc, z_advect, vpa, r, composition)
+    @views enforce_z_boundary_condition!(pdf.unnorm, moments.dens, moments, z.bc, z_advect, vpa, r, composition)
     if z.bc != "wall" || composition.n_neutral_species == 0
         begin_serial_region()
     end
@@ -675,7 +675,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     # enforce boundary conditions in z and vpa on the distribution function
     # NB: probably need to do the same for the evolved moments
-    enforce_boundary_conditions!(fvec_out, vpa.bc, z.bc, vpa, z, r, vpa_advect, z_advect, composition)
+    enforce_boundary_conditions!(fvec_out, fvec_in, moments, vpa.bc, z.bc, vpa, z, r, vpa_advect, z_advect, composition)
     # End of advance fo distribution function
 
     # Start advancing moments

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -388,9 +388,9 @@ function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition,
                 avgdens_ratio = dummy_sr[ir,is]
                 @loop_z iz begin
                     # update the density with the above factor to ensure particle conservation
-                    fvec_new.density[iz,is] += fvec_old.density[iz,is] * avgdens_ratio
+                    fvec_new.density[iz,ir,is] += fvec_old.density[iz,ir,is] * avgdens_ratio
                     # update the thermal speed, as the density has changed
-                    moments.vth[iz,is] = sqrt(2.0*fvec_new.ppar[iz,is]/fvec_new.density[iz,is])
+                    moments.vth[iz,ir,is] = sqrt(2.0*fvec_new.ppar[iz,ir,is]/fvec_new.density[iz,ir,is])
                 end
             end
         end

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -368,9 +368,9 @@ function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition,
     # This loop needs to be @loop_s_r because it fills the (not-shared)
     # dummy_sr buffer to be used within the @loop_s_r below, so the values
     # of is looped over by this process need to be the same.
-    if moments.particle_number_conserved
-    	@loop_s_r is ir begin
-            @views @. z.scratch = fvec_old.density[:,ir,is] - fvec_new.density[:,ir,is]
+    @loop_s_r is ir begin
+        if moments.particle_number_conserved[is]
+	    @views @. z.scratch = fvec_old.density[:,ir,is] - fvec_new.density[:,ir,is]
             @views dummy_sr[ir,is] = integral(z.scratch, z.wgts)/integral(fvec_old.density[:,ir,is], z.wgts)
 	end
     end

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -395,7 +395,6 @@ function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition,
             end
         end
         @loop_r ir begin
-#            avgdens_ratio = dummy_sr[ir,is]
             @loop_z iz begin
                 # Create views once to save overhead
                 fnew_view = @view(fvec_new.pdf[:,iz,ir,is])

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -430,9 +430,6 @@ function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition,
                         @. fnew_view -= vpa.scratch * (vpa.grid * vpa.grid - 0.5) * ppar_integral
                     end
                 end
- #               fvec_new.density[iz,ir,is] += fvec_old.density[iz,ir,is] * avgdens_ratio
- #               # update the thermal speed, as the density has changed
- #               moments.vth[iz,ir,is] = sqrt(2.0*fvec_new.ppar[iz,ir,is]/fvec_new.density[iz,ir,is])
             end
         end
     end


### PR DESCRIPTION
This branch has all of the changes needed to reproduce the results from the standard drift kinetic equation for the case with a wall BC and including ionization collisions, but with the pdf normalised by density so that a continuity equation has to be solved to evolve the density.