### PR TITLE
Fix some MPI errors

### DIFF
--- a/src/communication.jl
+++ b/src/communication.jl
@@ -12,8 +12,8 @@ loop ranges), as at the moment we only run with 1 ion species and 1 neutral spec
 """
 module communication
 
-export allocate_shared, block_rank, block_size, comm_block,
-       comm_world, finalize_comms!, initialize_comms!, global_rank, MPISharedArray
+export allocate_shared, block_rank, block_size, comm_block, comm_world, finalize_comms!,
+       initialize_comms!, global_rank, global_size, MPISharedArray
 
 using MPI
 using SHA

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -507,27 +507,27 @@ function write_data_to_binary(ff, ff_neutral, moments, fields, t, n_ion_species,
         # add the time for this time slice to the netcdf file
         cdf.time[t_idx] = t
         # add the distribution function data at this time slice to the netcdf file
-        cdf.f[:,:,:,:,:,t_idx] = ff
+        cdf.f[:,:,:,:,:,t_idx] .= ff
         # add the electrostatic potential data at this time slice to the netcdf file
-        cdf.phi[:,:,t_idx] = fields.phi
-        cdf.Er[:,:,t_idx] = fields.Er
-        cdf.Ez[:,:,t_idx] = fields.Ez
+        cdf.phi[:,:,t_idx] .= fields.phi
+        cdf.Er[:,:,t_idx] .= fields.Er
+        cdf.Ez[:,:,t_idx] .= fields.Ez
         # add the density data at this time slice to the netcdf file
         for is ∈ 1:n_ion_species
-            cdf.density[:,:,:,t_idx] = moments.charged.dens
-            cdf.parallel_flow[:,:,:,t_idx] = moments.charged.upar
-            cdf.parallel_pressure[:,:,:,t_idx] = moments.charged.ppar
-            cdf.parallel_heat_flux[:,:,:,t_idx] = moments.charged.qpar
-            cdf.thermal_speed[:,:,:,t_idx] = moments.charged.vth
+            cdf.density[:,:,:,t_idx] .= moments.charged.dens
+            cdf.parallel_flow[:,:,:,t_idx] .= moments.charged.upar
+            cdf.parallel_pressure[:,:,:,t_idx] .= moments.charged.ppar
+            cdf.parallel_heat_flux[:,:,:,t_idx] .= moments.charged.qpar
+            cdf.thermal_speed[:,:,:,t_idx] .= moments.charged.vth
         end
         if n_neutral_species > 0
-            cdf.f_neutral[:,:,:,:,:,:,t_idx] = ff_neutral
+            cdf.f_neutral[:,:,:,:,:,:,t_idx] .= ff_neutral
             for is ∈ 1:n_neutral_species
-                cdf.density_neutral[:,:,:,t_idx] = moments.neutral.dens
-                cdf.uz_neutral[:,:,:,t_idx] = moments.neutral.uz
-                cdf.pz_neutral[:,:,:,t_idx] = moments.neutral.pz
-                cdf.qz_neutral[:,:,:,t_idx] = moments.neutral.qz
-                cdf.thermal_speed_neutral[:,:,:,t_idx] = moments.neutral.vth
+                cdf.density_neutral[:,:,:,t_idx] .= moments.neutral.dens
+                cdf.uz_neutral[:,:,:,t_idx] .= moments.neutral.uz
+                cdf.pz_neutral[:,:,:,t_idx] .= moments.neutral.pz
+                cdf.qz_neutral[:,:,:,t_idx] .= moments.neutral.qz
+                cdf.thermal_speed_neutral[:,:,:,t_idx] .= moments.neutral.vth
             end
         end
     end

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -259,62 +259,66 @@ end
 
 function init_knudsen_cosine(vz, vr, vzeta, vpa, vperp, composition)
     knudsen_cosine = allocate_shared_float(vz.n, vr.n, vzeta.n)
-    integrand = zeros(mk_float, vz.n, vr.n, vzeta.n)
-    
-    vtfac = sqrt(composition.T_wall * composition.mn_over_mi)
-    
-    if vzeta.n > 1 && vr.n > 1
-        # 3V specification of neutral wall emission distribution for boundary condition 
-        if composition.use_test_neutral_wall_pdf
-        # use test distribution that is easy for integration scheme to handle
-            for ivzeta in 1:vzeta.n
-                for ivr in 1:vr.n
-                    for ivz in 1:vz.n
-                        v_transverse = sqrt(vzeta.grid[ivzeta]^2 + vr.grid[ivr]^2)
-                        v_normal = abs(vz.grid[ivz])                    
-                        knudsen_cosine[ivz,ivr,ivzeta] = (4.0/vtfac^5)*v_normal*exp( - (v_normal/vtfac)^2 - (v_transverse/vtfac)^2 )
-                        integrand[ivz,ivr,ivzeta] = vz.grid[ivz]*knudsen_cosine[ivz,ivr,ivzeta]
-                    end
-                end
-            end
-        else # get the true Knudsen cosine distribution for neutral particle wall emission
-            for ivzeta in 1:vzeta.n
-                for ivr in 1:vr.n
-                    for ivz in 1:vz.n
-                        v_transverse = sqrt(vzeta.grid[ivzeta]^2 + vr.grid[ivr]^2)
-                        v_normal = abs(vz.grid[ivz])
-                        v_tot = sqrt(v_normal^2 + v_transverse^2)
-                        if  v_tot > 0.0
-                            prefac = v_normal/v_tot 
-                        else
-                            prefac = 0.0
-                        end 
-                        knudsen_cosine[ivz,ivr,ivzeta] = (3.0*sqrt(pi)/vtfac^4)*prefac*exp( - (v_normal/vtfac)^2 - (v_transverse/vtfac)^2 )
-                        integrand[ivz,ivr,ivzeta] = vz.grid[ivz]*knudsen_cosine[ivz,ivr,ivzeta]
-                    end
-                end
-            end
-        end 
-        normalisation = integrate_over_positive_vz(integrand, vz.grid, vz.wgts,
-                                                    vz.scratch, vr.grid, vr.wgts, vzeta.grid, vzeta.wgts)
-        # uncomment this line to test:
-        #println("normalisation should be 1, it is = ", normalisation)
-        #correct knudsen_cosine to conserve particle fluxes numerically
-        @. knudsen_cosine /= normalisation 
 
-    elseif vzeta.n == 1 && vr.n == 1
-        # get the marginalised Knudsen cosine distribution after integrating over vperp
-        # appropriate for 1V model 
-        @. vz.scratch = (3.0*pi/vtfac^3)*abs(vz.grid)*erfc(abs(vz.grid)/vtfac)
-        normalisation = integrate_over_positive_vz(vz.grid .* vz.scratch, vz.grid, vz.wgts, vz.scratch2, 
-                                                     vr.grid, vr.wgts, vzeta.grid, vzeta.wgts)
-        # uncomment this line to test:
-        #println("normalisation should be 1, it is = ", normalisation)
-        #correct knudsen_cosine to conserve particle fluxes numerically
-        @. vz.scratch /= normalisation
-        @. knudsen_cosine[:,1,1] = vz.scratch[:]        
-                
-    end    
+    begin_serial_region()
+    @serial_region begin
+        integrand = zeros(mk_float, vz.n, vr.n, vzeta.n)
+
+        vtfac = sqrt(composition.T_wall * composition.mn_over_mi)
+
+        if vzeta.n > 1 && vr.n > 1
+            # 3V specification of neutral wall emission distribution for boundary condition
+            if composition.use_test_neutral_wall_pdf
+                # use test distribution that is easy for integration scheme to handle
+                for ivzeta in 1:vzeta.n
+                    for ivr in 1:vr.n
+                        for ivz in 1:vz.n
+                            v_transverse = sqrt(vzeta.grid[ivzeta]^2 + vr.grid[ivr]^2)
+                            v_normal = abs(vz.grid[ivz])
+                            knudsen_cosine[ivz,ivr,ivzeta] = (4.0/vtfac^5)*v_normal*exp( - (v_normal/vtfac)^2 - (v_transverse/vtfac)^2 )
+                            integrand[ivz,ivr,ivzeta] = vz.grid[ivz]*knudsen_cosine[ivz,ivr,ivzeta]
+                        end
+                    end
+                end
+            else # get the true Knudsen cosine distribution for neutral particle wall emission
+                for ivzeta in 1:vzeta.n
+                    for ivr in 1:vr.n
+                        for ivz in 1:vz.n
+                            v_transverse = sqrt(vzeta.grid[ivzeta]^2 + vr.grid[ivr]^2)
+                            v_normal = abs(vz.grid[ivz])
+                            v_tot = sqrt(v_normal^2 + v_transverse^2)
+                            if  v_tot > 0.0
+                                prefac = v_normal/v_tot
+                            else
+                                prefac = 0.0
+                            end
+                            knudsen_cosine[ivz,ivr,ivzeta] = (3.0*sqrt(pi)/vtfac^4)*prefac*exp( - (v_normal/vtfac)^2 - (v_transverse/vtfac)^2 )
+                            integrand[ivz,ivr,ivzeta] = vz.grid[ivz]*knudsen_cosine[ivz,ivr,ivzeta]
+                        end
+                    end
+                end
+            end
+            normalisation = integrate_over_positive_vz(integrand, vz.grid, vz.wgts,
+                                                       vz.scratch, vr.grid, vr.wgts, vzeta.grid, vzeta.wgts)
+            # uncomment this line to test:
+            #println("normalisation should be 1, it is = ", normalisation)
+            #correct knudsen_cosine to conserve particle fluxes numerically
+            @. knudsen_cosine /= normalisation
+
+        elseif vzeta.n == 1 && vr.n == 1
+            # get the marginalised Knudsen cosine distribution after integrating over vperp
+            # appropriate for 1V model
+            @. vz.scratch = (3.0*pi/vtfac^3)*abs(vz.grid)*erfc(abs(vz.grid)/vtfac)
+            normalisation = integrate_over_positive_vz(vz.grid .* vz.scratch, vz.grid, vz.wgts, vz.scratch2,
+                                                       vr.grid, vr.wgts, vzeta.grid, vzeta.wgts)
+            # uncomment this line to test:
+            #println("normalisation should be 1, it is = ", normalisation)
+            #correct knudsen_cosine to conserve particle fluxes numerically
+            @. vz.scratch /= normalisation
+            @. knudsen_cosine[:,1,1] = vz.scratch[:]
+
+        end
+    end
     return knudsen_cosine
 end 
 

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -103,6 +103,7 @@ function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
         # throws an error
         if global_size[] > 1
             println(e)
+            display(stacktrace(catch_backtrace()))
             MPI.Abort(comm_world, 1)
         end
 

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -79,19 +79,16 @@ function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
         # set up all the structs, etc. needed for a run
         mk_state = setup_moment_kinetics(input_dict)
 
-        try
-            # solve the 1+1D kinetic equation to advance f in time by nstep time steps
-            if run_type == performance_test
-                @timeit to "time_advance" time_advance!(mk_state...)
-            else
-                time_advance!(mk_state...)
-            end
-        finally
-
-            # clean up i/o and communications
-            # last 2 elements of mk_state are `io` and `cdf`
-            cleanup_moment_kinetics!(mk_state[end-1:end]...)
+        # solve the 1+1D kinetic equation to advance f in time by nstep time steps
+        if run_type == performance_test
+            @timeit to "time_advance" time_advance!(mk_state...)
+        else
+            time_advance!(mk_state...)
         end
+
+        # clean up i/o and communications
+        # last 2 elements of mk_state are `io` and `cdf`
+        cleanup_moment_kinetics!(mk_state[end-1:end]...)
 
         if block_rank[] == 0 && run_type == performance_test
             # Print the timing information if this is a performance test
@@ -105,6 +102,10 @@ function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
             println(e)
             display(stacktrace(catch_backtrace()))
             MPI.Abort(comm_world, 1)
+        else
+            # Error almost certainly occured before cleanup. If running in serial we can
+            # still finalise file I/O
+            cleanup_moment_kinetics!(mk_state[end-1:end]...)
         end
 
         rethrow(e)

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -99,7 +99,8 @@ function run_moment_kinetics(to::TimerOutput, input_dict=Dict())
         # Stop code from hanging when running on multiple processes if only one of them
         # throws an error
         if global_size[] > 1
-            println(e)
+            println("$(typeof(e)) on process $(global_rank[]):")
+            println(e.msg, "\n")
             display(stacktrace(catch_backtrace()))
             MPI.Abort(comm_world, 1)
         else


### PR DESCRIPTION
Fix #86:
* The export of `global_size` from the `communication` module was missing, which caused an undefined-variable error in the `catch`-block here https://github.com/mabarnes/moment_kinetics/blob/7975a26ce44f790f2c53e44f34a5ba079c347e74/src/moment_kinetics.jl#L101-L110 that prevented `MPI.Abort()` from being called.
* `MPI.free()` is a collective call, and previously there was a `try...finally...` that tried to call `cleanup_moment_kinetics!()` (which calls `MPI.free()`) on any error. When running on multiple processes, this meant the code would hang if an error occured on some processes and not on others. Removing the `try...finally...` allows errors to trigger `MPI.Abort()` as intended.

Fix inconsistency of some errors reported in #85
* Shared-memory bug, need to use `@serial_region` in `init_knudsen_cosine()`.

Copy fix from 1D1V branch for error in file I/O when using DebugMPISharedArray for debugging.

Nicer printing of caught errors before calling `MPI.Abort()` - may help to diagnose the origin of the errors.