### PR TITLE
Allow forcing a minimum value for the pdf

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v2

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -260,7 +260,8 @@ function setup_moment_kinetics(input_dict::Dict; backup_filename=nothing,
     # the main time advance loop -- including normalisation of f by density if requested
     moments, fields, vpa_advect, z_advect, r_advect, vpa_SL, z_SL, r_SL, scratch,
         advance, scratch_dummy_sr = setup_time_advance!(pdf, vpa, z, r, z_spectral,
-            composition, drive_input, moments, t_input, collisions, species)
+            composition, drive_input, moments, t_input, collisions, species,
+            num_diss_params)
 
     if backup_filename !== nothing
         # Have done unnecessary initialisation of pdf and moments, which is overwritten


### PR DESCRIPTION
Introduces a function `force_minimum_pdf_value!()` that can be used to set any values less than the minimum to the minimum. Forcing `f >= 0.0` can sometimes help numerical stability when running in moment-kinetic mode, as negative values sometimes seem to 'confuse' the algorithm applying the constraints. However sometimes applying this forcing reduces the accuracy of the simulation - for example in the Harrison-Thompson test, forcing a minimum of 0 pushes the numerical solution far from the analytical one with errors ~100% rather than errors <3%.

By default no minimum value is applied. The value to use can be set in input options (0.0 is probably the most useful choice...) like
```
[numerical_dissipation]
force_minimum_pdf_value = 0.0
```

The forcing applied before applying boundary conditions so that integral constraint corrections in sheath boundary conditions do not get messed up.