### PR TITLE
Ionization fixes

### DIFF
--- a/examples/wall-bc/wall-bc_cheb_split1.toml
+++ b/examples/wall-bc/wall-bc_cheb_split1.toml
@@ -1,11 +1,12 @@
 n_ion_species = 1
 n_neutral_species = 1
 boltzmann_electron_response = true
-run_name = "wall-bc_cheb"
-evolve_moments_density = false
+run_name = "wall-bc_cheb_split1"
+#runtime_plots = true
+evolve_moments_density = true
 evolve_moments_parallel_flow = false
 evolve_moments_parallel_pressure = false
-evolve_moments_conservation = false
+evolve_moments_conservation = true
 T_e = 1.0
 T_wall = 1.0
 initial_density1 = 1.0

--- a/examples/wall-bc/wall-bc_cheb_split2.toml
+++ b/examples/wall-bc/wall-bc_cheb_split2.toml
@@ -1,11 +1,12 @@
 n_ion_species = 1
 n_neutral_species = 1
 boltzmann_electron_response = true
-run_name = "wall-bc_cheb"
-evolve_moments_density = false
-evolve_moments_parallel_flow = false
+run_name = "wall-bc_cheb_split2"
+#runtime_plots = true
+evolve_moments_density = true
+evolve_moments_parallel_flow = true
 evolve_moments_parallel_pressure = false
-evolve_moments_conservation = false
+evolve_moments_conservation = true
 T_e = 1.0
 T_wall = 1.0
 initial_density1 = 1.0

--- a/examples/wall-bc/wall-bc_cheb_split3.toml
+++ b/examples/wall-bc/wall-bc_cheb_split3.toml
@@ -1,11 +1,12 @@
 n_ion_species = 1
 n_neutral_species = 1
 boltzmann_electron_response = true
-run_name = "wall-bc_cheb"
-evolve_moments_density = false
-evolve_moments_parallel_flow = false
-evolve_moments_parallel_pressure = false
-evolve_moments_conservation = false
+run_name = "wall-bc_cheb_split3"
+#runtime_plots = true
+evolve_moments_density = true
+evolve_moments_parallel_flow = true
+evolve_moments_parallel_pressure = true
+evolve_moments_conservation = true
 T_e = 1.0
 T_wall = 1.0
 initial_density1 = 1.0

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -124,7 +124,7 @@ function ionization_collisions_single_species!(f_out, fvec_in, moments, vpa, vpa
                 # to get f_{s'}(wpa_s), need to obtain wpa_s grid locations
                 # in terms of the wpa_{s'} coordinate:
                 # (wpa_s)_j = (wpa_{s'})_j + upar_{s'} - upar_{s}
-                @. vpa.scratch = vpa.grid + fvec_in.upar[iz,ir,isp] - fvec_in.upar[iz,ir,is]
+                @. vpa.scratch = vpa.grid + fvec_in.upar[iz,ir,is] - fvec_in.upar[iz,ir,isp]
             else
                 # if evolve_ppar = true and evolve_upar = true, vpa coordinate is
                 # wpahat_s = (vpa-upar_s)/vth_s;

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -25,17 +25,17 @@ function ionization_collisions!(f_out, fvec_in, moments, n_ion_species,
             if is ∈ composition.ion_species_range
                 @loop_r_z ir iz begin
                     if moments.evolve_ppar && moments.evolve_upar
-                        @. vpa.scratch = vpa.grid / moments.vth[iz] + moments.upar[iz] 
-                        prefactor = moments.vth[iz] / moments.dens[iz]
+                        @. vpa.scratch = vpa.grid / moments.vth[iz] + fvec_in.upar[iz]
+                        prefactor = moments.vth[iz] / fvec_in.dens[iz]
                     elseif moments.evolve_ppar
                         @. vpa.scratch = vpa.grid / moments.vth[iz]
-                        prefactor = moments.vth[iz] / moments.dens[iz]
+                        prefactor = moments.vth[iz] / fvec_in.dens[iz]
                     elseif moments.evolve_upar
-                        @. vpa.scratch = vpa.grid + moments.upar[iz]
-                        prefactor = 1.0 / moments.dens[iz]
+                        @. vpa.scratch = vpa.grid + fvec_in.upar[iz]
+                        prefactor = 1.0 / fvec_in.dens[iz]
                     elseif moments.evolve_density
                         @. vpa.scratch = vpa.grid
-                        prefactor = 1.0 / moments.dens[iz]
+                        prefactor = 1.0 / fvec_in.dens[iz]
                     else
                         @. vpa.scratch = vpa.grid
                         prefactor = 1.0

--- a/src/vpa_advection.jl
+++ b/src/vpa_advection.jl
@@ -213,10 +213,10 @@ function update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r, c
             # update parallel acceleration to account for vpahat*(upar/vth-vpahat) * d(vth)/dz term
             @loop_z iz begin
                 @views @. advect[is].speed[:,iz,ir] += vpa.grid*z.scratch[iz] *
-                                                    (moments.upar[iz,ir,is]/moments.vth[iz,ir,is] - vpa.grid)
+                                                    (fvec.upar[iz,ir,is]/moments.vth[iz,ir,is] - vpa.grid)
             end
             # calculate d(upar)/dz
-            derivative!(z.scratch, view(moments.upar,:,ir,is), z, z_spectral)
+            derivative!(z.scratch, view(fvec.upar,:,ir,is), z, z_spectral)
             # update parallel acceleration to account for vpahat*d(upar)/dz
             @loop_z iz begin
                 @views @. advect[is].speed[:,iz,ir] += vpa.grid*z.scratch[iz]

--- a/src/vpa_advection.jl
+++ b/src/vpa_advection.jl
@@ -165,26 +165,51 @@ function update_speed_n_u_p_evolution!(advect, fvec, moments, vpa, z, r, composi
             end
         end
     end
-    # add in contributions from charge exchange collisions
-    if composition.n_neutral_species > 0 && abs(collisions.charge_exchange) > 0.0
+    # add in contributions from charge exchange and ionization collisions
+    if composition.n_neutral_species > 0 &&
+            abs(collisions.charge_exchange) > 0.0 || abs(collisions.ionization) > 0.0
+
         @loop_s is begin
             if is ∈ composition.ion_species_range
                 for isp ∈ composition.neutral_species_range
                     @loop_r_z ir iz begin
-                        @views @. advect[is].speed[:,iz,ir] += collisions.charge_exchange *
-                        (0.5*vpa.grid/fvec.ppar[iz,ir,is] * (fvec.density[iz,ir,isp]*fvec.ppar[iz,ir,is]
-                                                          - fvec.density[iz,ir,is]*fvec.ppar[iz,ir,isp])
-                         - fvec.density[iz,ir,isp] * (fvec.upar[iz,ir,isp]-fvec.upar[iz,ir,is])/moments.vth[iz,ir,is])
+                        @views @. advect[is].speed[:,iz,ir] +=
+                            collisions.charge_exchange *
+                            (0.5*vpa.grid/fvec.ppar[iz,ir,is]
+                             * (fvec.density[iz,ir,isp]*fvec.ppar[iz,ir,is]
+                                - fvec.density[iz,ir,is]*fvec.ppar[iz,ir,isp]
+                                - fvec.density[iz,ir,is]*fvec.density[iz,ir,isp]
+                                  * (fvec.upar[iz,ir,is]-fvec.upar[iz,ir,isp])^2)
+                             - fvec.density[iz,ir,isp]
+                               * (fvec.upar[iz,ir,isp]-fvec.upar[iz,ir,is])
+                               / moments.vth[iz,ir,is]) +
+                            collisions.ionization *
+                            (0.5*vpa.grid
+                               * (fvec.density[iz,ir,isp]
+                                  - fvec.density[iz,ir,is]*fvec.ppar[iz,ir,isp]
+                                    / fvec.ppar[iz,ir,is]
+                                  - fvec.density[iz,ir,is]*fvec.density[iz,ir,isp]
+                                    * (fvec.upar[iz,ir,isp] - fvec.upar[iz,ir,is])^2
+                                    / fvec.ppar[iz,ir,is])
+                             - fvec.density[iz,ir,isp]
+                               * (fvec.upar[iz,ir,isp] - fvec.upar[iz,ir,is])
+                               / moments.vth[iz,ir,is])
                     end
                 end
             end
             if is ∈ composition.neutral_species_range
                 for isp ∈ composition.ion_species_range
                     @loop_r_z ir iz begin
-                        @views @. advect[is].speed[:,iz,ir] += collisions.charge_exchange *
-                        (0.5*vpa.grid/fvec.ppar[iz,ir,is] * (fvec.density[iz,ir,isp]*fvec.ppar[iz,ir,is]
-                                                          - fvec.density[iz,ir,is]*fvec.ppar[iz,ir,isp])
-                         - fvec.density[iz,ir,isp] * (fvec.upar[iz,ir,isp]-fvec.upar[iz,ir,is])/moments.vth[iz,ir,is])
+                        @views @. advect[is].speed[:,iz,ir] +=
+                            collisions.charge_exchange *
+                            (0.5*vpa.grid/fvec.ppar[iz,ir,is]
+                             * (fvec.density[iz,ir,isp]*fvec.ppar[iz,ir,is]
+                                - fvec.density[iz,ir,is]*fvec.ppar[iz,ir,isp]
+                                - fvec.density[iz,ir,is]*fvec.density[iz,ir,isp]
+                                  * (fvec.upar[iz,ir,is]-fvec.upar[iz,ir,isp])^2)
+                             - fvec.density[iz,ir,isp]
+                               * (fvec.upar[iz,ir,isp]-fvec.upar[iz,ir,is])
+                               / moments.vth[iz,ir,is])
                     end
                 end
             end
@@ -237,6 +262,9 @@ function update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r, c
     end
     # add in contributions from charge exchange and ionization collisions
     if composition.n_neutral_species > 0
+        error("suspect the charge exchange and ionization contributions here may be "
+              * "wrong because (upar[is]-upar[isp])^2 type terms were missed in the "
+              * "energy equation when it was substituted in to derive them.")
         @loop_s is begin
             if is ∈ composition.ion_species_range && abs(collisions.charge_exchange + collisions.ionization) > 0.0
                 for isp ∈ composition.neutral_species_range


### PR DESCRIPTION
* `ionization_collisions!()` uses `fvec.dens` and `fvec.upar` instead of `moments.dens` and `moments.upar` as the `moments` versions are only updated at the end of the full timestep, not at each RK stage.
* fix index error in interpolation for evolving_upar case in `ionization_collisions!()`
* add missing contributions like (u[s]-u[s'])^2 to ionization terms in energy equation, and in places where energy equation contributes to `vpa_advection!()` and `source_terms!()`.

With these fixes, I have a 'full moment-kinetic' case (evolving density, upar and ppar) with wall boundary conditions that runs and agrees pretty well with the 'full-f' and 'evolving upar' cases!