### PR TITLE
Stop all MPI processes when an error occurs

### DIFF
--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -75,24 +75,33 @@ using .time_advance: setup_time_advance!, time_advance!
 main function that contains all of the content of the program
 """
 function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
-    # set up all the structs, etc. needed for a run
-    mk_state = setup_moment_kinetics(input_dict)
+    try
+        # set up all the structs, etc. needed for a run
+        mk_state = setup_moment_kinetics(input_dict)
 
-    # solve the 1+1D kinetic equation to advance f in time by nstep time steps
-    if run_type == performance_test
-        @timeit to "time_advance" time_advance!(mk_state...)
-    else
-        time_advance!(mk_state...)
-    end
+        try
+            # solve the 1+1D kinetic equation to advance f in time by nstep time steps
+            if run_type == performance_test
+                @timeit to "time_advance" time_advance!(mk_state...)
+            else
+                time_advance!(mk_state...)
+            end
+        finally
 
-    # clean up i/o and communications
-    # last 2 elements of mk_state are `io` and `cdf`
-    cleanup_moment_kinetics!(mk_state[end-1:end]...)
+            # clean up i/o and communications
+            # last 2 elements of mk_state are `io` and `cdf`
+            cleanup_moment_kinetics!(mk_state[end-1:end]...)
+        end
 
-    if block_rank[] == 0 && run_type == performance_test
-        # Print the timing information if this is a performance test
-        display(to)
-        println()
+        if block_rank[] == 0 && run_type == performance_test
+            # Print the timing information if this is a performance test
+            display(to)
+            println()
+        end
+    catch
+        # Stop code from hanging when running on multiple processes if only one of them
+        # throws an error
+        global_size[] > 1 && MPI.Abort(comm_world, 1)
     end
 
     return nothing

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -98,10 +98,15 @@ function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
             display(to)
             println()
         end
-    catch
+    catch e
         # Stop code from hanging when running on multiple processes if only one of them
         # throws an error
-        global_size[] > 1 && MPI.Abort(comm_world, 1)
+        if global_size[] > 1
+            println(e)
+            MPI.Abort(comm_world, 1)
+        end
+
+        rethrow(e)
     end
 
     return nothing


### PR DESCRIPTION
If just one process throws an exception, we need to catch it and call `MPI.Abort()` to stop all processes.

Also uses a `try...finally...end` construct to try to call `cleanup_moment_kinetics!()` when an error occurs, to close output files properly, etc. This can probably fail if `MPI.Abort()` is called as I guess `MPI.Abort()` kills the other processes without waiting for exception handling. Unfortunately I don't know of a decent solution for error/exception handling with MPI...

Fixes #65.