### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Michael Barnes and contributors to the moment_kinetics project
+Copyright (c) Michael Barnes, John Omotani, Michael Hardman and contributors to the moment_kinetics project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It would be good to add an explicit license for the project. MIT is used by Julia itself, and many Julia projects. I've tried to follow the advice on writing the copyright notice here https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects.