### PR TITLE
Make moment constraints interact better with boundary conditions

### DIFF
--- a/src/moment_constraints.jl
+++ b/src/moment_constraints.jl
@@ -140,23 +140,50 @@ initial state, and when applying boundary conditions.
 Note this function assumes the input is given at a single spatial position.
 """
 function hard_force_moment_constraints!(f, moments, vpa)
+    #if moments.evolve_ppar
+    #    I0 = integrate_over_vspace(f, vpa.wgts)
+    #    I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
+    #    I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
+    #    I3 = integrate_over_vspace(f, vpa.grid, 3, vpa.wgts)
+    #    I4 = integrate_over_vspace(f, vpa.grid, 4, vpa.wgts)
+    #    A = ((1.0 - 0.5*I2/I4)*(I2 - I3^2/I4) + 0.5*I3/I4*(I1-I2*I3/I4)) /
+    #        ((I0 - I2^2/I4)*(I2 - I3^2/I4) - (I1 - I2*I3/I4)^2)
+    #    B = -(0.5*I3/I4 + A*(I1 - I2*I3/I4)) / (I2 - I3^2/I4)
+    #    C = -(A*I1 + B*I2) / I3
+    #    @. f = A*f + B*vpa.grid*f + C*vpa.grid*vpa.grid*f
+    #elseif moments.evolve_upar
+    #    I0 = integrate_over_vspace(f, vpa.wgts)
+    #    I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
+    #    I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
+    #    A = 1.0 / (I0 + I1*I1/I2)
+    #    B = -I1*A/I2
+    #    @. f = A*f + B*vpa.grid*f
+    #elseif moments.evolve_density
+    #    I0 = integrate_over_vspace(f, vpa.wgts)
+    #    @. f = f / I0
+    #end
+
     if moments.evolve_ppar
         I0 = integrate_over_vspace(f, vpa.wgts)
         I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
         I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
         I3 = integrate_over_vspace(f, vpa.grid, 3, vpa.wgts)
         I4 = integrate_over_vspace(f, vpa.grid, 4, vpa.wgts)
-        A = ((1.0 - 0.5*I2)*(I2 - I3^2/I4) + 0.5*I3/I4*(I1-I2*I3/I4)) /
-            ((I0 - I2^2)*(I2 - I3^2/I4) - (I1 - I2*I3/I4)^2)
-        B = -(0.5*I3/I4 + A*(I1 - I2*I3/I4)) / (I2 - I3^2/I4)
-        C = -(A*I1 + B*I2) / I3
+
+        A = (I3^2 - I2*I4 + 0.5*(I2^2 - I1*I3)) /
+            (I0*(I3^2 - I2*I4) + I1*I1*I4 - 2.0*I1*I2*I3 + I2^3)
+        B = (0.5*I3 + A*(I1*I4 - I2*I3)) / (I3^2 - I2*I4)
+        C = (0.5 - A*I2 -B*I3) / I4
+
         @. f = A*f + B*vpa.grid*f + C*vpa.grid*vpa.grid*f
     elseif moments.evolve_upar
         I0 = integrate_over_vspace(f, vpa.wgts)
         I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
         I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
-        A = 1.0 / (I0 + I1*I1/I2)
-        B = -I1*A/I2
+
+        A = 1.0 / (I0 - I1^2/I2)
+        B = -A*I1/I2
+
         @. f = A*f + B*vpa.grid*f
     elseif moments.evolve_density
         I0 = integrate_over_vspace(f, vpa.wgts)

--- a/src/moment_constraints.jl
+++ b/src/moment_constraints.jl
@@ -1,0 +1,169 @@
+"""
+Functions for enforcing integral constraints on the normalised distribution function.
+Ensures consistency of evolution split into moments and normalised distribution
+function.
+"""
+module moment_constraints
+
+using ..communication: _block_synchronize
+using ..initial_conditions: enforce_zero_incoming_bc!
+using ..looping
+using ..velocity_moments: integrate_over_vspace, update_qpar!
+
+export enforce_moment_constraints!, hard_force_moment_constraints!
+
+"""
+    enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition, moments, dummy_sr)
+
+Force moment constraints to be true for fvec_new if they were true for fvec_old. Should
+always be a small correction because the time step is 'small' so fvec_new should only
+violate the constraints by a small amount.
+"""
+function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition, moments, dummy_sr)
+    # pre-calculate avgdens_ratio so that we don't read fvec_new.density[:,is] on every
+    # process in the next loop - that would be an error because different processes
+    # write to fvec_new.density[:,is]
+    # This loop needs to be @loop_s_r because it fills the (not-shared)
+    # dummy_sr buffer to be used within the @loop_s_r below, so the values
+    # of is looped over by this process need to be the same.
+    # Need to call _block_synchronize() even though loop type does not change because
+    # all spatial ranks read fvec_new.density, but it will be written below.
+    if any(moments.particle_number_conserved)
+        _block_synchronize()
+    end
+    @loop_s_r is ir begin
+        if moments.particle_number_conserved[is]
+            @views @. z.scratch = fvec_old.density[:,ir,is] - fvec_new.density[:,ir,is]
+            @views dummy_sr[ir,is] = integral(z.scratch, z.wgts)/integral(fvec_old.density[:,ir,is], z.wgts)
+        end
+    end
+    # Need to call _block_synchronize() even though loop type does not change because
+    # all spatial ranks read fvec_new.density, but it will be written below.
+    if any(moments.particle_number_conserved)
+        _block_synchronize()
+    end
+
+    @loop_s is begin
+        # add a small correction to the density for each species to ensure that
+        # that particle number is conserved if it should be;
+        # ionisation collisions and net particle flux out of the domain due to, e.g.,
+        # a wall BC break particle conservation, in which cases it should not be enforced.
+        if moments.particle_number_conserved[is]
+            @loop_r ir begin
+                avgdens_ratio = dummy_sr[ir,is]
+                @loop_z iz begin
+                    # update the density with the above factor to ensure particle conservation
+                    fvec_new.density[iz,ir,is] += fvec_old.density[iz,ir,is] * avgdens_ratio
+                    # update the thermal speed, as the density has changed
+                    moments.vth[iz,ir,is] = sqrt(2.0*fvec_new.ppar[iz,ir,is]/fvec_new.density[iz,ir,is])
+                end
+            end
+        end
+        @loop_r ir begin
+            if moments.evolve_upar && is ∈ composition.ion_species_range && z.bc == "wall"
+                # Enforce zero-incoming boundary condition on the old distribution
+                # function with the new parallel flow, then force the updated old
+                # distribution function to obey the integral constraints exactly, which
+                # should be a small correction here as the boundary condition should
+                # only modify a few points due to the small change in upar.
+                # This procedure ensures that fvec_old obeys both the new boundary
+                # conditions and the moment constraints, so that when it is used to
+                # update f_new, f_new also does.
+                # Note fvec_old is never used after this function, so it is OK to modify
+                # it in-place.
+
+                # define a zero that accounts for finite precision
+                zero = 1.0e-10
+
+                @views enforce_zero_incoming_bc!(fvec_old.pdf[:,:,ir,is],
+                                                 vpa, fvec_new.upar[:,ir,is], zero)
+                @loop_z iz begin
+                    @views hard_force_moment_constraints!(fvec_old.pdf[:,iz,ir,is],
+                                                          moments, vpa)
+                end
+            end
+            @loop_z iz begin
+                # Create views once to save overhead
+                fnew_view = @view(fvec_new.pdf[:,iz,ir,is])
+                fold_view = @view(fvec_old.pdf[:,iz,ir,is])
+
+                # first calculate all of the integrals involving the updated pdf fvec_new.pdf
+                density_integral = integrate_over_vspace(fnew_view, vpa.wgts)
+                if moments.evolve_upar
+                    upar_integral = integrate_over_vspace(fnew_view, vpa.grid, vpa.wgts)
+                end
+                if moments.evolve_ppar
+                    ppar_integral = integrate_over_vspace(fnew_view, vpa.grid, 2, vpa.wgts)
+                end
+                # update the pdf to account for the density-conserving correction
+                @. fnew_view += fold_view * (1.0 - density_integral)
+                if moments.evolve_upar
+                    if !moments.evolve_ppar
+                        upar_coefficient = upar_integral /
+                            integrate_over_vspace(fold_view, vpa.grid, 2, vpa.wgts)
+                    else
+                        vpa3_moment = integrate_over_vspace(fold_view, vpa.grid, 3, vpa.wgts)
+                        vpa4_moment = integrate_over_vspace(fold_view, vpa.grid, 4, vpa.wgts)
+                        ppar_coefficient = (-ppar_integral + 0.5*density_integral +
+                                            2.0*upar_integral*vpa3_moment) /
+                                            (vpa4_moment - 0.25 - 2.0*vpa3_moment*vpa3_moment)
+                        upar_coefficient = 2.0 * (upar_integral + ppar_coefficient * vpa3_moment)
+                    end
+                    # update the pdf to account for the momentum-conserving correction
+                    @. fnew_view -= upar_coefficient * vpa.grid * fold_view
+                    if moments.evolve_ppar
+                        # update the pdf to account for the energy-conserving correction
+                        #@. fnew_view += ppar_coefficient * (vpa.grid^2 - 0.5) * fold_view
+                        # Until julia-1.8 is released, prefer x*x to x^2 to avoid
+                        # extra allocations when broadcasting.
+                        @. fnew_view += ppar_coefficient * (vpa.grid * vpa.grid - 0.5) * fold_view
+                    end
+                end
+            end
+        end
+    end
+    # the pdf, density and thermal speed have been changed so the corresponding parallel heat flux must be updated
+    moments.qpar_updated .= false
+    update_qpar!(moments.qpar, moments.qpar_updated, fvec_new.density, fvec_new.upar,
+                 moments.vth, fvec_new.pdf, vpa, z, r, composition,
+                 moments.evolve_density, moments.evolve_upar, moments.evolve_ppar)
+end
+
+"""
+    hard_force_moment_constraints!(f, moments, vpa)
+
+Force the moment constraints needed for the system being evolved to be applied to `f`.
+Not guaranteed to be a small correction, if `f` does not approximately obey the
+constraints to start with, but can be useful at initialisation to ensure a consistent
+initial state, and when applying boundary conditions.
+
+Note this function assumes the input is given at a single spatial position.
+"""
+function hard_force_moment_constraints!(f, moments, vpa)
+    if moments.evolve_ppar
+        I0 = integrate_over_vspace(f, vpa.wgts)
+        I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
+        I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
+        I3 = integrate_over_vspace(f, vpa.grid, 3, vpa.wgts)
+        I4 = integrate_over_vspace(f, vpa.grid, 4, vpa.wgts)
+        A = ((1.0 - 0.5*I2)*(I2 - I3^2/I4) + 0.5*I3/I4*(I1-I2*I3/I4)) /
+            ((I0 - I2^2)*(I2 - I3^2/I4) - (I1 - I2*I3/I4)^2)
+        B = -(0.5*I3/I4 + A*(I1 - I2*I3/I4)) / (I2 - I3^2/I4)
+        C = -(A*I1 + B*I2) / I3
+        @. f = A*f + B*vpa.grid*f + C*vpa.grid*vpa.grid*f
+    elseif moments.evolve_upar
+        I0 = integrate_over_vspace(f, vpa.wgts)
+        I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
+        I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
+        A = 1.0 / (I0 + I1*I1/I2)
+        B = -I1*A/I2
+        @. f = A*f + B*vpa.grid*f
+    elseif moments.evolve_density
+        I0 = integrate_over_vspace(f, vpa.wgts)
+        @. f = f / I0
+    end
+
+    return nothing
+end
+
+end

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -30,6 +30,7 @@ include("velocity_moments.jl")
 include("em_fields.jl")
 include("bgk.jl")
 include("initial_conditions.jl")
+include("moment_constraints.jl")
 include("semi_lagrange.jl")
 include("advection.jl")
 include("vpa_advection.jl")
@@ -63,6 +64,7 @@ using .coordinates: define_coordinate
 using .debugging
 using .initial_conditions: init_pdf_and_moments
 using .looping
+using .moment_constraints: hard_force_moment_constraints!
 using .moment_kinetics_input: mk_input, run_type, performance_test
 using .time_advance: setup_time_advance!, time_advance!
 

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -701,12 +701,14 @@ function ssp_rk!(pdf, scratch, t, t_input, vpa, z, r,
     end
 
     istage = n_rk_stages+1
+    final_scratch = scratch[istage]
     if moments.evolve_density && moments.enforce_conservation
-        enforce_moment_constraints!(scratch[istage], scratch[1], vpa, z, r, composition, moments, scratch_dummy_sr)
+        @loop_s_r_z is ir iz begin
+            @views hard_force_moment_constraints!(final_scratch.pdf[:,iz,ir,is], moments, vpa)
+        end
     end
 
     # update the pdf.norm and moments arrays as needed
-    final_scratch = scratch[istage]
     @loop_s_r_z_vpa is ir iz ivpa begin
         pdf.norm[ivpa,iz,ir,is] = final_scratch.pdf[ivpa,iz,ir,is]
     end

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -11,9 +11,9 @@ using ..communication: _block_synchronize
 using ..debugging
 using ..file_io: write_data_to_ascii, write_data_to_binary, debug_dump
 using ..looping
+using ..moment_constraints: enforce_moment_constraints!, hard_force_moment_constraints!
 using ..moment_kinetics_structs: scratch_pdf
 using ..velocity_moments: update_moments!, reset_moments_status!
-using ..velocity_moments: enforce_moment_constraints!
 using ..velocity_moments: update_density!, update_upar!, update_ppar!, update_qpar!
 using ..initial_conditions: enforce_z_boundary_condition!, enforce_boundary_conditions!
 using ..initial_conditions: enforce_z_boundary_condition_moments!

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -11,13 +11,11 @@ export update_upar!
 export update_ppar!
 export update_qpar!
 export reset_moments_status!
-export enforce_moment_constraints!
 
 using ..type_definitions: mk_float
 using ..array_allocation: allocate_shared_float, allocate_bool
 using ..calculus: integral
 using ..communication
-using ..communication: _block_synchronize
 using ..looping
 
 #global tmpsum1 = 0.0
@@ -482,140 +480,6 @@ function integrate_over_negative_vpa(integrand, dzdt, vpa_wgts, wgts_mod)
         @views vpa_integral = integral(integrand[1:ivpa_zero], wgts_mod[1:ivpa_zero])/sqrt(pi)
     end
     return vpa_integral
-end
-
-"""
-    enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition, moments, dummy_sr)
-
-Force moment constraints to be true for fvec_new if they were true for fvec_old. Should
-always be a small correction because the time step is 'small' so fvec_new should only
-violate the constraints by a small amount.
-"""
-function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition, moments, dummy_sr)
-
-    begin_s_r_z_region()
-
-    # pre-calculate avgdens_ratio so that we don't read fvec_new.density[:,is] on every
-    # process in the next loop - that would be an error because different processes
-    # write to fvec_new.density[:,is]
-    # This loop needs to be @loop_s_r because it fills the (not-shared)
-    # dummy_sr buffer to be used within the @loop_s_r below, so the values
-    # of is looped over by this process need to be the same.
-    # Need to call _block_synchronize() even though loop type does not change because
-    # all spatial ranks read fvec_new.density, but it will be written below.
-    if any(moments.particle_number_conserved)
-        _block_synchronize()
-    end
-    @loop_s_r is ir begin
-        if moments.particle_number_conserved[is]
-            @views @. z.scratch = fvec_old.density[:,ir,is] - fvec_new.density[:,ir,is]
-            @views dummy_sr[ir,is] = integral(z.scratch, z.wgts)/integral(fvec_old.density[:,ir,is], z.wgts)
-        end
-    end
-    # Need to call _block_synchronize() even though loop type does not change because
-    # all spatial ranks read fvec_new.density, but it will be written below.
-    if any(moments.particle_number_conserved)
-        _block_synchronize()
-    end
-
-    @loop_s is begin
-        # add a small correction to the density for each species to ensure that
-        # that particle number is conserved if it should be;
-        # ionisation collisions and net particle flux out of the domain due to, e.g.,
-        # a wall BC break particle conservation, in which cases it should not be enforced.
-        if moments.particle_number_conserved[is]
-            @loop_r ir begin
-                avgdens_ratio = dummy_sr[ir,is]
-                @loop_z iz begin
-                    # update the density with the above factor to ensure particle conservation
-                    fvec_new.density[iz,ir,is] += fvec_old.density[iz,ir,is] * avgdens_ratio
-                    # update the thermal speed, as the density has changed
-                    moments.vth[iz,ir,is] = sqrt(2.0*fvec_new.ppar[iz,ir,is]/fvec_new.density[iz,ir,is])
-                end
-            end
-        end
-        @loop_r ir begin
-            @loop_z iz begin
-                # Create views once to save overhead
-                fnew_view = @view(fvec_new.pdf[:,iz,ir,is])
-                fold_view = @view(fvec_old.pdf[:,iz,ir,is])
-
-                # first calculate all of the integrals involving the updated pdf fvec_new.pdf
-                density_integral = integrate_over_vspace(fnew_view, vpa.wgts)
-                if moments.evolve_upar
-                    upar_integral = integrate_over_vspace(fnew_view, vpa.grid, vpa.wgts)
-                end
-                if moments.evolve_ppar
-                    ppar_integral = integrate_over_vspace(fnew_view, vpa.grid, 2, vpa.wgts)
-                end
-                # update the pdf to account for the density-conserving correction
-                @. fnew_view += fold_view * (1.0 - density_integral)
-                if moments.evolve_upar
-                    if !moments.evolve_ppar
-                        upar_coefficient = upar_integral /
-                            integrate_over_vspace(fold_view, vpa.grid, 2, vpa.wgts)
-                    else
-                        vpa3_moment = integrate_over_vspace(fold_view, vpa.grid, 3, vpa.wgts)
-                        vpa4_moment = integrate_over_vspace(fold_view, vpa.grid, 4, vpa.wgts)
-                        ppar_coefficient = (-ppar_integral + 0.5*density_integral +
-                                            2.0*upar_integral*vpa3_moment) /
-                                            (vpa4_moment - 0.25 - 2.0*vpa3_moment*vpa3_moment)
-                        upar_coefficient = 2.0 * (upar_integral + ppar_coefficient * vpa3_moment)
-                    end
-                    # update the pdf to account for the momentum-conserving correction
-                    @. fnew_view -= upar_coefficient * vpa.grid * fold_view
-                    if moments.evolve_ppar
-                        # update the pdf to account for the energy-conserving correction
-                        #@. fnew_view += ppar_coefficient * (vpa.grid^2 - 0.5) * fold_view
-                        # Until julia-1.8 is released, prefer x*x to x^2 to avoid
-                        # extra allocations when broadcasting.
-                        @. fnew_view += ppar_coefficient * (vpa.grid * vpa.grid - 0.5) * fold_view
-                    end
-                end
-            end
-        end
-    end
-    # the pdf, density and thermal speed have been changed so the corresponding parallel heat flux must be updated
-    moments.qpar_updated .= false
-    update_qpar!(moments.qpar, moments.qpar_updated, fvec_new.density, fvec_new.upar,
-                 moments.vth, fvec_new.pdf, vpa, z, r, composition,
-                 moments.evolve_density, moments.evolve_upar, moments.evolve_ppar)
-end
-
-"""
-
-Force the moment constraints needed for the system being evolved to be applied to `f`.
-Not guaranteed to be a small correction, if `f` does not approximately obey the
-constraints to start with, but can be useful at initialisation to ensure a consistent
-initial state, and when applying boundary conditions.
-
-Note this function assumes the input is given at a single spatial position.
-"""
-function hard_force_moment_constraints!(f, moments, vpa)
-    if moments.evolve_ppar
-        I0 = integrate_over_vspace(f, vpa.wgts)
-        I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
-        I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
-        I3 = integrate_over_vspace(f, vpa.grid, 3, vpa.wgts)
-        I4 = integrate_over_vspace(f, vpa.grid, 4, vpa.wgts)
-        A = ((1.0 - 0.5*I2)*(I2 - I3^2/I4) + 0.5*I3/I4*(I1-I2*I3/I4)) /
-            ((I0 - I2^2)*(I2 - I3^2/I4) - (I1 - I2*I3/I4)^2)
-        B = -(0.5*I3/I4 + A*(I1 - I2*I3/I4)) / (I2 - I3^2/I4)
-        C = -(A*I1 + B*I2) / I3
-        @. f = A*f + B*vpa.grid*f + C*vpa.grid*vpa.grid*f
-    elseif moments.evolve_upar
-        I0 = integrate_over_vspace(f, vpa.wgts)
-        I1 = integrate_over_vspace(f, vpa.grid, vpa.wgts)
-        I2 = integrate_over_vspace(f, vpa.grid, 2, vpa.wgts)
-        A = 1.0 / (I0 + I1*I1/I2)
-        B = -I1*A/I2
-        @. f = A*f + B*vpa.grid*f
-    elseif moments.evolve_density
-        I0 = integrate_over_vspace(f, vpa.wgts)
-        @. f = f / I0
-    end
-
-    return nothing
 end
 
 """

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -541,28 +541,30 @@ function enforce_moment_constraints!(fvec_new, fvec_old, vpa, z, r, composition,
                     upar_integral = integrate_over_vspace(fnew_view, vpa.grid, vpa.wgts)
                 end
                 if moments.evolve_ppar
-                    ppar_integral = integrate_over_vspace(fnew_view, vpa.grid, 2, vpa.wgts) - 0.5*density_integral
+                    ppar_integral = integrate_over_vspace(fnew_view, vpa.grid, 2, vpa.wgts)
                 end
                 # update the pdf to account for the density-conserving correction
                 @. fnew_view += fold_view * (1.0 - density_integral)
                 if moments.evolve_upar
-                    # next form the even part of the old distribution function that is needed
-                    # to ensure momentum and energy conservation
-                    @. vpa.scratch = fold_view
-                    reverse!(vpa.scratch)
-                    @. vpa.scratch = 0.5*(vpa.scratch + fold_view)
-                    # calculate the integrals involving this even pdf
-                    vpa2_moment = integrate_over_vspace(vpa.scratch, vpa.grid, 2, vpa.wgts)
-                    upar_integral /= vpa2_moment
+                    if !moments.evolve_ppar
+                        upar_coefficient = upar_integral /
+                            integrate_over_vspace(fold_view, vpa.grid, 2, vpa.wgts)
+                    else
+                        vpa3_moment = integrate_over_vspace(fold_view, vpa.grid, 3, vpa.wgts)
+                        vpa4_moment = integrate_over_vspace(fold_view, vpa.grid, 4, vpa.wgts)
+                        ppar_coefficient = (-ppar_integral + 0.5*density_integral +
+                                            2.0*upar_integral*vpa3_moment) /
+                                            (vpa4_moment - 0.25 - 2.0*vpa3_moment*vpa3_moment)
+                        upar_coefficient = 2.0 * (upar_integral + ppar_coefficient * vpa3_moment)
+                    end
                     # update the pdf to account for the momentum-conserving correction
-                    @. fnew_view -= vpa.scratch * vpa.grid * upar_integral
+                    @. fnew_view -= upar_coefficient * vpa.grid * fold_view
                     if moments.evolve_ppar
-                        ppar_integral /= integrate_over_vspace(vpa.scratch, vpa.grid, 4, vpa.wgts) - 0.5 * vpa2_moment
                         # update the pdf to account for the energy-conserving correction
-                        #@. fnew_view -= vpa.scratch * (vpa.grid^2 - 0.5) * ppar_integral
+                        #@. fnew_view += ppar_coefficient * (vpa.grid^2 - 0.5) * fold_view
                         # Until julia-1.8 is released, prefer x*x to x^2 to avoid
                         # extra allocations when broadcasting.
-                        @. fnew_view -= vpa.scratch * (vpa.grid * vpa.grid - 0.5) * ppar_integral
+                        @. fnew_view += ppar_coefficient * (vpa.grid * vpa.grid - 0.5) * fold_view
                     end
                 end
             end


### PR DESCRIPTION
Updates to moment constraints:
* Use the full pdf everywhere, rather than using a symmetrized pdf in some terms. This makes the expressions a bit more complicated but avoids issues near sheath boundaries: the previous form would add some correction terms proportional to `f_sym = (f(vpa)+f(-vpa))/2`, but these corrections are non-zero in the part of velocity space where the f_ion is forced to be zero at the sheath entrance, and are also not ideal for f_neutral at the wall as f_neutral is not symmetric and has a sharp feature where the outgoing Knudsen distribution joins on to the incoming distribution.
* Use f at the current timestep to correct the moments, rather than f at the previous timestep. Requires computing several moments of the 'initial guess' for f, so a bit more expensive, but avoids the problem that the new f might be forced, by the boundary condition, to be 0 at a grid point where the previous f was non-zero.
* Apply the constraints at each RK stage, not just at the end of the full timestep. When I implemented this change, I thought it behaved a bit better numerically, but many other fixes that came later were needed to get moment-kinetic simulations with wall bcs running, so not sure it's really necessary.

I have some notes on extending @mabarnes's expressions for the constraint-enforcement. I'll tidy them up soon to share/upload.