### PR TITLE
Enable restarting of runs

### DIFF
--- a/restart_moment_kinetics.jl
+++ b/restart_moment_kinetics.jl
@@ -1,0 +1,7 @@
+# provide option of running from command line via 'julia run_moment_kinetics.jl'
+using Pkg
+Pkg.activate(".")
+
+using moment_kinetics
+
+restart_moment_kinetics()

--- a/src/command_line_options.jl
+++ b/src/command_line_options.jl
@@ -15,6 +15,10 @@ const s = ArgParseSettings()
         help = "Name of TOML input file."
         arg_type = String
         default = nothing
+    "restartfile"
+        help = "Name of NetCDF file to restart from"
+        arg_type = String
+        default = nothing
     "--debug", "-d"
         help = "Set debugging level, default is 0 (no extra debugging). Higher " *
                "integer values activate more checks (and increase run time)"
@@ -24,6 +28,10 @@ const s = ArgParseSettings()
     "--long"
         help = "Include more tests, increasing test run time."
         action = :store_true
+    "--restart-time-index"
+        help = "Time index in output file to restart from, defaults to final time point"
+        arg_type = Int
+        default = -1
     "--verbose", "-v"
         help = "Print verbose output from tests."
         action = :store_true

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -12,8 +12,8 @@ loop ranges), as at the moment we only run with 1 ion species and 1 neutral spec
 """
 module communication
 
-export allocate_shared, block_rank, block_size, comm_block,
-       comm_world, finalize_comms!, initialize_comms!, global_rank, MPISharedArray
+export allocate_shared, block_rank, block_size, comm_block, comm_world, finalize_comms!,
+       initialize_comms!, global_rank, global_size, MPISharedArray
 
 using MPI
 using SHA

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -408,6 +408,48 @@ function open_output_file(prefix, ext)
 end
 
 """
+Reload pdf and moments from an existing output file.
+"""
+function reload_evolving_fields!(pdf, moments, restart_filename, time_index,
+                                 composition, r, z, vpa)
+    code_time = 0.0
+    begin_serial_region()
+    @serial_region begin
+        fid = NCDataset(restart_filename,"r")
+        try
+            if time_index < 0
+                time_index = fid.dim["ntime"]
+            end
+            restart_n_species = fid.dim["n_species"]
+            restart_nr = fid.dim["nr"]
+            restart_nz = fid.dim["nz"]
+            restart_nvpa = fid.dim["nvpa"]
+            if restart_n_species != composition.n_species || restart_nr != r.n ||
+                restart_nz != z.n || restart_nvpa != vpa.n
+
+                error("Dimensions of restart file and input do not match.\n" *
+                      "Restart file was n_species=$restart_n_species, nr=$restart_nr, " *
+                      "nz=$restart_nz, nvpa=$restart_nvpa.\n" *
+                      "Input file gave  n_species=$(composition.n_species), nr=$(r.n), " *
+                      "nz=$(z.n), nvpa=$(vpa.n).")
+            end
+
+            code_time = fid["time"].var[time_index]
+            pdf.norm .= fid["f"].var[:,:,:,:,time_index]
+            moments.dens .= fid["density"].var[:,:,:,time_index]
+            moments.upar .= fid["parallel_flow"].var[:,:,:,time_index]
+            moments.ppar .= fid["parallel_pressure"].var[:,:,:,time_index]
+            moments.qpar .= fid["parallel_heat_flux"].var[:,:,:,time_index]
+            moments.vth .= fid["thermal_speed"].var[:,:,:,time_index]
+        finally
+            close(fid)
+        end
+    end
+
+    return code_time
+end
+
+"""
 An nc_info instance that may be initialised for writing debug output
 
 This is a non-const module variable, so does cause type instability, but it is only used

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -159,9 +159,9 @@ function setup_moment_kinetics(input_dict::Dict)
     io, cdf = setup_file_io(output_dir, run_name, vpa, z, r, composition, collisions,
                             moments.evolve_ppar)
     # write initial data to ascii files
-    write_data_to_ascii(pdf.unnorm, moments, fields, vpa, z, r, code_time, composition.n_species, io)
+    write_data_to_ascii(pdf.norm, moments, fields, vpa, z, r, code_time, composition.n_species, io)
     # write initial data to binary file (netcdf)
-    write_data_to_binary(pdf.unnorm, moments, fields, code_time, composition.n_species, cdf, 1)
+    write_data_to_binary(pdf.norm, moments, fields, code_time, composition.n_species, cdf, 1)
 
     begin_s_r_z_region()
 

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -72,27 +72,39 @@ using .time_advance: setup_time_advance!, time_advance!
 main function that contains all of the content of the program
 """
 function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
-    # set up all the structs, etc. needed for a run
-    mk_state = setup_moment_kinetics(input_dict)
-
     try
-        # solve the 1+1D kinetic equation to advance f in time by nstep time steps
-        if run_type == performance_test
-            @timeit to "time_advance" time_advance!(mk_state...)
-        else
-            time_advance!(mk_state...)
+        # set up all the structs, etc. needed for a run
+        mk_state = setup_moment_kinetics(input_dict)
+
+        try
+            # solve the 1+1D kinetic equation to advance f in time by nstep time steps
+            if run_type == performance_test
+                @timeit to "time_advance" time_advance!(mk_state...)
+            else
+                time_advance!(mk_state...)
+            end
+        finally
+
+            # clean up i/o and communications
+            # last 2 elements of mk_state are `io` and `cdf`
+            cleanup_moment_kinetics!(mk_state[end-1:end]...)
         end
-    finally
 
-        # clean up i/o and communications
-        # last 2 elements of mk_state are `io` and `cdf`
-        cleanup_moment_kinetics!(mk_state[end-1:end]...)
-    end
+        if block_rank[] == 0 && run_type == performance_test
+            # Print the timing information if this is a performance test
+            display(to)
+            println()
+        end
+    catch e
+        # Stop code from hanging when running on multiple processes if only one of them
+        # throws an error
+        if global_size[] > 1
+            println("Abort called on rank $(block_rank[]) due to error. Error message "
+                    * "was:\n", e)
+            MPI.Abort(comm_world, 1)
+        end
 
-    if block_rank[] == 0 && run_type == performance_test
-        # Print the timing information if this is a performance test
-        display(to)
-        println()
+        rethrow(e)
     end
 
     return nothing
@@ -171,26 +183,39 @@ function restart_moment_kinetics()
 end
 function restart_moment_kinetics(restart_filename::String, input_dict::Dict,
                                  time_index::Int=-1)
-    # Move the output file being restarted from to make sure it doesn't get overwritten.
-    backup_filename = get_backup_filename(restart_filename)
-    global_rank[] == 0 && mv(restart_filename, backup_filename)
-
-    # Set up all the structs, etc. needed for a run.
-    pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral, z_spectral,
-    r_spectral, moments, fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL,
-    composition, collisions, advance, scratch_dummy_sr, io, cdf =
-    setup_moment_kinetics(input_dict, backup_filename=backup_filename,
-                          restart_time_index=time_index)
-
     try
-        time_advance!(pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral,
-                      z_spectral, r_spectral, moments, fields, vpa_advect, z_advect,
-                      r_advect, vpa_SL, z_SL, r_SL, composition, collisions, advance,
-                      scratch_dummy_sr, io, cdf)
-    finally
-        # clean up i/o and communications
-        # last 2 elements of mk_state are `io` and `cdf`
-        cleanup_moment_kinetics!(io, cdf)
+        # Move the output file being restarted from to make sure it doesn't get
+        # overwritten.
+        backup_filename = get_backup_filename(restart_filename)
+        global_rank[] == 0 && mv(restart_filename, backup_filename)
+
+        # Set up all the structs, etc. needed for a run.
+        pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral, z_spectral,
+        r_spectral, moments, fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL,
+        composition, collisions, advance, scratch_dummy_sr, io, cdf =
+        setup_moment_kinetics(input_dict, backup_filename=backup_filename,
+                              restart_time_index=time_index)
+
+        try
+            time_advance!(pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral,
+                          z_spectral, r_spectral, moments, fields, vpa_advect, z_advect,
+                          r_advect, vpa_SL, z_SL, r_SL, composition, collisions,
+                          advance, scratch_dummy_sr, io, cdf)
+        finally
+            # clean up i/o and communications
+            # last 2 elements of mk_state are `io` and `cdf`
+            cleanup_moment_kinetics!(io, cdf)
+        end
+    catch e
+        # Stop code from hanging when running on multiple processes if only one of them
+        # throws an error
+        if global_size[] > 1
+            println("Abort called on rank $(block_rank[]) due to error. Error message "
+                    * "was:\n", e)
+            MPI.Abort(comm_world, 1)
+        end
+
+        rethrow(e)
     end
 
     return nothing

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -2,7 +2,7 @@
 """
 module moment_kinetics
 
-export run_moment_kinetics
+export run_moment_kinetics, restart_moment_kinetics
 
 using MPI
 
@@ -54,10 +54,11 @@ include("post_processing.jl")
 using TimerOutputs
 using TOML
 
-using .file_io: setup_file_io, finish_file_io
+using .file_io: setup_file_io, finish_file_io, reload_evolving_fields!
 using .file_io: write_data_to_ascii, write_data_to_binary
 using .command_line_options: get_options
 using .communication
+using .communication: _block_synchronize
 using .coordinates: define_coordinate
 using .debugging
 using .initial_conditions: init_pdf_and_moments
@@ -124,9 +125,85 @@ function run_moment_kinetics()
 end
 
 """
-Perform all the initialization steps for a run.
+Append a number to the filename, to get a new, non-existing filename to backup the file
+to.
 """
-function setup_moment_kinetics(input_dict::Dict)
+function get_backup_filename(filename)
+    counter = 1
+    basename, extension = splitext(filename)
+    backup_name = ""
+    while true
+        backup_name = "$(basename)_$(counter)$(extension)"
+        if !isfile(backup_name)
+            break
+        end
+        counter += 1
+    end
+    backup_name == "" && error("Failed to find a name for backup file.")
+    return backup_name
+end
+
+"""
+Restart moment kinetics from an existing run. Space/velocity-space resolution in the
+input must be the same as for the original run.
+"""
+function restart_moment_kinetics(restart_filename::String, input_filename::String,
+                                 time_index::Int=-1)
+    restart_moment_kinetics(restart_filename, TOML.parsefile(input_filename),
+                            time_index)
+    return nothing
+end
+function restart_moment_kinetics()
+    options = get_options()
+    inputfile = options["inputfile"]
+    if inputfile === nothing
+        error("Must pass input file as first argument to restart a run.")
+    end
+    restartfile = options["restartfile"]
+    if restartfile === nothing
+        error("Must pass output file to restart from as second argument.")
+    end
+    time_index = options["restart-time-index"]
+
+    restart_moment_kinetics(restartfile, inputfile, time_index)
+
+    return nothing
+end
+function restart_moment_kinetics(restart_filename::String, input_dict::Dict,
+                                 time_index::Int=-1)
+    # Move the output file being restarted from to make sure it doesn't get overwritten.
+    backup_filename = get_backup_filename(restart_filename)
+    global_rank[] == 0 && mv(restart_filename, backup_filename)
+
+    # Set up all the structs, etc. needed for a run.
+    pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral, z_spectral,
+    r_spectral, moments, fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL,
+    composition, collisions, advance, scratch_dummy_sr, io, cdf =
+    setup_moment_kinetics(input_dict, backup_filename=backup_filename,
+                          restart_time_index=time_index)
+
+    try
+        time_advance!(pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral,
+                      z_spectral, r_spectral, moments, fields, vpa_advect, z_advect,
+                      r_advect, vpa_SL, z_SL, r_SL, composition, collisions, advance,
+                      scratch_dummy_sr, io, cdf)
+    finally
+        # clean up i/o and communications
+        # last 2 elements of mk_state are `io` and `cdf`
+        cleanup_moment_kinetics!(io, cdf)
+    end
+
+    return nothing
+end
+
+"""
+Perform all the initialization steps for a run.
+
+If `backup_filename` is `nothing`, set up for a regular run; if a filename is passed,
+reload data from time index given by `restart_time_index` for a restart.
+"""
+function setup_moment_kinetics(input_dict::Dict; backup_filename=nothing,
+                               restart_time_index=-1)
     # Set up MPI
     initialize_comms!()
 
@@ -155,6 +232,15 @@ function setup_moment_kinetics(input_dict::Dict)
     moments, fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL, scratch,
         advance, scratch_dummy_sr = setup_time_advance!(pdf, vpa, z, r, z_spectral,
             composition, drive_input, moments, t_input, collisions, species)
+
+    if backup_filename !== nothing
+        # Have done unnecessary initialisation of pdf and moments, which is overwritten
+        # here
+        code_time = reload_evolving_fields!(pdf, moments, backup_filename,
+                                            restart_time_index, composition, r, z, vpa)
+        _block_synchronize()
+    end
+
     # setup i/o
     io, cdf = setup_file_io(output_dir, run_name, vpa, z, r, composition, collisions,
                             moments.evolve_ppar)

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -362,9 +362,9 @@ function time_advance!(pdf, scratch, t, t_input, vpa, z, r, vpa_spectral, z_spec
             begin_serial_region()
             @serial_region println("finished time step ", i, "  ",
                                    Dates.format(now(), dateformat"H:MM:SS"))
-            write_data_to_ascii(pdf.unnorm, moments, fields, vpa, z, r, t, composition.n_species, io)
+            write_data_to_ascii(pdf.norm, moments, fields, vpa, z, r, t, composition.n_species, io)
             # write initial data to binary file (netcdf)
-            write_data_to_binary(pdf.unnorm, moments, fields, t, composition.n_species, cdf, iwrite)
+            write_data_to_binary(pdf.norm, moments, fields, t, composition.n_species, cdf, iwrite)
             iwrite += 1
 
             # Restore to same region type as in rk_update!() so that execution after a

--- a/test/nonlinear_sound_wave_tests.jl
+++ b/test/nonlinear_sound_wave_tests.jl
@@ -268,6 +268,19 @@ function run_test(test_input, rtol; args...)
             phi = phi_zrt[:,1,:]
             n, upar, ppar, qpar, v_t = n_zrst[:,1,:,:], upar_zrst[:,1,:,:], ppar_zrst[:,1,:,:], qpar_zrst[:,1,:,:], v_t_zrst[:,1,:,:]
             f = f_vpazrst[:,:,1,:,:]
+
+            # Unnormalize f
+            if input["evolve_moments_density"]
+                for it ∈ 1:length(time), is ∈ 1:n_species, iz ∈ 1:nz
+                    f[:,iz,is,it] .*= n[iz,is,it]
+                end
+            end
+            if input["evolve_moments_parallel_pressure"]
+                for it ∈ 1:length(time), is ∈ 1:n_species, iz ∈ 1:nz
+                    vth = sqrt(2.0*ppar[iz,is,it]/n[iz,is,it])
+                    f[:,iz,is,it] ./= vth
+                end
+            end
         end
 
         # Create coordinates


### PR DESCRIPTION
Add a function `restart_moment_kinetics()` that allows restarting a run from any time point in an existing output file.

Save the normalized pdf rather than an unnormalized one to output files - makes restarting simpler as the normalized pdf is the evolved variable.

Call MPI.Abort() if an error occurs on any process, printing the error message first. This helps to avoid a run hanging if an error occurs on only one (or a few) processes.