### PR TITLE
Second derivative and numerical dissipation

### DIFF
--- a/docs/src/numerical_dissipation.md
+++ b/docs/src/numerical_dissipation.md
@@ -1,0 +1,6 @@
+`numerical_dissipation`
+=================
+
+```@autodocs
+Modules = [moment_kinetics.numerical_dissipation]
+```

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -53,7 +53,7 @@ function derivative!(df, f, coord, spectral, ::Val{1})
     derivative_elements_to_full_grid!(df, coord.scratch_2d, coord)
 end
 
-function derivative!(df, f, coord, spectral::Bool, ::Val{2})
+function derivative!(df, f, coord, spectral::Bool, order::Val{2})
     # Finite difference version must use an appropriate second derivative stencil, not
     # apply the 1st derivative twice as for the spectral element method
 
@@ -65,16 +65,51 @@ function derivative!(df, f, coord, spectral::Bool, ::Val{2})
     derivative_elements_to_full_grid!(df, coord.scratch_2d, coord)
 end
 
-function derivative!(df, f, coord, spectral, ::Val{2})
-    # For spectral element method, apply the first derivative twice. This is necessary
-    # so that the first derivative is made continuous at the element boundaries,
-    # avoiding numerical instability due to e.g. a maximum at an element boundary where
-    # the second derivative on both sides as calculated in each element individually is
-    # positive, so averaging between the two elements would give a positive, but in
-    # reality the second derivative must be negative, because the value is a maximum.
+function derivative!(d2f, f, coord, spectral, ::Val{2})
+    # For spectral element methods, calculate second derivative by applying first
+    # derivative twice, with special treatment for element boundaries
 
-    derivative!(df, f, coord, spectral, Val(1))
-    derivative!(df, df, coord, spectral, Val(1))
+    # First derivative
+    elementwise_derivative!(coord, f, spectral, Val(1))
+    derivative_elements_to_full_grid!(coord.scratch3, coord.scratch_2d, coord)
+    # Save elementwise first derivative result
+    coord.scratch2_2d .= coord.scratch_2d
+
+    # Second derivative for element interiors
+    elementwise_derivative!(coord, coord.scratch3, spectral, Val(1))
+    derivative_elements_to_full_grid!(d2f, coord.scratch_2d, coord)
+
+    # Add contribution to penalise discontinuous first derivatives at element
+    # boundaries. For smooth functions this would do nothing so should not affect
+    # convergence of the second derivative. Aims to stabilise numerical instability when
+    # spike develops at an element boundary. The coefficient is an arbitrary choice, it
+    # should probably be large enough for stability but as small as possible.
+    function penalise_discontinuous_first_derivative!(d2f, imin, imax, df)
+        # Arbitrary numerical coefficient
+        C = 1.0
+
+        # Left element boundary
+        d2f[imin] += C * df[1]
+
+        # Right element boundary
+        d2f[imax] -= C * df[end]
+
+        return nothing
+    end
+    @views penalise_discontinuous_first_derivative!(d2f, 1, coord.imax[1],
+                                                    coord.scratch2_2d[:,1])
+    for ielement ∈ 2:coord.nelement
+        @views penalise_discontinuous_first_derivative!(d2f, coord.imin[ielement]-1,
+                                                        coord.imax[ielement],
+                                                        coord.scratch2_2d[:,ielement])
+    end
+
+    if coord.bc ∈ ("wall", "zero", "both_zero")
+        # For stability don't contribute to evolution at boundaries, in case these
+        # points are not set by a boundary condition.
+        d2f[1] = 0.0
+        d2f[end] = 0.0
+    end
 
     return nothing
 end

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -5,6 +5,7 @@ module calculus
 export derivative!
 export integral
 
+using ..moment_kinetics_structs: chebyshev_info
 using ..type_definitions: mk_float
 
 """
@@ -25,10 +26,10 @@ function elementwise_derivative! end
 
 Upwinding derivative.
 """
-function derivative!(df, f, coord, adv_fac, spectral)
+function derivative!(df, f, coord, adv_fac, spectral::Union{Bool,<:chebyshev_info}, order=Val(1))
     # get the derivative at each grid point within each element and store in
     # coord.scratch_2d
-    elementwise_derivative!(coord, f, adv_fac, spectral)
+    elementwise_derivative!(coord, f, adv_fac, spectral, order)
     # map the derivative from the elemental grid to the full grid;
     # at element boundaries, use the derivative from the upwind element.
     derivative_elements_to_full_grid!(df, coord.scratch_2d, coord, adv_fac)
@@ -39,10 +40,10 @@ end
 
 Non-upwinding derivative.
 """
-function derivative!(df, f, coord, spectral)
+function derivative!(df, f, coord, spectral, order=Val(1))
     # get the derivative at each grid point within each element and store in
     # coord.scratch_2d
-    elementwise_derivative!(coord, f, spectral)
+    elementwise_derivative!(coord, f, spectral, order)
     # map the derivative from the elem;ntal grid to the full grid;
     # at element boundaries, use the average of the derivatives from neighboring elements.
     derivative_elements_to_full_grid!(df, coord.scratch_2d, coord)

--- a/src/coordinates.jl
+++ b/src/coordinates.jl
@@ -59,9 +59,10 @@ struct coordinate
     scratch2::Array{mk_float,1}
     # scratch3 is an array used for intermediate calculations requiring n entries
     scratch3::Array{mk_float,1}
-    # scratch_2d is an array used for intermediate calculations requiring ngrid x
-    # nelement entries
+    # scratch_2d and scratch2_2d are arrays used for intermediate calculations requiring
+    # ngrid x nelement entries
     scratch_2d::Array{mk_float,2}
+    scratch2_2d::Array{mk_float,2}
     # struct containing advection speed options/inputs
     advection::advection_input
 end
@@ -101,7 +102,7 @@ function define_coordinate(input, composition=nothing)
     coord = coordinate(input.name, n, input.ngrid, input.nelement, input.L, grid,
         cell_width, igrid, ielement, imin, imax, input.discretization, input.fd_option,
         input.bc, wgts, uniform_grid, duniform_dgrid, scratch, copy(scratch),
-        copy(scratch), scratch_2d, advection)
+        copy(scratch), scratch_2d, copy(scratch_2d), advection)
 
     if input.discretization == "chebyshev_pseudospectral"
         # create arrays needed for explicit Chebyshev pseudospectral treatment in this

--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -373,11 +373,11 @@ function centered_second_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 		df[igrid[i],ielement[i]] = 0.5*(ghost-f[i-1])/del[n-1]
 	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
                 # For boundary conditions that set the values of fields at the boundary,
-                # just use a one-sided difference away from the boundary.
+                # just use a first-order, one-sided difference away from the boundary.
 		i = 1
-                df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
+                df[igrid[i],ielement[i]] = (f[i+1]-f[i])/del[i+1]
 		i = n
-                df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i-1])
+                df[igrid[i],ielement[i]] =  (f[i]-f[i-1])/del[i-1]
 	end
 end
 
@@ -415,9 +415,9 @@ function centered_second_order!(df::Array{mk_float,1}, f, del, bc, igrid, ieleme
                 # For boundary conditions that set the values of fields at the boundary,
                 # just use a one-sided difference away from the boundary.
 		i = 1
-                df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
+                df[igrid[i],ielement[i]] = (f[i+1]-f[i])/del[i+1]
 		i = n
-                df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i-1])
+                df[igrid[i],ielement[i]] =  (f[i]-f[i-1])/del[i-1]
 	end
 end
 

--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -42,7 +42,7 @@ end
 Calculate the derivative of f using 4th order centered finite differences; result stored
 in coord.scratch_2d.
 """
-function elementwise_derivative!(coord, f, not_spectral::Bool)
+function elementwise_derivative!(coord, f, not_spectral::Bool, ::Val{1})
     return derivative_finite_difference!(coord.scratch_2d, f, coord.cell_width,
         coord.bc, "fourth_order_centered", coord.igrid, coord.ielement)
 end

--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -31,7 +31,7 @@ end
 Calculate the derivative of f using finite differences, with particular scheme
 specified by coord.fd_option; result stored in coord.scratch_2d.
 """
-function elementwise_derivative!(coord, f, adv_fac, not_spectral::Bool)
+function elementwise_derivative!(coord, f, adv_fac, not_spectral::Bool, ::Val{1})
     return derivative_finite_difference!(coord.scratch_2d, f, coord.cell_width, adv_fac,
         coord.bc, coord.fd_option, coord.igrid, coord.ielement)
 end

--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -127,7 +127,7 @@ function upwind_first_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				tmp = f[n-1]
 			elseif bc == "constant"
 				tmp = f[1]
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp = 0.0
 			end
 			#df[i] = (f[i]-tmp)/del[i]
@@ -142,7 +142,7 @@ function upwind_first_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				tmp = f[2]
 			elseif bc == "constant"
 				tmp = f[n]
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp = 0.0
 			end
 			#df[i] = (tmp-f[i])/del[1]
@@ -178,7 +178,7 @@ function upwind_second_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				tmp1 = f[n-1]
 			elseif bc == "constant"
 				tmp1 = f[1]
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp1 = 0.0
 			end
 			#df[i] = (3.0*f[i]-4.0*f[i-1]+tmp1)/(2.0*del[i])
@@ -195,7 +195,7 @@ function upwind_second_order!(df, f, del, adv_fac, bc, igrid, ielement)
 			elseif bc == "constant"
 				tmp2 = f[1]
 				tmp1 = tmp2
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp2 = 0.0
 				tmp1 = tmp2
 			end
@@ -210,7 +210,7 @@ function upwind_second_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				tmp1 = f[2]
 			elseif bc == "constant"
 				tmp1 = f[n]
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp1 = 0.0
 			end
 			i = n-1
@@ -229,7 +229,7 @@ function upwind_second_order!(df, f, del, adv_fac, bc, igrid, ielement)
 			elseif bc == "constant"
 				tmp2 = f[n]
 				tmp1 = tmp2
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp2 = 0.0
 				tmp1 = tmp2
 			end
@@ -268,7 +268,7 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				tmp1 = f[n-1]
 			elseif bc == "constant"
 				tmp1 = f[1]
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp1 = 0.0
 			end
 			df[igrid[i],ielement[i]] = (2.0*f[i+1]+3.0*f[i]-6.0*f[i-1]+tmp1)/(6.0*del[i])
@@ -282,7 +282,7 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 		elseif bc == "constant"
 			tmp2 = f[1]
 			tmp1 = tmp2
-		elseif bc == "zero" || bc == "wall"
+		elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 			tmp2 = 0.0
 			tmp1 = tmp2
 		end
@@ -302,7 +302,7 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 				tmp1 = f[2]
 			elseif bc == "constant"
 				tmp1 = f[n]
-			elseif bc == "zero" || bc == "wall"
+			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp1 = 0.0
 			end
 			i = n-1
@@ -317,7 +317,7 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 		elseif bc == "constant"
 			tmp2 = f[n]
 			tmp1 = tmp2
-		elseif bc == "zero" || bc == "wall"
+		elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 			tmp2 = 0.0
 			tmp1 = tmp2
 		end
@@ -370,7 +370,7 @@ function centered_second_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 		i = n
 		ghost = f[n]
 		df[igrid[i],ielement[i]] = 0.5*(ghost-f[i-1])/del[n-1]
-	elseif bc == "zero" || bc == "wall"
+	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 		i = 1
 		df[igrid[i],ielement[i]] = 0.5*f[i+1]/del[i]
 		i = n
@@ -408,7 +408,7 @@ function centered_second_order!(df::Array{mk_float,1}, f, del, bc, igrid, ieleme
 		i = n
 		ghost = f[n]
 		df[i] = 0.5*(ghost-f[i-1])/del[n-1]
-	elseif bc == "zero" || bc == "wall"
+	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 		i = 1
 		df[i] = 0.5*f[i+1]/del[i]
 		i = n
@@ -452,7 +452,7 @@ function centered_fourth_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 		df[igrid[i],ielement[i]] = (8.0*(ghost-f[i-1])+f[i-2]-ghost)/(12.0*del[i])
 		i = n-1
 		df[igrid[i],ielement[i]] = (8.0*(f[i+1]-f[i-1])+f[i-2]-ghost)/(12.0*del[i])
-	elseif bc == "zero" || bc == "wall"
+	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 		i = 1
 		df[igrid[i],ielement[i]] = (8.0*f[i+1]-f[i+2])/(12.0*del[i])
 		i = 2

--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -122,7 +122,12 @@ function upwind_first_order!(df, f, del, adv_fac, bc, igrid, ielement)
             df[1, j] = df[end, j-1]
         end
 		i = 1
-		if adv_fac[i] < 0
+                if adv_fac[i] >= 0.0 || bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, just use a one-sided difference away from the
+                        # boundary.
+			df[igrid[i],ielement[i]] = (f[i+1]-f[i])/del[i+1]
+                else
 			if bc == "periodic"
 				tmp = f[n-1]
 			elseif bc == "constant"
@@ -132,24 +137,21 @@ function upwind_first_order!(df, f, del, adv_fac, bc, igrid, ielement)
 			end
 			#df[i] = (f[i]-tmp)/del[i]
 			df[igrid[i],ielement[i]] = (f[i]-tmp)/del[i]
-		else
-			#df[i] = (f[i+1]-f[i])/del[i+1]
-			df[igrid[i],ielement[i]] = (f[i+1]-f[i])/del[i+1]
 		end
 		i = n
-		if adv_fac[i] > 0
+		if adv_fac[i] <= 0 || bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, just use a one-sided difference away from the
+                        # boundary.
+			df[igrid[i],ielement[i]] =  (f[i]-f[i-1])/del[i]
+                else
 			if bc == "periodic"
 				tmp = f[2]
 			elseif bc == "constant"
 				tmp = f[n]
-			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-				tmp = 0.0
 			end
 			#df[i] = (tmp-f[i])/del[1]
 			df[igrid[i],ielement[i]] = (tmp-f[i])/del[1]
-		else
-			#df[i] =  (f[i]-f[i-1])/del[i]
-			df[igrid[i],ielement[i]] =  (f[i]-f[i-1])/del[i]
 		end
     end
 	return nothing
@@ -173,71 +175,74 @@ function upwind_second_order!(df, f, del, adv_fac, bc, igrid, ielement)
             end
         end
 		i = 2
-		if adv_fac[i] < 0
+		if adv_fac[i] >= 0
+			df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
+                elseif bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, use a centred difference for this second point.
+			df[igrid[i],ielement[i]] = (f[i+1]-f[i-1])/(2*del[i])
+                else
 			if bc == "periodic"
 				tmp1 = f[n-1]
 			elseif bc == "constant"
 				tmp1 = f[1]
-			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-				tmp1 = 0.0
 			end
 			#df[i] = (3.0*f[i]-4.0*f[i-1]+tmp1)/(2.0*del[i])
 			df[igrid[i],ielement[i]] = (3.0*f[i]-4.0*f[i-1]+tmp1)/(2.0*del[i])
-		else
-			#df[i] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
-			df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
 		end
 		i = 1
-		if adv_fac[i] < 0
+		if adv_fac[i] >= 0 || bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, just use a one-sided difference away from the
+                        # boundary.
+			df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
+                else
 			if bc == "periodic"
 				tmp1 = f[n-1]
 				tmp2 = f[n-2]
 			elseif bc == "constant"
 				tmp2 = f[1]
 				tmp1 = tmp2
-			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-				tmp2 = 0.0
-				tmp1 = tmp2
 			end
 			#df[i] = (3.0*f[i]-4.0*tmp1+tmp2)/(2.0*del[i])
 			df[igrid[i],ielement[i]] = (3.0*f[i]-4.0*tmp1+tmp2)/(2.0*del[i])
-		else
-			#df[i] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
-			df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
 		end
-		if adv_fac[n-1] > 0
+                i = n-1
+		if adv_fac[i] <= 0
+			df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i])
+                elseif bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, use a centred difference for this second point.
+			df[igrid[i],ielement[i]] = (f[i+1]-f[i-1])/(2*del[i])
+		else
 			if bc == "periodic"
 				tmp1 = f[2]
 			elseif bc == "constant"
 				tmp1 = f[n]
-			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-				tmp1 = 0.0
-			end
-			i = n-1
+                        end
 			#df[i] = (-tmp1+4*f[i+1]-3*f[i])/(2*del[i+1])
 			df[igrid[i],ielement[i]] = (-tmp1+4*f[i+1]-3*f[i])/(2*del[1])
 			#println("i: ", i, "  adv_fac: ", adv_fac[i], "  tmp1: ", tmp1)
-		else
-			i = n-1
-			#df[i] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i])
-			df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i])
 		end
-		if adv_fac[n] > 0
+                i = n
+		if adv_fac[i] <= 0 || bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, just use a one-sided difference away from the
+                        # boundary.
+			df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i-1])
+                else
 			if bc == "periodic"
 				tmp2 = f[3]
 				tmp1 = f[2]
 			elseif bc == "constant"
-				tmp2 = f[n]
+				tmp2 = f[i]
 				tmp1 = tmp2
 			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
 				tmp2 = 0.0
 				tmp1 = tmp2
 			end
 			#df[i] = (-tmp2+4*tmp1-3*f[i])/(2*del[1])
-			df[igrid[n],ielement[n]] = (-tmp2+4*tmp1-3*f[n])/(2*del[1])
-		else
-			#df[i] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i])
-			df[igrid[n],ielement[n]] =  (3*f[n]-4*f[n-1]+f[n-2])/(2*del[n-1])
+			df[igrid[i],ielement[i]] = (-tmp2+4*tmp1-3*f[i])/(2*del[1])
 		end
 	end
         # fill in points at start of elements, in case we are using more than one
@@ -263,17 +268,18 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
             end
         end
 		i = 2
-		if adv_fac[i] < 0
+		if adv_fac[i] >= 0 || bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, use the unbalanced difference away from the
+                        # boundary.
+			df[igrid[i],ielement[i]] = (-f[i+2]+6.0*f[i+1]-3.0*f[i]-2.0*f[i-1])/(6.0*del[i+1])
+                else
 			if bc == "periodic"
 				tmp1 = f[n-1]
 			elseif bc == "constant"
 				tmp1 = f[1]
-			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-				tmp1 = 0.0
 			end
 			df[igrid[i],ielement[i]] = (2.0*f[i+1]+3.0*f[i]-6.0*f[i-1]+tmp1)/(6.0*del[i])
-		else
-			df[igrid[i],ielement[i]] = (-f[i+2]+6.0*f[i+1]-3.0*f[i]-2.0*f[i-1])/(6.0*del[i+1])
 		end
 		i = 1
 		if bc == "periodic"
@@ -282,34 +288,31 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 		elseif bc == "constant"
 			tmp2 = f[1]
 			tmp1 = tmp2
-		elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-			tmp2 = 0.0
-			tmp1 = tmp2
 		end
-		if adv_fac[i] < 0
-			df[igrid[i],ielement[i]] = (2.0*f[i+1]+3.0*f[i]-6.0*tmp1+tmp2)/(6.0*del[i])
-		else
+		if adv_fac[i] >= 0 || bc ∈ ("zero", "both_zero", "wall")
                     if bc == "periodic"
 			df[igrid[i],ielement[i]] = (-f[i+2]+6.0*f[i+1]-3.0*f[i]-2.0*tmp1)/(6.0*del[i+1])
                     else
                         # Downwind boundary, don't want to impose tmp1=0.0, so instead
-                        # just use 2nd order accurate difference formula
-                        df[igrid[i],ielement[i]] = (-f[i+2]+4.0*f[i+1]-3.0*f[i])/(2.0*del[i+1])
+                        # use one-sided difference formula
+                        df[igrid[i],ielement[i]] = (2.0*f[i+3]-9.0*f[i+2]+18.0*f[i+1]-11.0*f[i])/(6.0*del[i+1])
                     end
+		else
+			df[igrid[i],ielement[i]] = (2.0*f[i+1]+3.0*f[i]-6.0*tmp1+tmp2)/(6.0*del[i])
 		end
-		if adv_fac[n-1] > 0
+                i = n-1
+		if adv_fac[i] <= 0 || bc ∈ ("zero", "both_zero", "wall")
+                        # For boundary conditions that set the values of fields at the
+                        # boundary, use the unbalanced difference away from the
+                        # boundary.
+			df[igrid[i],ielement[i]] =  (2.0*f[i+1]+3.0*f[i]-6.0*f[i-1]+f[i-2])/(6.0*del[i])
+		else
 			if bc == "periodic"
 				tmp1 = f[2]
 			elseif bc == "constant"
 				tmp1 = f[n]
-			elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-				tmp1 = 0.0
 			end
-			i = n-1
 			df[igrid[i],ielement[i]] = (-tmp1+6.0*f[i+1]-3.0*f[i]-2.0*f[i-1])/(6.0*del[1])
-		else
-			i = n-1
-			df[igrid[i],ielement[i]] =  (2.0*f[i+1]+3.0*f[i]-6.0*f[i-1]+f[i-2])/(6.0*del[i])
 		end
 		if bc == "periodic"
 			tmp2 = f[3]
@@ -317,20 +320,18 @@ function upwind_third_order!(df, f, del, adv_fac, bc, igrid, ielement)
 		elseif bc == "constant"
 			tmp2 = f[n]
 			tmp1 = tmp2
-		elseif bc == "zero" || bc == "both_zero" || bc == "wall"
-			tmp2 = 0.0
-			tmp1 = tmp2
 		end
-		if adv_fac[n] > 0
-			df[igrid[n],ielement[n]] = (-tmp2+6.0*tmp1-3.0*f[n]-2.0*f[n-1])/(6.0*del[1])
-		else
+                i = n
+		if adv_fac[i] <= 0 || bc ∈ ("zero", "both_zero", "wall")
                     if bc == "periodic"
-			df[igrid[n],ielement[n]] =  (2.0*tmp1+3.0*f[n]-6.0*f[n-1]+f[n-2])/(6.0*del[n-1])
+			df[igrid[i],ielement[i]] =  (2.0*tmp1+3.0*f[i]-6.0*f[i-1]+f[i-2])/(6.0*del[i-1])
                     else
                         # Downwind boundary, don't want to impose tmp1=0.0, so instead
-                        # just use 2nd order accurate difference formula
-                        df[igrid[n],ielement[n]] =  (3.0*f[n]-4.0*f[n-1]+f[n-2])/(2.0*del[n-1])
+                        # use one-sided difference formula
+                        df[igrid[i],ielement[i]] =  (11.0*f[i]-18.0*f[i-1]+9.0*f[i-2]-2.0*f[i-3])/(6.0*del[i-1])
                     end
+		else
+			df[igrid[i],ielement[i]] = (-tmp2+6.0*tmp1-3.0*f[i]-2.0*f[i-1])/(6.0*del[1])
 		end
 	#end
         # fill in points at start of elements, in case we are using more than one
@@ -371,10 +372,12 @@ function centered_second_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 		ghost = f[n]
 		df[igrid[i],ielement[i]] = 0.5*(ghost-f[i-1])/del[n-1]
 	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
+                # For boundary conditions that set the values of fields at the boundary,
+                # just use a one-sided difference away from the boundary.
 		i = 1
-		df[igrid[i],ielement[i]] = 0.5*f[i+1]/del[i]
+                df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
 		i = n
-		df[igrid[i],ielement[i]] = -0.5*f[i-1]/del[n-1]
+                df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i-1])
 	end
 end
 
@@ -409,10 +412,12 @@ function centered_second_order!(df::Array{mk_float,1}, f, del, bc, igrid, ieleme
 		ghost = f[n]
 		df[i] = 0.5*(ghost-f[i-1])/del[n-1]
 	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
+                # For boundary conditions that set the values of fields at the boundary,
+                # just use a one-sided difference away from the boundary.
 		i = 1
-		df[i] = 0.5*f[i+1]/del[i]
+                df[igrid[i],ielement[i]] = (-f[i+2]+4*f[i+1]-3*f[i])/(2*del[i+1])
 		i = n
-		df[i] = -0.5*f[i-1]/del[n-1]
+                df[igrid[i],ielement[i]] =  (3*f[i]-4*f[i-1]+f[i-2])/(2*del[i-1])
 	end
 end
 
@@ -453,14 +458,16 @@ function centered_fourth_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
 		i = n-1
 		df[igrid[i],ielement[i]] = (8.0*(f[i+1]-f[i-1])+f[i-2]-ghost)/(12.0*del[i])
 	elseif bc == "zero" || bc == "both_zero" || bc == "wall"
+                # For boundary conditions that set the values of fields at the boundary,
+                # use 3rd order one-sided or unbalanced difference away from the boundary.
 		i = 1
-		df[igrid[i],ielement[i]] = (8.0*f[i+1]-f[i+2])/(12.0*del[i])
+                df[igrid[i],ielement[i]] = (2.0*f[i+3]-9.0*f[i+2]+18.0*f[i+1]-11.0*f[i])/(6.0*del[i+1])
 		i = 2
-		df[igrid[i],ielement[i]] = (8.0*(f[i+1]-f[i-1])-f[i+2])/(12.0*del[i])
+                df[igrid[i],ielement[i]] = (-f[i+2]+6.0*f[i+1]-3.0*f[i]-2.0*f[i-1])/(6.0*del[i+1])
 		i = n
-		df[igrid[i],ielement[i]] = (-8.0*f[i-1]+f[i-2])/(12.0*del[i])
+                df[igrid[i],ielement[i]] =  (11.0*f[i]-18.0*f[i-1]+9.0*f[i-2]-2.0*f[i-3])/(6.0*del[i-1])
 		i = n-1
-		df[igrid[i],ielement[i]] = (8.0*(f[i+1]-f[i-1])+f[i-2])/(12.0*del[i])
+                df[igrid[i],ielement[i]] =  (2.0*f[i+1]+3.0*f[i]-6.0*f[i-1]+f[i-2])/(6.0*del[i])
 	end
         # fill in points at start of elements, in case we are using more than one
         for j ∈ 2:ielement[end]
@@ -499,10 +506,12 @@ function second_derivative_finite_difference!(df::Array{mk_float,2}, f, del, bc,
         ghost = f[n]
         df[igrid[i],ielement[i]] = (ghost - 2.0*f[i] + f[i-1]) / del[i]^2
     elseif bc == "zero" || bc == "both_zero" || bc == "wall"
+        # For boundary conditions that set the values of fields at the boundary,
+        # just use a one-sided difference away from the boundary.
         i = 1
-        df[igrid[i],ielement[i]] = (f[i+1] - 2.0*f[i]) / del[i]^2
+        df[igrid[i],ielement[i]] = (-f[i+3] + 4.0*f[i+2] - 5.0*f[i+1] + 2.0*f[i]) / del[i]^2
         i = n
-        df[igrid[i],ielement[i]] = (-2.0*f[i] + f[i-1]) / del[i]^2
+        df[igrid[i],ielement[i]] = (2.0*f[i] - 5.0*f[i-1] + 4.0*f[i-2] - f[i-3]) / del[i]^2
     end
 end
 

--- a/src/finite_differences.jl
+++ b/src/finite_differences.jl
@@ -48,6 +48,17 @@ function elementwise_derivative!(coord, f, not_spectral::Bool, ::Val{1})
 end
 
 """
+    elementwise_derivative!(coord, f, not_spectral::Bool, Val(2))
+
+Calculate the second derivative of f using 2nd order centered finite differences; result
+stored in coord.scratch_2d.
+"""
+function elementwise_derivative!(coord, f, not_spectral::Bool, ::Val{2})
+    return second_derivative_finite_difference!(coord.scratch_2d, f, coord.cell_width,
+        coord.bc, coord.igrid, coord.ielement)
+end
+
+"""
 """
 function derivative_finite_difference!(df, f, del, adv_fac, bc, fd_option, igrid, ielement)
 	if fd_option == "second_order_upwind"
@@ -455,6 +466,44 @@ function centered_fourth_order!(df::Array{mk_float,2}, f, del, bc, igrid, ieleme
         for j ∈ 2:ielement[end]
             df[1, j] = df[end, j-1]
         end
+end
+
+"""
+Take the second derivative of input function f and return as df using second-order,
+centered differences.
+output array df is 2D array of size ngrid x nelement
+"""
+function second_derivative_finite_difference!(df::Array{mk_float,2}, f, del, bc, igrid, ielement)
+    n = length(f)
+    # get derivative at internal points
+    for i ∈ 2:n-1
+        df[igrid[i],ielement[i]] = (f[i+1] - 2.0*f[i] + f[i-1]) / del[i]^2
+    end
+    # fill in points at start of elements, in case we are using more than one
+    for j ∈ 2:ielement[end]
+        df[1, j] = df[end, j-1]
+    end
+    # use BCs to treat boundary points
+    if bc == "periodic"
+        i = 1
+        ghost = f[n-1]
+        df[igrid[i],ielement[i]] = (f[i+1] - 2.0*f[i] + ghost) / del[i]^2
+        i = n
+        ghost = f[2]
+        df[igrid[i],ielement[i]] = (ghost - 2.0*f[i] + f[i-1]) / del[i]^2
+    elseif bc == "constant"
+        i = 1
+        ghost = f[1]
+        df[igrid[i],ielement[i]] = (f[i+1] - 2.0*f[i] + ghost) / del[i]^2
+        i = n
+        ghost = f[n]
+        df[igrid[i],ielement[i]] = (ghost - 2.0*f[i] + f[i-1]) / del[i]^2
+    elseif bc == "zero" || bc == "both_zero" || bc == "wall"
+        i = 1
+        df[igrid[i],ielement[i]] = (f[i+1] - 2.0*f[i]) / del[i]^2
+        i = n
+        df[igrid[i],ielement[i]] = (-2.0*f[i] + f[i-1]) / del[i]^2
+    end
 end
 
 end

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -42,6 +42,7 @@ include("continuity.jl")
 include("energy_equation.jl")
 include("force_balance.jl")
 include("source_terms.jl")
+include("numerical_dissipation.jl")
 include("time_advance.jl")
 
 include("moment_kinetics_input.jl")

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -195,7 +195,7 @@ function restart_moment_kinetics(restart_filename::String, input_dict::Dict,
         # Set up all the structs, etc. needed for a run.
         pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral, z_spectral,
         r_spectral, moments, fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL,
-        composition, collisions, advance, scratch_dummy_sr, io, cdf =
+        composition, collisions, num_diss_params, advance, scratch_dummy_sr, io, cdf =
         setup_moment_kinetics(input_dict, backup_filename=backup_filename,
                               restart_time_index=time_index)
 
@@ -203,7 +203,7 @@ function restart_moment_kinetics(restart_filename::String, input_dict::Dict,
             time_advance!(pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral,
                           z_spectral, r_spectral, moments, fields, vpa_advect, z_advect,
                           r_advect, vpa_SL, z_SL, r_SL, composition, collisions,
-                          advance, scratch_dummy_sr, io, cdf)
+                          num_diss_params, advance, scratch_dummy_sr, io, cdf)
         finally
             # clean up i/o and communications
             # last 2 elements of mk_state are `io` and `cdf`
@@ -239,7 +239,7 @@ function setup_moment_kinetics(input_dict::Dict; backup_filename=nothing,
     # obtain input options from moment_kinetics_input.jl
     # and check input to catch errors
     run_name, output_dir, evolve_moments, t_input, z_input, r_input, vpa_input,
-        composition, species, collisions, drive_input = input
+        composition, species, collisions, drive_input, num_diss_params = input
     # initialize z grid and write grid point locations to file
     z, z_spectral = define_coordinate(z_input, composition)
     # initialize r grid and write grid point locations to file
@@ -281,8 +281,8 @@ function setup_moment_kinetics(input_dict::Dict; backup_filename=nothing,
     begin_s_r_z_region()
 
     return pdf, scratch, code_time, t_input, vpa, z, r, vpa_spectral, z_spectral, r_spectral, moments,
-           fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL, composition, collisions, advance,
-           scratch_dummy_sr, io, cdf
+           fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL, composition,
+           collisions, num_diss_params, advance, scratch_dummy_sr, io, cdf
 end
 
 """

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -12,6 +12,7 @@ using ..communication
 using ..file_io: input_option_error, open_output_file
 using ..finite_differences: fd_check_option
 using ..input_structs
+using ..numerical_dissipation: setup_numerical_dissipation
 
 @enum RunType single performance_test scan
 const run_type = single
@@ -176,6 +177,9 @@ function mk_input(scan_input=Dict())
     vpa.discretization = get(scan_input, "vpa_discretization", "chebyshev_pseudospectral")
     vpa.fd_option = get(scan_input, "vpa_finite_difference_option", "third_order_upwind")
 
+    num_diss_params = setup_numerical_dissipation(
+        get(scan_input, "numerical_dissipation", Dict{String,Any}()))
+
     #########################################################################
     ########## end user inputs. do not modify following code! ###############
     #########################################################################
@@ -238,7 +242,7 @@ function mk_input(scan_input=Dict())
 
     # return immutable structs for z, vpa, species and composition
     all_inputs = (run_name, output_dir, evolve_moments, t, z_immutable, r_immutable, vpa_immutable,
-                  composition, species_immutable, collisions, drive_immutable)
+                  composition, species_immutable, collisions, drive_immutable, num_diss_params)
     println(io, "\nAll inputs returned from mk_input():")
     println(io, all_inputs)
     close(io)

--- a/src/moment_kinetics_structs.jl
+++ b/src/moment_kinetics_structs.jl
@@ -4,6 +4,7 @@ cycles when they are used by several other modules.
 """
 module moment_kinetics_structs
 
+using FFTW
 using ..communication
 using ..type_definitions: mk_float
 
@@ -29,6 +30,25 @@ struct em_fields_struct
     force_phi::Bool
     drive_amplitude::mk_float
     drive_frequency::mk_float
+end
+
+"""
+"""
+struct chebyshev_info{TForward <: FFTW.cFFTWPlan, TBackward <: AbstractFFTs.ScaledPlan}
+    # fext is an array for storing f(z) on the extended domain needed
+    # to perform complex-to-complex FFT using the fact that f(theta) is even in theta
+    fext::Array{Complex{mk_float},1}
+    # Chebyshev spectral coefficients of distribution function f
+    # first dimension contains location within element
+    # second dimension indicates the element
+    f::Array{mk_float,2}
+    # Chebyshev spectral coefficients of derivative of f
+    df::Array{mk_float,1}
+    # plan for the complex-to-complex, in-place, forward Fourier transform on Chebyshev-Gauss-Lobatto grid
+    forward::TForward
+    # plan for the complex-to-complex, in-place, backward Fourier transform on Chebyshev-Gauss-Lobatto grid
+    #backward_transform::FFTW.cFFTWPlan
+    backward::TBackward
 end
 
 end

--- a/src/numerical_dissipation.jl
+++ b/src/numerical_dissipation.jl
@@ -1,0 +1,72 @@
+"""
+"""
+module numerical_dissipation
+
+export vpa_dissipation!
+
+using ..looping
+using ..calculus: derivative!
+
+"""
+Add diffusion in the vpa direction to suppress oscillations
+"""
+function vpa_dissipation!(f_out, fvec_in, moments, vpa, spectral::T_spectral, dt) where T_spectral
+    begin_s_r_z_region()
+
+    # #diffusion_coefficient = 1.0e4
+    # diffusion_coefficient = 2.0e1
+
+    # if diffusion_coefficient <= 0.0
+    #     return nothing
+    # end
+
+    # if T_spectral <: Bool
+    #     # Scale diffusion coefficient like square of grid spacing, so convergence will
+    #     # be second order accurate despite presence of numerical dissipation.
+    #     # Assume constant grid spacing, so all cell_width entries are the same.
+    #     diffusion_coefficient *= vpa.cell_width[1]^2
+    # else
+    #     # Dissipation should decrease with element size at order (ngrid-1) to preserve
+    #     # expected convergence of Chebyshev pseudospectral scheme
+    #     diffusion_coefficient *= (vpa.L/vpa.nelement)^(vpa.ngrid-1)
+    # end
+
+    diffusion_coefficient = -1.0 #1.e-1 #1.0e-3
+    if diffusion_coefficient <= 0.0
+        return nothing
+    end
+
+    @loop_s_r_z is ir iz begin
+        # # Don't want to dissipate the fluid moments, so divide out the Maxwellian, then
+        # # diffuse the result, i.e.
+        # # df/dt += diffusion_coefficient * f_M d2(f/f_M)/dvpa2
+        # # Store f_M in vpa.scratch
+        # if (moments.evolve_ppar || moments.evolve_vth) && moments.evolve_upar
+        #     @views @. vpa.scratch = exp(-vpa.grid^2)
+        # elseif moments.evolve_ppar || moments.evolve_vth
+        #     vth = sqrt(2.0*fvec_in.ppar[iz,ir,is]/fvec_in.density[iz,ir,is])
+        #     @views @. vpa.scratch = exp(-(vpa.grid - fvec_in.upar[iz,ir,is]/vth)^2)
+        # elseif moments.evolve_upar
+        #     vth = sqrt(2.0*fvec_in.ppar[iz,ir,is]/fvec_in.density[iz,ir,is])
+        #     @views @. vpa.scratch = exp(-(vpa.grid/vth)^2)
+        # elseif moments.evolve_density
+        #     vth = sqrt(2.0*fvec_in.ppar[iz,ir,is]/fvec_in.density[iz,ir,is])
+        #     @views @. vpa.scratch = exp(-((vpa.grid - fvec_in.upar[iz,ir,is])/vth)^2)
+        # else
+        #     vth = sqrt(2.0*fvec_in.ppar[iz,ir,is]/fvec_in.density[iz,ir,is])
+        #     @views @. vpa.scratch = (fvec_in.density[iz,ir,is] *
+        #                              exp(-((vpa.grid - fvec_in.upar[iz,ir,is])/vth)^2))
+        # end
+        # @views @. vpa.scratch2 = fvec_in.pdf[:,iz,ir,is] / vpa.scratch
+        # derivative!(vpa.scratch3, vpa.scratch2, vpa, spectral, Val(2))
+        # @views @. f_out[:,iz,ir,is] += dt * diffusion_coefficient * vpa.scratch *
+        #                                vpa.scratch3
+
+        @views derivative!(vpa.scratch, fvec_in.pdf[:,iz,ir,is], vpa, spectral, Val(2))
+        @views @. f_out[:,iz,ir,is] += dt * diffusion_coefficient * vpa.scratch
+    end
+
+    return nothing
+end
+
+end

--- a/src/numerical_dissipation.jl
+++ b/src/numerical_dissipation.jl
@@ -27,6 +27,14 @@ end
 """
 Suppress the distribution function by damping towards a Maxwellian in the last element
 before the vpa boundaries, to avoid numerical instabilities there.
+
+Disabled by default.
+
+The damping rate is set in the input TOML file by the parameter
+```
+[numerical_dissipation]
+vpa_boundary_buffer_damping_rate = 0.1
+```
 """
 function vpa_boundary_buffer_decay!(f_out, fvec_in, moments, vpa, dt,
                                     num_diss_params::numerical_dissipation_parameters)
@@ -118,6 +126,14 @@ end
 """
 Suppress the distribution function by applying diffusion in the last element before the
 vpa boundaries, to avoid numerical instabilities there.
+
+Disabled by default.
+
+The maximum diffusion rate in the buffer is set in the input TOML file by the parameter
+```
+[numerical_dissipation]
+vpa_boundary_buffer_diffusion_coefficient = 0.1
+```
 """
 function vpa_boundary_buffer_diffusion!(f_out, fvec_in, vpa, vpa_spectral, dt,
                                         num_diss_params::numerical_dissipation_parameters)
@@ -170,6 +186,8 @@ end
 Try to suppress oscillations near the boundary by ensuring that every point in the final
 element is ≤ the innermost value. The distribution function should be decreasing near
 the boundaries, so this should be an OK thing to force.
+
+Note: not currently used.
 """
 function vpa_boundary_force_decreasing!(f_out, vpa)
     begin_s_r_z_region()
@@ -197,6 +215,14 @@ end
 
 """
 Add diffusion in the vpa direction to suppress oscillations
+
+Disabled by default.
+
+The diffusion coefficient is set in the input TOML file by the parameter
+```
+[numerical_dissipation]
+vpa_dissipation_coefficient = 0.1
+```
 """
 function vpa_dissipation!(f_out, fvec_in, moments, vpa, spectral::T_spectral, dt,
         num_diss_params::numerical_dissipation_parameters) where T_spectral
@@ -253,6 +279,14 @@ end
 
 """
 Add diffusion in the z direction to suppress oscillations
+
+Disabled by default.
+
+The diffusion coefficient is set in the input TOML file by the parameter
+```
+[numerical_dissipation]
+z_dissipation_coefficient = 0.1
+```
 """
 function z_dissipation!(f_out, fvec_in, moments, z, vpa, spectral::T_spectral, dt,
         num_diss_params::numerical_dissipation_parameters) where T_spectral

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -24,7 +24,7 @@ using ..r_advection: update_speed_r!, r_advection!
 using ..vpa_advection: update_speed_vpa!, vpa_advection!
 using ..charge_exchange: charge_exchange_collisions!
 using ..ionization: ionization_collisions!
-using ..numerical_dissipation: vpa_dissipation!
+using ..numerical_dissipation: vpa_dissipation!, z_dissipation!
 using ..source_terms: source_terms!
 using ..continuity: continuity_equation!
 using ..force_balance: force_balance!
@@ -799,6 +799,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     # add numerical dissipation
     if advance.numerical_dissipation
         vpa_dissipation!(fvec_out.pdf, fvec_in, moments, vpa, vpa_spectral, dt)
+        z_dissipation!(fvec_out.pdf, fvec_in, moments, z, vpa, z_spectral, dt)
     end
     # End of advance of distribution function
 

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -24,7 +24,9 @@ using ..r_advection: update_speed_r!, r_advection!
 using ..vpa_advection: update_speed_vpa!, vpa_advection!
 using ..charge_exchange: charge_exchange_collisions!
 using ..ionization: ionization_collisions!
-using ..numerical_dissipation: vpa_boundary_buffer!, vpa_dissipation!, z_dissipation!
+using ..numerical_dissipation: vpa_boundary_buffer_decay!,
+                               vpa_boundary_buffer_diffusion!, vpa_dissipation!,
+                               z_dissipation!, vpa_boundary_force_decreasing!
 using ..source_terms: source_terms!
 using ..continuity: continuity_equation!
 using ..force_balance: force_balance!
@@ -798,7 +800,8 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     # add numerical dissipation
     if advance.numerical_dissipation
-        vpa_boundary_buffer!(fvec_out.pdf, fvec_in, moments, vpa, dt)
+        vpa_boundary_buffer_decay!(fvec_out.pdf, fvec_in, moments, vpa, dt)
+        vpa_boundary_buffer_diffusion!(fvec_out.pdf, fvec_in, vpa, vpa_spectral, dt)
         vpa_dissipation!(fvec_out.pdf, fvec_in, moments, vpa, vpa_spectral, dt)
         z_dissipation!(fvec_out.pdf, fvec_in, moments, z, vpa, z_spectral, dt)
     end

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -24,7 +24,7 @@ using ..r_advection: update_speed_r!, r_advection!
 using ..vpa_advection: update_speed_vpa!, vpa_advection!
 using ..charge_exchange: charge_exchange_collisions!
 using ..ionization: ionization_collisions!
-using ..numerical_dissipation: vpa_dissipation!, z_dissipation!
+using ..numerical_dissipation: vpa_boundary_buffer!, vpa_dissipation!, z_dissipation!
 using ..source_terms: source_terms!
 using ..continuity: continuity_equation!
 using ..force_balance: force_balance!
@@ -798,6 +798,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     # add numerical dissipation
     if advance.numerical_dissipation
+        vpa_boundary_buffer!(fvec_out.pdf, fvec_in, moments, vpa, dt)
         vpa_dissipation!(fvec_out.pdf, fvec_in, moments, vpa, vpa_spectral, dt)
         z_dissipation!(fvec_out.pdf, fvec_in, moments, z, vpa, z_spectral, dt)
     end

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -24,6 +24,7 @@ using ..r_advection: update_speed_r!, r_advection!
 using ..vpa_advection: update_speed_vpa!, vpa_advection!
 using ..charge_exchange: charge_exchange_collisions!
 using ..ionization: ionization_collisions!
+using ..numerical_dissipation: vpa_dissipation!
 using ..source_terms: source_terms!
 using ..continuity: continuity_equation!
 using ..force_balance: force_balance!
@@ -43,6 +44,7 @@ mutable struct advance_info
     cx_collisions::Bool
     ionization_collisions::Bool
     source_terms::Bool
+    numerical_dissipation::Bool
     continuity::Bool
     force_balance::Bool
     energy::Bool
@@ -182,6 +184,7 @@ function setup_advance_flags(moments, composition, split_operators, collisions, 
     advance_cx = false
     advance_ionization = false
     advance_sources = false
+    advance_numerical_dissipation = false
     advance_continuity = false
     advance_force_balance = false
     advance_energy = false
@@ -207,6 +210,7 @@ function setup_advance_flags(moments, composition, split_operators, collisions, 
         elseif collisions.constant_ionization_rate && collisions.ionization > 0.0
             advance_ionization = true
         end
+        advance_numerical_dissipation = true
         # if evolving the density, must advance the continuity equation,
         # in addition to including sources arising from the use of a modified distribution
         # function in the kinetic equation
@@ -230,7 +234,8 @@ function setup_advance_flags(moments, composition, split_operators, collisions, 
         end
     end
     return advance_info(advance_vpa_advection, advance_z_advection, advance_cx,
-                        advance_ionization, advance_sources, advance_continuity,
+                        advance_ionization, advance_sources,
+                        advance_numerical_dissipation, advance_continuity,
                         advance_force_balance, advance_energy, rk_coefs)
 end
 
@@ -790,6 +795,10 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
         ionization_collisions!(fvec_out.pdf, fvec_in, moments, n_ion_species,
             composition.n_neutral_species, vpa, z, r, vpa_spectral, composition,
             collisions, z.n, dt)
+    end
+    # add numerical dissipation
+    if advance.numerical_dissipation
+        vpa_dissipation!(fvec_out.pdf, fvec_in, moments, vpa, vpa_spectral, dt)
     end
     # End of advance of distribution function
 

--- a/test/calculus_tests.jl
+++ b/test/calculus_tests.jl
@@ -230,8 +230,14 @@ function runtests()
                     # Note: only get 1st order convergence at the boundary for an input
                     # function that has zero gradient at the boundary
                     rtol = rtol_prefactor / (nelement*(ngrid-1))
-                    @test isapprox(df, expected_df, rtol=rtol, atol=1.e-15,
+                    @test isapprox(df[2:end-1], expected_df[2:end-1], rtol=rtol, atol=1.e-15,
                                    norm=maxabs_norm)
+                    # Some methods use 1st order one-sided derivative at boundaries
+                    # (where derivative is zero for this example), so need higher atol
+                    for ix ∈ (1,x.n)
+                        @test isapprox(df[ix], expected_df[ix], rtol=rtol, atol=2.0*rtol,
+                                       norm=maxabs_norm)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Introduces a collection of functions to add numerical dissipation, all disabled by default. Currently, these seem to be useful to avoid a numerical (?) instability in the initial stages of wall-bc runs.

The dissipation is switched on and controlled by input parameters. These parameters are passed in a section `[numerical_dissipation]` in the TOML files.

Adds a second derivative function to be used for numerical dissipation. Finite difference version is standard second order centred difference. The Chebyshev pseudospectral version is a tentative attempt at an implementation; the current implementation does the following:
* Take the first derivative, storing the values in each separate element
* Get the continuous first derivative at element boundaries by averaging the values from both elements
* Take the derivative of the continuous first derivative to get a second derivative
* At each element boundary, the first derivative will generally be discontinuous, and the second derivative calculated so far will not necessarily tend to smooth out the discontinuity (or at least not that strongly). To try and help this, add an extra contribution at the element boundaries proportional to the discontinuity in the first derivative between elements.