### PR TITLE
Upar evolution wall bc

### DIFF
--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -142,7 +142,7 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
     @views enforce_z_boundary_condition!(pdf.unnorm, moments.dens, moments, z.bc, z_advect, vpa, r, composition)
     # enforce prescribed boundary condition in z on the velocity space moments of f
     @views enforce_z_boundary_condition_moments!(moments.dens, moments, z.bc)
-    
+
     if z.bc != "wall" || composition.n_neutral_species == 0
         begin_serial_region()
     end
@@ -170,7 +170,7 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
     # initialise the vpa advection speed
     begin_s_r_z_region()
     update_speed_vpa!(vpa_advect, fields, scratch[1], moments, vpa, z, r, composition,
-                      collisions.charge_exchange, 0.0, z_spectral)
+                      collisions, 0.0, z_spectral)
     if moments.evolve_upar
         nspec = n_species
     else
@@ -650,7 +650,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     if advance.vpa_advection
         vpa_advection!(fvec_out.pdf, fvec_in, pdf.norm, fields, moments,
             vpa_SL, vpa_advect, vpa, z, r, use_semi_lagrange, dt, t,
-            vpa_spectral, z_spectral, composition, collisions.charge_exchange, istage)
+            vpa_spectral, z_spectral, composition, collisions, istage)
     end
 
     # z_advection! advances 1D advection equation in z

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -139,7 +139,8 @@ function setup_time_advance!(pdf, vpa, z, r, z_spectral, composition, drive_inpu
         update_boundary_indices!(z_advect[is], loop_ranges[].vpa, loop_ranges[].r)
     end
     # enforce prescribed boundary condition in z on the distribution function f
-    @views enforce_z_boundary_condition!(pdf.unnorm, moments.dens, moments, z.bc, z_advect, vpa, r, composition)
+    @views enforce_z_boundary_condition!(pdf.unnorm, moments.dens, moments.upar, moments,
+                                         z.bc, z_advect, vpa, r, composition)
     # enforce prescribed boundary condition in z on the velocity space moments of f
     @views enforce_z_boundary_condition_moments!(moments.dens, moments, z.bc)
 
@@ -680,7 +681,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     # enforce boundary conditions in z and vpa on the distribution function
     # NB: probably need to do the same for the evolved moments
     enforce_boundary_conditions!(fvec_out, fvec_in, moments, vpa.bc, z.bc, vpa, z, r, vpa_advect, z_advect, composition)
-    # End of advance fo distribution function
+    # End of advance of distribution function
 
     # Start advancing moments
     # Do not actually need to synchronize here because above we only modify the


### PR DESCRIPTION
added option to evolve upar as well as density with ionization collisions and wall BC.  Use of the peculiar velocity as a phase space coordinate, as is done for upar evolution, is not recommended for use with the wall BC, given the fact that the wall BC works with dz/dt as a coordinate rather than the peculiar velocity.