### PR TITLE
Add upwinding in moment equations

### DIFF
--- a/src/continuity.jl
+++ b/src/continuity.jl
@@ -10,7 +10,8 @@ using ..looping
 """
 use the continuity equation dn/dt + d(n*upar)/dz to update the density n for all species
 """
-function continuity_equation!(dens_out, fvec_in, moments, composition, vpa, z, r, dt, spectral, ionization)
+function continuity_equation!(dens_out, fvec_in, moments, composition, vpa, z, r, dt,
+                              spectral, ionization, num_diss_params)
     # use the continuity equation dn/dt + d(n*upar)/dz to update the density n
     # for each species
 
@@ -19,7 +20,7 @@ function continuity_equation!(dens_out, fvec_in, moments, composition, vpa, z, r
     @loop_s is begin
         @loop_r ir begin #MRH NOT SURE ABOUT THIS!
             @views continuity_equation_single_species!(dens_out[:,ir,is],
-                fvec_in.density[:,ir,:], fvec_in.upar[:,ir,is], z, dt, spectral, ionization, composition, is)
+                fvec_in.density[:,ir,:], fvec_in.upar[:,ir,is], z, dt, spectral, ionization, composition, is, num_diss_params)
         end
     end
 end
@@ -27,7 +28,9 @@ end
 """
 use the continuity equation dn/dt + d(n*upar)/dz to update the density n
 """
-function continuity_equation_single_species!(dens_out, dens_in, upar, z, dt, spectral, ionization, composition, is)
+function continuity_equation_single_species!(dens_out, dens_in, upar, z, dt, spectral,
+                                             ionization, composition, is,
+                                             num_diss_params)
     ## calculate the particle flux nu
     #@. z.scratch = dens_in[:,is]*upar
     ## Use as 'adv_fac' for upwinding
@@ -57,6 +60,15 @@ function continuity_equation_single_species!(dens_out, dens_in, upar, z, dt, spe
             @. dens_out -= dt*ionization*dens_in[:,is]*dens_in[:,isi]
         end
     end
+
+    # Ad-hoc diffusion to stabilise numerics...
+    diffusion_coefficient = num_diss_params.moment_dissipation_coefficient
+    if diffusion_coefficient > 0.0
+        derivative!(z.scratch, dens_in[:,is], z, spectral, Val(2))
+        @. dens_out += dt*diffusion_coefficient*z.scratch
+    end
+
+    return nothing
 end
 
 end

--- a/src/energy_equation.jl
+++ b/src/energy_equation.jl
@@ -37,7 +37,9 @@ include all contributions to the energy equation aside from collisions
 """
 function energy_equation_no_collisions!(ppar_out, upar, ppar, qpar, dt, z, spectral)
     # calculate dppar/dz and store in z.scratch
-    derivative!(z.scratch, ppar, z, spectral)
+    # Use as 'adv_fac' for upwinding
+    @. z.scratch3 = -upar
+    derivative!(z.scratch, ppar, z, z.scratch3, spectral)
     # update ppar to account for contribution from parallel pressure gradient
     @. ppar_out -= dt*upar*z.scratch
     # calculate dqpar/dz and store in z.scratch

--- a/src/force_balance.jl
+++ b/src/force_balance.jl
@@ -12,8 +12,8 @@ use the force balance equation d(nu)/dt + d(ppar + n*upar*upar)/dz =
 -(dens/2)*dphi/dz + R*dens_i*dens_n*(upar_n-upar_i)
 to update the parallel particle flux dens*upar for each species
 """
-function force_balance!(pflx, fvec, fields, collisions, vpa, z, r, dt, spectral,
-                        composition, num_diss_params)
+function force_balance!(pflx, density, fvec, fields, collisions, vpa, z, r, dt,
+                        spectral, composition, num_diss_params)
 
     begin_s_r_region()
 
@@ -40,6 +40,11 @@ function force_balance!(pflx, fvec, fields, collisions, vpa, z, r, dt, spectral,
             force_balance_ionization!(pflx, fvec.density, fvec.upar, collisions.ionization,
                                       composition, z.n, dt)
         end
+    end
+
+    @loop_s_r_z is ir iz begin
+        # convert from the particle flux to the parallel flow
+        pflx[iz,ir,is] /= density[iz,ir,is]
     end
 end
 

--- a/src/force_balance.jl
+++ b/src/force_balance.jl
@@ -47,13 +47,31 @@ flux term above
 """
 function force_balance_flux_species!(pflx, dens, upar, ppar, z, dt, spectral)
     # calculate the parallel flux of parallel momentum densitg at the previous time level/RK stage
-    #@. z.scratch = ppar + dens*upar^2
-    # Until julia-1.8 is released, prefer x*x to x^2 to avoid extra allocations when broadcasting.
-    @. z.scratch = ppar + dens*upar*upar
-    # calculate d(nu)/dz, averaging the derivative values at element boundaries
-    derivative!(z.scratch, z.scratch, z, spectral)
+    derivative!(z.scratch, ppar, z, spectral)
+
+    ##@. z.scratch2 = dens*upar^2
+    ## Until julia-1.8 is released, prefer x*x to x^2 to avoid extra allocations when broadcasting.
+    #@. z.scratch2 = dens*upar*upar
+    ## Use as 'adv_fac' for upwinding
+    #@. z.scratch3 = -upar
+    #derivative!(z.scratch2, z.scratch2, z, z.scratch3, spectral)
+
+    #@. z.scratch2 = dens*upar
+    ## Use as 'adv_fac' for upwinding
+    #@. z.scratch3 = -upar
+    #derivative!(z.scratch2, z.scratch2, z, z.scratch3, spectral)
+    #derivative!(z.scratch3, upar, z, spectral)
+
+    # Use as 'adv_fac' for upwinding
+    @. z.scratch3 = -upar
+    derivative!(z.scratch2, dens, z, z.scratch3, spectral)
+
+    derivative!(z.scratch3, upar, z, z.scratch3, spectral)
+
     # update the parallel momentum density to account for the parallel flux of parallel momentum
-    @. pflx = dens*upar - dt*z.scratch
+    #@. pflx = dens*upar - dt*(z.scratch + z.scratch2)
+    #@. pflx = dens*upar - dt*(z.scratch + upar*z.scratch2 + dens.*upar*z.scratch3)
+    @. pflx = dens*upar - dt*(z.scratch + upar*upar*z.scratch2 + 2.0*dens*upar*z.scratch3)
 end
 
 """

--- a/src/numerical_dissipation.jl
+++ b/src/numerical_dissipation.jl
@@ -16,6 +16,7 @@ Base.@kwdef struct numerical_dissipation_parameters
     vpa_boundary_buffer_diffusion_coefficient::mk_float = -1.0
     vpa_dissipation_coefficient::mk_float = -1.0
     z_dissipation_coefficient::mk_float = -1.0
+    moment_dissipation_coefficient::mk_float = -1.0
     force_minimum_pdf_value::Union{Nothing,mk_float} = nothing
 end
 

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -842,12 +842,8 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     if advance.force_balance
         # fvec_out.upar is over-written in force_balance! and contains the particle flux
-        force_balance!(fvec_out.upar, fvec_in, fields, collisions, vpa, z, r, dt,
-                       z_spectral, composition, num_diss_params)
-        # convert from the particle flux to the parallel flow
-        @loop_s_r_z is ir iz begin
-            fvec_out.upar[iz,ir,is] /= fvec_out.density[iz,ir,is]
-        end
+        force_balance!(fvec_out.upar, fvec_out.density, fvec_in, fields, collisions,
+                       vpa, z, r, dt, z_spectral, composition, num_diss_params)
     end
     if advance.energy
         energy_equation!(fvec_out.ppar, fvec_in, moments, collisions, z,

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -838,12 +838,12 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     if advance.continuity
         continuity_equation!(fvec_out.density, fvec_in, moments, composition, vpa, z, r,
-                             dt, z_spectral, collisions.ionization)
+                             dt, z_spectral, collisions.ionization, num_diss_params)
     end
     if advance.force_balance
         # fvec_out.upar is over-written in force_balance! and contains the particle flux
         force_balance!(fvec_out.upar, fvec_in, fields, collisions, vpa, z, r, dt,
-                       z_spectral, composition)
+                       z_spectral, composition, num_diss_params)
         # convert from the particle flux to the parallel flow
         @loop_s_r_z is ir iz begin
             fvec_out.upar[iz,ir,is] /= fvec_out.density[iz,ir,is]
@@ -851,7 +851,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments, vpa_SL, z_
     end
     if advance.energy
         energy_equation!(fvec_out.ppar, fvec_in, moments, collisions, z,
-                         r, dt, z_spectral, composition)
+                         r, dt, z_spectral, composition, num_diss_params)
     end
     # reset "xx.updated" flags to false since ff has been updated
     # and the corresponding moments have not

--- a/test/nonlinear_sound_wave_tests.jl
+++ b/test/nonlinear_sound_wave_tests.jl
@@ -185,7 +185,8 @@ test_input_chebyshev = merge(test_input_finite_difference,
 test_input_chebyshev_split_1_moment =
     merge(test_input_chebyshev,
           Dict("run_name" => "chebyshev_pseudospectral_split_1_moment",
-               "evolve_moments_density" => true))
+               "evolve_moments_density" => true,
+               "z_nelement" => 4))
 
 test_input_chebyshev_split_2_moments =
     merge(test_input_chebyshev_split_1_moment,


### PR DESCRIPTION
Use upwinding at element boundaries in the moment equations: helps avoid numerical instability in moment-kinetic runs with wall boundary conditions.

Also add an option for adding diffusion (for numerical dissipation) in the moment equations, disabled by default.

Move the conversion from 'particle flux' to 'parallel flow' inside the `force_balance!()` function. This just makes `euler_time_advance!()` look a bit neater.

I wonder if the z-derivatives of moments that appear in the drift kinetic equation for moment-kinetic cases need to use upwinding in a way somehow consistent with the moment equations. I'm still testing whether this makes any significant difference...