### PR TITLE
Parallel I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,23 @@ this can be suppressed by setting
     export QT_QPA_PLATFORM=offscreen
     ```
 in your `.bashrc` or `.bash_profile` files. 
-    
+
+## Parallel I/O
+
+Note that to enable parallel I/O, you need to get HDF5.jl to use the system
+HDF5 library (which must be MPI-enabled and compiled using the same MPI as you
+run Julia with). To do this (see [the HDF5.jl
+docs](https://juliaio.github.io/HDF5.jl/stable/#Using-custom-or-system-provided-HDF5-binaries))
+run (with the `moment_kinetics` project activated in Julia)
+```
+julia> ENV["JULIA_HDF5_PATH"] = "/path/to/your/hdf5/directory"; using Pkg(); Pkg.build()
+```
+JTO also found that (on a Linux laptop) it was necessary to compile HDF5 from
+source. The system-provided, MPI-linked libhdf5 depended on libcurl, and Julia
+links to an incompatible libcurl, causing an error. When compiled from source
+(enabling MPI!), HDF5 does not require libcurl (guess it is an optional
+dependency), avoiding the problem.
+
 ## Running parameter scans
 Parameter scans can be run, and can (optionally) use multiple processors. Short summary of implementation and usage:
 1) `mk_input()` takes a Dict argument, which can modify values. So `mk_input()` sets the 'defaults' (for a scan), which are overridden by any key/value pairs in the Dict.

--- a/src/coordinates.jl
+++ b/src/coordinates.jl
@@ -86,7 +86,7 @@ create arrays associated with a given coordinate,
 setup the coordinate grid, and populate the coordinate structure
 containing all of this information
 """
-function define_coordinate(input, composition=nothing)
+function define_coordinate(input)
     # total number of grid points is ngrid for the first element
     # plus ngrid-1 unique points for each additional element due
     # to the repetition of a point at the element boundary

--- a/src/coordinates.jl
+++ b/src/coordinates.jl
@@ -90,11 +90,11 @@ function define_coordinate(input, composition=nothing)
     # to the repetition of a point at the element boundary
     n_global = (input.ngrid-1)*input.nelement_global + 1
     # local number of points on this process
-	n_local = (input.ngrid-1)*input.nelement_local + 1
-	# obtain index mapping from full (local) grid to the
+    n_local = (input.ngrid-1)*input.nelement_local + 1
+    # obtain index mapping from full (local) grid to the
     # grid within each element (igrid, ielement)
     igrid, ielement = full_to_elemental_grid_map(input.ngrid,
-    	input.nelement_local, n_local)
+        input.nelement_local, n_local)
     # obtain (local) index mapping from the grid within each element
     # to the full grid
     imin, imax = elemental_to_full_grid_map(input.ngrid, input.nelement_local)
@@ -114,13 +114,13 @@ function define_coordinate(input, composition=nothing)
     scratch_2d = allocate_float(input.ngrid, input.nelement_local)
     # struct containing the advection speed options/inputs for this coordinate
     advection = input.advection
-	send_buffer = allocate_float(1)
-	receive_buffer = allocate_float(1)
-    # buffer for cyclic communication of boundary points
-    # each chain of elements has only two external (off-rank) 
-	#endpoints, so only two pieces of information must be shared
-	return coordinate(input.name, n_global, n_local, input.ngrid, 
-	    input.nelement_global, input.nelement_local, input.nrank, input.irank, input.L, grid,
+    # buffers for cyclic communication of boundary points
+    # each chain of elements has only two external (off-rank)
+    # endpoints, so only two pieces of information must be shared
+    send_buffer = allocate_float(1)
+    receive_buffer = allocate_float(1)
+    return coordinate(input.name, n_global, n_local, input.ngrid,
+        input.nelement_global, input.nelement_local, input.nrank, input.irank, input.L, grid,
         cell_width, igrid, ielement, imin, imax, input.discretization, input.fd_option,
         input.bc, wgts, uniform_grid, duniform_dgrid, scratch, copy(scratch), copy(scratch),
         scratch_2d, copy(scratch_2d), advection, send_buffer, receive_buffer, input.comm)

--- a/src/coordinates.jl
+++ b/src/coordinates.jl
@@ -11,6 +11,8 @@ using ..chebyshev: scaled_chebyshev_grid
 using ..quadrature: composite_simpson_weights
 using ..input_structs: advection_input
 
+using MPI
+
 """
 structure containing basic information related to coordinates
 """
@@ -71,12 +73,12 @@ struct coordinate
     scratch2_2d::Array{mk_float,2}
     # struct containing advection speed options/inputs
     advection::advection_input
-	# buffer of size 1 for communicating information about cell boundaries
-	send_buffer::Array{mk_float,1}
-	# buffer of size 1 for communicating information about cell boundaries
-	receive_buffer::Array{mk_float,1}
-	# the MPI communicator appropriate for this calculation
-	comm::T where T
+    # buffer of size 1 for communicating information about cell boundaries
+    send_buffer::Array{mk_float,1}
+    # buffer of size 1 for communicating information about cell boundaries
+    receive_buffer::Array{mk_float,1}
+    # the MPI communicator appropriate for this calculation
+    comm::MPI.Comm
 end
 
 """

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -89,6 +89,15 @@ struct io_dfns_info{Tfile, Ttime, Tfi, Tfn}
 end
 
 """
+    io_has_parallel(Val(binary_format))
+
+Test if the backend supports parallel I/O.
+
+`binary_format` should be one of the values of the `binary_format_type` enum
+"""
+function io_has_parallel() end
+
+"""
 open the necessary output files
 """
 function setup_file_io(io_input, vz, vr, vzeta, vpa, vperp, z, r, composition, collisions)

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -96,10 +96,10 @@ function setup_file_io(io_input, vz, vr, vzeta, vpa, vperp, z, r, composition, c
         out_prefix = string(io_input.output_dir, "/", io_input.run_name, ".", iblock_index[])
 
         if io_input.ascii_output
-            #ff_io = open_output_file(out_prefix, "f_vs_t")
-            mom_chrg_io = open_output_file(out_prefix, "moments_charged_vs_t")
-            mom_ntrl_io = open_output_file(out_prefix, "moments_neutral_vs_t")
-            fields_io = open_output_file(out_prefix, "fields_vs_t")
+            #ff_io = open_ascii_output_file(out_prefix, "f_vs_t")
+            mom_chrg_io = open_ascii_output_file(out_prefix, "moments_charged_vs_t")
+            mom_ntrl_io = open_ascii_output_file(out_prefix, "moments_neutral_vs_t")
+            fields_io = open_ascii_output_file(out_prefix, "fields_vs_t")
             ascii = ascii_ios(mom_chrg_io, mom_ntrl_io, fields_io)
         else
             ascii = ascii_ios(nothing, nothing, nothing)

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -255,10 +255,19 @@ function define_io_coordinate!(parent, coord, coord_name, description, parallel_
         # create the "group" sub-group of "parent" that will contain coord_str coordinate info
         group = create_io_group(parent, coord_name, description=description)
 
-        # write the number of local grid points for this coordinate to variable "n_local"
-        # within "coords/coord_name" group
-        write_single_value!(group, "n_local", coord.n; parallel_io=parallel_io,
-                            description="number of local $coord_name grid points")
+        if parallel_io
+            # When using parallel I/O, write n_global as n_local because the file is as if
+            # it had been produced by a serial run.
+            # This is a bit of a hack and should probably be removed when
+            # post_processing.jl is updated to be compatible with that.
+            write_single_value!(group, "n_local", coord.n_global; parallel_io=parallel_io,
+                                description="number of local $coord_name grid points")
+        else
+            # write the number of local grid points for this coordinate to variable
+            # "n_local" within "coords/coord_name" group
+            write_single_value!(group, "n_local", coord.n; parallel_io=parallel_io,
+                                description="number of local $coord_name grid points")
+        end
 
         # write the number of global grid points for this coordinate to variable "n_local"
         # within "coords/coord_name" group

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -152,10 +152,10 @@ function define_spatial_coordinates!(fid, z, r)
     coords = create_io_group(fid, "coords")
     # create the "z" sub-group of "coords" that will contain z coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, z, "z", "spatial coordinate z")
+    define_io_coordinate!(coords, z, "z", "spatial coordinate z")
     # create the "r" sub-group of "coords" that will contain r coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, r, "r", "spatial coordinate r")
+    define_io_coordinate!(coords, r, "r", "spatial coordinate r")
 
     # Write variable recording the index of the block within the global domain
     # decomposition
@@ -176,19 +176,19 @@ Add to coords group in output file information about vspace coordinate grids
 function add_vspace_coordinates!(coords, vz, vr, vzeta, vpa, vperp)
     # create the "vz" sub-group of "coords" that will contain vz coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, vz, "vz", "velocity coordinate v_z")
+    define_io_coordinate!(coords, vz, "vz", "velocity coordinate v_z")
     # create the "vr" sub-group of "coords" that will contain vr coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, vr, "vr", "velocity coordinate v_r")
+    define_io_coordinate!(coords, vr, "vr", "velocity coordinate v_r")
     # create the "vzeta" sub-group of "coords" that will contain vzeta coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, vzeta, "vzeta", "velocity coordinate v_zeta")
+    define_io_coordinate!(coords, vzeta, "vzeta", "velocity coordinate v_zeta")
     # create the "vpa" sub-group of "coords" that will contain vpa coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, vpa, "vpa", "velocity coordinate v_parallel")
+    define_io_coordinate!(coords, vpa, "vpa", "velocity coordinate v_parallel")
     # create the "vperp" sub-group of "coords" that will contain vperp coordinate info,
     # including total number of grid points and grid point locations
-    define_coordinate!(coords, vperp, "vperp", "velocity coordinate v_perp")
+    define_io_coordinate!(coords, vperp, "vperp", "velocity coordinate v_perp")
 
     return nothing
 end
@@ -196,7 +196,7 @@ end
 """
 define a sub-group for each code coordinate and write to output file
 """
-function define_coordinate!(parent, coord, coord_name, description)
+function define_io_coordinate!(parent, coord, coord_name, description)
     # create the "group" sub-group of "parent" that will contain coord_str coordinate info
     group = create_io_group(parent, coord_name, description=description)
 

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -8,7 +8,7 @@ export setup_file_io, finish_file_io
 export write_data_to_ascii
 export write_data_to_netcdf, write_data_to_hdf5
 
-using ..communication: _block_synchronize, iblock_index, block_size, global_size
+using ..communication
 using ..coordinates: coordinate
 using ..debugging
 using ..input_structs
@@ -108,7 +108,11 @@ function setup_file_io(io_input, vz, vr, vzeta, vpa, vperp, z, r, composition, c
         # check to see if output_dir exists in the current directory
         # if not, create it
         isdir(io_input.output_dir) || mkdir(io_input.output_dir)
-        out_prefix = string(io_input.output_dir, "/", io_input.run_name, ".", iblock_index[])
+        if io_input.parallel_io
+            out_prefix = string(io_input.output_dir, "/", io_input.run_name)
+        else
+            out_prefix = string(io_input.output_dir, "/", io_input.run_name, ".", iblock_index[])
+        end
 
         if io_input.ascii_output
             #ff_io = open_ascii_output_file(out_prefix, "f_vs_t")
@@ -121,10 +125,11 @@ function setup_file_io(io_input, vz, vr, vzeta, vpa, vperp, z, r, composition, c
         end
 
         io_moments = setup_moments_io(out_prefix, io_input.binary_format, r, z,
-                                      composition, collisions, io_input.parallel_io)
+                                      composition, collisions, io_input.parallel_io,
+                                      comm_inter_block[])
         io_dfns = setup_dfns_io(out_prefix, io_input.binary_format, r, z, vperp, vpa,
                                 vzeta, vr, vz, composition, collisions,
-                                io_input.parallel_io)
+                                io_input.parallel_io, comm_inter_block[])
 
         return ascii, io_moments, io_dfns
     end
@@ -143,20 +148,27 @@ function write_single_value!() end
 """
 write some overview information for the simulation to the binary file
 """
-function write_overview!(fid, composition, collisions)
-    overview = create_io_group(fid, "overview")
-    write_single_value!(overview, "nspecies", composition.n_species,
-                        description="total number of evolved plasma species")
-    write_single_value!(overview, "n_ion_species", composition.n_ion_species,
-                        description="number of evolved ion species")
-    write_single_value!(overview, "n_neutral_species", composition.n_neutral_species,
-                        description="number of evolved neutral species")
-    write_single_value!(overview, "T_e", composition.T_e,
-                        description="fixed electron temperature")
-    write_single_value!(overview, "charge_exchange_frequency", collisions.charge_exchange,
-                        description="quantity related to the charge exchange frequency")
-    write_single_value!(overview, "ionization_frequency", collisions.ionization,
-                        description="quantity related to the ionization frequency")
+function write_overview!(fid, composition, collisions, parallel_io)
+    @serial_region begin
+        overview = create_io_group(fid, "overview")
+        write_single_value!(overview, "nspecies", composition.n_species,
+                            parallel_io=parallel_io,
+                            description="total number of evolved plasma species")
+        write_single_value!(overview, "n_ion_species", composition.n_ion_species,
+                            parallel_io=parallel_io,
+                            description="number of evolved ion species")
+        write_single_value!(overview, "n_neutral_species", composition.n_neutral_species,
+                            parallel_io=parallel_io,
+                            description="number of evolved neutral species")
+        write_single_value!(overview, "T_e", composition.T_e, parallel_io=parallel_io,
+                            description="fixed electron temperature")
+        write_single_value!(overview, "charge_exchange_frequency",
+                            collisions.charge_exchange, parallel_io=parallel_io,
+                            description="quantity related to the charge exchange frequency")
+        write_single_value!(overview, "ionization_frequency", collisions.ionization,
+                            parallel_io=parallel_io,
+                            description="quantity related to the ionization frequency")
+    end
 end
 
 """
@@ -164,47 +176,73 @@ Define coords group for coordinate information in the output file and write info
 about spatial coordinate grids
 """
 function define_spatial_coordinates!(fid, z, r, parallel_io)
-    # create the "coords" group that will contain coordinate information
-    coords = create_io_group(fid, "coords")
-    # create the "z" sub-group of "coords" that will contain z coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, z, "z", "spatial coordinate z")
-    # create the "r" sub-group of "coords" that will contain r coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, r, "r", "spatial coordinate r")
+    @serial_region begin
+        # create the "coords" group that will contain coordinate information
+        coords = create_io_group(fid, "coords")
+        # create the "z" sub-group of "coords" that will contain z coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, z, "z", "spatial coordinate z", parallel_io)
+        # create the "r" sub-group of "coords" that will contain r coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, r, "r", "spatial coordinate r", parallel_io)
 
-    # Write variable recording the index of the block within the global domain
-    # decomposition
-    write_single_value!(coords, "iblock", iblock_index[],
-                        description="index of this zr block")
+        if parallel_io
+            # Parallel I/O produces a single file, so effectively a 'single block'
 
-    # Write variable recording the total number of blocks in the global domain
-    # decomposition
-    write_single_value!(coords, "nblocks", global_size[]÷block_size[],
-                        description="number of zr blocks")
+            # Write variable recording the index of the block within the global domain
+            # decomposition
+            write_single_value!(coords, "iblock", 0, parallel_io=parallel_io,
+                                description="index of this zr block")
 
-    return coords
+            # Write variable recording the total number of blocks in the global domain
+            # decomposition
+            write_single_value!(coords, "nblocks", 1, parallel_io=parallel_io,
+                                description="number of zr blocks")
+        else
+            # Write a separate file for each block
+
+            # Write variable recording the index of the block within the global domain
+            # decomposition
+            write_single_value!(coords, "iblock", iblock_index[], parallel_io=parallel_io,
+                                description="index of this zr block")
+
+            # Write variable recording the total number of blocks in the global domain
+            # decomposition
+            write_single_value!(coords, "nblocks", global_size[]÷block_size[],
+                                parallel_io=parallel_io, description="number of zr blocks")
+        end
+
+        return coords
+    end
+
+    # For processes other than the root process of each shared-memory group...
+    return nothing
 end
 
 """
 Add to coords group in output file information about vspace coordinate grids
 """
-function add_vspace_coordinates!(coords, vz, vr, vzeta, vpa, vperp)
-    # create the "vz" sub-group of "coords" that will contain vz coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, vz, "vz", "velocity coordinate v_z")
-    # create the "vr" sub-group of "coords" that will contain vr coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, vr, "vr", "velocity coordinate v_r")
-    # create the "vzeta" sub-group of "coords" that will contain vzeta coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, vzeta, "vzeta", "velocity coordinate v_zeta")
-    # create the "vpa" sub-group of "coords" that will contain vpa coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, vpa, "vpa", "velocity coordinate v_parallel")
-    # create the "vperp" sub-group of "coords" that will contain vperp coordinate info,
-    # including total number of grid points and grid point locations
-    define_io_coordinate!(coords, vperp, "vperp", "velocity coordinate v_perp")
+function add_vspace_coordinates!(coords, vz, vr, vzeta, vpa, vperp, parallel_io)
+    @serial_region begin
+        # create the "vz" sub-group of "coords" that will contain vz coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, vz, "vz", "velocity coordinate v_z", parallel_io)
+        # create the "vr" sub-group of "coords" that will contain vr coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, vr, "vr", "velocity coordinate v_r", parallel_io)
+        # create the "vzeta" sub-group of "coords" that will contain vzeta coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, vzeta, "vzeta", "velocity coordinate v_zeta",
+                              parallel_io)
+        # create the "vpa" sub-group of "coords" that will contain vpa coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, vpa, "vpa", "velocity coordinate v_parallel",
+                              parallel_io)
+        # create the "vperp" sub-group of "coords" that will contain vperp coordinate info,
+        # including total number of grid points and grid point locations
+        define_io_coordinate!(coords, vperp, "vperp", "velocity coordinate v_perp",
+                              parallel_io)
+    end
 
     return nothing
 end
@@ -212,38 +250,43 @@ end
 """
 define a sub-group for each code coordinate and write to output file
 """
-function define_io_coordinate!(parent, coord, coord_name, description)
-    # create the "group" sub-group of "parent" that will contain coord_str coordinate info
-    group = create_io_group(parent, coord_name, description=description)
+function define_io_coordinate!(parent, coord, coord_name, description, parallel_io)
+    @serial_region begin
+        # create the "group" sub-group of "parent" that will contain coord_str coordinate info
+        group = create_io_group(parent, coord_name, description=description)
 
-    # write the number of local grid points for this coordinate to variable "n_local"
-    # within "coords/coord_name" group
-    write_single_value!(group, "n_local", coord.n;
-                        description="number of local $coord_name grid points")
+        # write the number of local grid points for this coordinate to variable "n_local"
+        # within "coords/coord_name" group
+        write_single_value!(group, "n_local", coord.n; parallel_io=parallel_io,
+                            description="number of local $coord_name grid points")
 
-    # write the number of global grid points for this coordinate to variable "n_local"
-    # within "coords/coord_name" group
-    write_single_value!(group, "n_global", coord.n_global;
-                        description="total number of $coord_name grid points")
+        # write the number of global grid points for this coordinate to variable "n_local"
+        # within "coords/coord_name" group
+        write_single_value!(group, "n_global", coord.n_global; parallel_io=parallel_io,
+                            description="total number of $coord_name grid points")
 
-    # write the rank in the coord-direction of this process
-    write_single_value!(group, "irank", coord.irank,
-                        description="rank of this block in the $(coord.name) grid communicator")
+        # write the rank in the coord-direction of this process
+        write_single_value!(group, "irank", coord.irank, parallel_io=parallel_io,
+                            description="rank of this block in the $(coord.name) grid communicator")
 
-    # write the global length of this coordinate to variable "L"
-    # within "coords/coord_name" group
-    write_single_value!(group, "L", coord.L;
-                        description="box length in $coord_name")
+        # write the global length of this coordinate to variable "L"
+        # within "coords/coord_name" group
+        write_single_value!(group, "L", coord.L; parallel_io=parallel_io,
+                            description="box length in $coord_name")
 
-    # write the locations of this coordinate's grid points to variable "grid" within "coords/coord_name" group
-    write_single_value!(group, "grid", coord.grid, coord;
-                        description="$coord_name values sampled by the $coord_name grid")
+        # write the locations of this coordinate's grid points to variable "grid" within "coords/coord_name" group
+        write_single_value!(group, "grid", coord.grid, coord; parallel_io=parallel_io,
+                            description="$coord_name values sampled by the $coord_name grid")
 
-    # write the integration weights attached to each coordinate grid point
-    write_single_value!(group, "wgts", coord.wgts, coord;
-                        description="integration weights associated with the $coord_name grid points")
+        # write the integration weights attached to each coordinate grid point
+        write_single_value!(group, "wgts", coord.wgts, coord; parallel_io=parallel_io,
+                            description="integration weights associated with the $coord_name grid points")
 
-    return group
+        return group
+    end
+
+    # For processes other than the root process of each shared-memory group...
+    return nothing
 end
 
 """
@@ -263,87 +306,106 @@ define dynamic (time-evolving) moment variables for writing to the hdf5 file
 """
 function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
                                           r::coordinate, z::coordinate, parallel_io)
-    dynamic = create_io_group(fid, "dynamic_data", description="time evolving variables")
+    @serial_region begin
+        dynamic = create_io_group(fid, "dynamic_data", description="time evolving variables")
 
-    io_time = create_dynamic_variable!(dynamic, "time", mk_float; description="simulation time")
+        io_time = create_dynamic_variable!(dynamic, "time", mk_float; parallel_io=parallel_io,
+                                           description="simulation time")
 
-    # io_phi is the handle referring to the electrostatic potential phi
-    io_phi = create_dynamic_variable!(dynamic, "phi", mk_float, z, r;
-                                      description="electrostatic potential",
-                                      units="T_ref/e")
-    # io_Er is the handle for the radial component of the electric field
-    io_Er = create_dynamic_variable!(dynamic, "Er", mk_float, z, r;
-                                     description="radial electric field",
-                                     units="T_ref/e L_ref")
-    # io_Ez is the handle for the zed component of the electric field
-    io_Ez = create_dynamic_variable!(dynamic, "Ez", mk_float, z, r;
-                                     description="vertical electric field",
-                                     units="T_ref/e L_ref")
+        # io_phi is the handle referring to the electrostatic potential phi
+        io_phi = create_dynamic_variable!(dynamic, "phi", mk_float, z, r;
+                                          parallel_io=parallel_io,
+                                          description="electrostatic potential",
+                                          units="T_ref/e")
+        # io_Er is the handle for the radial component of the electric field
+        io_Er = create_dynamic_variable!(dynamic, "Er", mk_float, z, r;
+                                         parallel_io=parallel_io,
+                                         description="radial electric field",
+                                         units="T_ref/e L_ref")
+        # io_Ez is the handle for the zed component of the electric field
+        io_Ez = create_dynamic_variable!(dynamic, "Ez", mk_float, z, r;
+                                         parallel_io=parallel_io,
+                                         description="vertical electric field",
+                                         units="T_ref/e L_ref")
 
-    # io_density is the handle for the ion particle density
-    io_density = create_dynamic_variable!(dynamic, "density", mk_float, z, r;
+        # io_density is the handle for the ion particle density
+        io_density = create_dynamic_variable!(dynamic, "density", mk_float, z, r;
+                                              n_ion_species=n_ion_species,
+                                              parallel_io=parallel_io,
+                                              description="charged species density",
+                                              units="n_ref")
+
+        # io_upar is the handle for the ion parallel flow density
+        io_upar = create_dynamic_variable!(dynamic, "parallel_flow", mk_float, z, r;
+                                           n_ion_species=n_ion_species,
+                                           parallel_io=parallel_io,
+                                           description="charged species parallel flow",
+                                           units="c_ref = sqrt(2*T_ref/mi)")
+
+        # io_ppar is the handle for the ion parallel pressure
+        io_ppar = create_dynamic_variable!(dynamic, "parallel_pressure", mk_float, z, r;
+                                           n_ion_species=n_ion_species,
+                                           parallel_io=parallel_io,
+                                           description="charged species parallel pressure",
+                                           units="n_ref*T_ref")
+
+        # io_qpar is the handle for the ion parallel heat flux
+        io_qpar = create_dynamic_variable!(dynamic, "parallel_heat_flux", mk_float, z, r;
+                                           n_ion_species=n_ion_species,
+                                           parallel_io=parallel_io,
+                                           description="charged species parallel heat flux",
+                                           units="n_ref*T_ref*c_ref")
+
+        # io_vth is the handle for the ion thermal speed
+        io_vth = create_dynamic_variable!(dynamic, "thermal_speed", mk_float, z, r;
                                           n_ion_species=n_ion_species,
-                                          description="charged species density",
-                                          units="n_ref")
+                                          parallel_io=parallel_io,
+                                          description="charged species thermal speed",
+                                          units="c_ref")
 
-    # io_upar is the handle for the ion parallel flow density
-    io_upar = create_dynamic_variable!(dynamic, "parallel_flow", mk_float, z, r;
-                                       n_ion_species=n_ion_species,
-                                       description="charged species parallel flow",
-                                       units="c_ref = sqrt(2*T_ref/mi)")
+        # io_density_neutral is the handle for the neutral particle density
+        io_density_neutral = create_dynamic_variable!(dynamic, "density_neutral", mk_float, z, r;
+                                                      n_neutral_species=n_neutral_species,
+                                                      parallel_io=parallel_io,
+                                                      description="neutral species density",
+                                                      units="n_ref")
 
-    # io_ppar is the handle for the ion parallel pressure
-    io_ppar = create_dynamic_variable!(dynamic, "parallel_pressure", mk_float, z, r;
-                                       n_ion_species=n_ion_species,
-                                       description="charged species parallel pressure",
-                                       units="n_ref*T_ref")
+        # io_uz_neutral is the handle for the neutral z momentum density
+        io_uz_neutral = create_dynamic_variable!(dynamic, "uz_neutral", mk_float, z, r;
+                                                 n_neutral_species=n_neutral_species,
+                                                 parallel_io=parallel_io,
+                                                 description="neutral species mean z velocity",
+                                                 units="c_ref = sqrt(2*T_ref/mi)")
 
-    # io_qpar is the handle for the ion parallel heat flux
-    io_qpar = create_dynamic_variable!(dynamic, "parallel_heat_flux", mk_float, z, r;
-                                       n_ion_species=n_ion_species,
-                                       description="charged species parallel heat flux",
-                                       units="n_ref*T_ref*c_ref")
+        # io_pz_neutral is the handle for the neutral species zz pressure
+        io_pz_neutral = create_dynamic_variable!(dynamic, "pz_neutral", mk_float, z, r;
+                                                 n_neutral_species=n_neutral_species,
+                                                 parallel_io=parallel_io,
+                                                 description="neutral species mean zz pressure",
+                                                 units="n_ref*T_ref")
 
-    # io_vth is the handle for the ion thermal speed
-    io_vth = create_dynamic_variable!(dynamic, "thermal_speed", mk_float, z, r;
-                                      n_ion_species=n_ion_species,
-                                      description="charged species thermal speed",
-                                      units="c_ref")
+        # io_qz_neutral is the handle for the neutral z heat flux
+        io_qz_neutral = create_dynamic_variable!(dynamic, "qz_neutral", mk_float, z, r;
+                                                 n_neutral_species=n_neutral_species,
+                                                 parallel_io=parallel_io,
+                                                 description="neutral species z heat flux",
+                                                 units="n_ref*T_ref*c_ref")
 
-    # io_density_neutral is the handle for the neutral particle density
-    io_density_neutral = create_dynamic_variable!(dynamic, "density_neutral", mk_float, z, r;
-                                                  n_neutral_species=n_neutral_species,
-                                                  description="neutral species density",
-                                                  units="n_ref")
+        # io_thermal_speed_neutral is the handle for the neutral thermal speed
+        io_thermal_speed_neutral = create_dynamic_variable!(
+            dynamic, "thermal_speed_neutral", mk_float, z, r;
+            n_neutral_species=n_neutral_species,
+            parallel_io=parallel_io, description="neutral species thermal speed",
+            units="c_ref")
 
-    # io_uz_neutral is the handle for the neutral z momentum density
-    io_uz_neutral = create_dynamic_variable!(dynamic, "uz_neutral", mk_float, z, r;
-                                             n_neutral_species=n_neutral_species,
-                                             description="neutral species mean z velocity",
-                                             units="c_ref = sqrt(2*T_ref/mi)")
+        return io_moments_info(fid, io_time, io_phi, io_Er, io_Ez, io_density, io_upar,
+                               io_ppar, io_qpar, io_vth, io_density_neutral, io_uz_neutral,
+                               io_pz_neutral, io_qz_neutral, io_thermal_speed_neutral,
+                               parallel_io)
+    end
 
-    # io_pz_neutral is the handle for the neutral species zz pressure
-    io_pz_neutral = create_dynamic_variable!(dynamic, "pz_neutral", mk_float, z, r;
-                                             n_neutral_species=n_neutral_species,
-                                             description="neutral species mean zz pressure",
-                                             units="n_ref*T_ref")
-
-    # io_qz_neutral is the handle for the neutral z heat flux
-    io_qz_neutral = create_dynamic_variable!(dynamic, "qz_neutral", mk_float, z, r;
-                                             n_neutral_species=n_neutral_species,
-                                             description="neutral species z heat flux",
-                                             units="n_ref*T_ref*c_ref")
-
-    # io_thermal_speed_neutral is the handle for the neutral thermal speed
-    io_thermal_speed_neutral = create_dynamic_variable!(
-        dynamic, "thermal_speed_neutral", mk_float, z, r;
-        n_neutral_species=n_neutral_species,
-        description="neutral species thermal speed", units="c_ref")
-
-    return io_moments_info(fid, io_time, io_phi, io_Er, io_Ez, io_density, io_upar,
-                           io_ppar, io_qpar, io_vth, io_density_neutral, io_uz_neutral,
-                           io_pz_neutral, io_qz_neutral, io_thermal_speed_neutral,
-                           parallel_io)
+    # For processes other than the root process of each shared-memory group...
+    return nothing
 end
 
 """
@@ -353,29 +415,37 @@ file
 function define_dynamic_dfn_variables!(fid, r, z, vperp, vpa, vzeta, vr, vz,
                                        n_ion_species, n_neutral_species, parallel_io)
 
-    if !haskey(fid, "dynamic_data")
-        dynamic = create_io_group(fid, "dynamic_data", description="time evolving
-                                  variables")
-    else
-        dynamic = fid["dynamic_data"]
+    @serial_region begin
+        if !haskey(fid, "dynamic_data")
+            dynamic = create_io_group(fid, "dynamic_data",
+                                      description="time evolving variables")
+        else
+            dynamic = fid["dynamic_data"]
+        end
+
+        if !haskey(dynamic, "time")
+            io_time = create_dynamic_variable!(dynamic, "time", mk_float;
+                                               parallel_io=parallel_io,
+                                               description="simulation time")
+        end
+
+        # io_f is the handle for the ion pdf
+        io_f = create_dynamic_variable!(dynamic, "f", mk_float, vpa, vperp, z, r;
+                                        n_ion_species=n_ion_species,
+                                        parallel_io=parallel_io,
+                                        description="charged species distribution function")
+
+        # io_f_neutral is the handle for the neutral pdf
+        io_f_neutral = create_dynamic_variable!(dynamic, "f_neutral", mk_float, vz, vr, vzeta, z, r;
+                                                n_neutral_species=n_neutral_species,
+                                                parallel_io=parallel_io,
+                                                description="neutral species distribution function")
+
+        return io_dfns_info(fid, io_time, io_f, io_f_neutral, parallel_io)
     end
 
-    if !haskey(dynamic, "time")
-        io_time = create_dynamic_variable!(dynamic, "time", mk_float;
-                                           description="simulation time")
-    end
-
-    # io_f is the handle for the ion pdf
-    io_f = create_dynamic_variable!(dynamic, "f", mk_float, vpa, vperp, z, r;
-                                    n_ion_species=n_ion_species,
-                                    description="charged species distribution function")
-
-    # io_f_neutral is the handle for the neutral pdf
-    io_f_neutral = create_dynamic_variable!(dynamic, "f_neutral", mk_float, vz, vr, vzeta, z, r;
-                                            n_neutral_species=n_neutral_species,
-                                            description="neutral species distribution function")
-
-    return io_dfns_info(fid, io_time, io_f, io_f_neutral, parallel_io)
+    # For processes other than the root process of each shared-memory group...
+    return nothing
 end
 
 """
@@ -386,11 +456,11 @@ function add_attribute!() end
 """
 Open an output file, selecting the backend based on io_option
 """
-function open_output_file(prefix, binary_format)
+function open_output_file(prefix, binary_format, parallel_io, io_comm)
     if binary_format == hdf5
-        return open_output_file_hdf5(prefix)
+        return open_output_file_hdf5(prefix, parallel_io, io_comm)
     elseif binary_format == netcdf
-        return open_output_file_netcdf(prefix)
+        return open_output_file_netcdf(prefix, parallel_io, io_comm)
     else
         error("Unsupported I/O format $binary_format")
     end
@@ -400,59 +470,73 @@ end
 setup file i/o for moment variables
 """
 function setup_moments_io(prefix, binary_format, r, z, composition, collisions,
-                          parallel_io)
-    fid = open_output_file(string(prefix, ".moments"), binary_format)
+                          parallel_io, io_comm)
+    @serial_region begin
+        fid = open_output_file(string(prefix, ".moments"), binary_format, parallel_io,
+                               io_comm)
 
-    # write a header to the output file
-    add_attribute!(fid, "file_info", "Output moments data from the moment_kinetics code")
+        # write a header to the output file
+        add_attribute!(fid, "file_info", "Output moments data from the moment_kinetics code")
 
-    # write some overview information to the output file
-    write_overview!(fid, composition, collisions)
+        # write some overview information to the output file
+        write_overview!(fid, composition, collisions, parallel_io)
 
-    ### define coordinate dimensions ###
-    define_spatial_coordinates!(fid, z, r)
+        ### define coordinate dimensions ###
+        define_spatial_coordinates!(fid, z, r, parallel_io)
 
-    ### create variables for time-dependent quantities and store them ###
-    ### in a struct for later access ###
-    io_moments = define_dynamic_moment_variables!(
-        fid, composition.n_ion_species, composition.n_neutral_species, r, z, parallel_io)
+        ### create variables for time-dependent quantities and store them ###
+        ### in a struct for later access ###
+        io_moments = define_dynamic_moment_variables!(
+            fid, composition.n_ion_species, composition.n_neutral_species, r, z, parallel_io)
 
-    return io_moments
+        return io_moments
+    end
+
+    # For processes other than the root process of each shared-memory group...
+    return nothing
 end
 
 """
 setup file i/o for distribution function variables
 """
 function setup_dfns_io(prefix, binary_format, r, z, vperp, vpa, vzeta, vr, vz, composition,
-                       collisions, parallel_io)
+                       collisions, parallel_io, io_comm)
 
-    fid = open_output_file(string(prefix, ".dfns"), binary_format)
+    @serial_region begin
+        fid = open_output_file(string(prefix, ".dfns"), binary_format, parallel_io,
+                               io_comm)
 
-    # write a header to the output file
-    add_attribute!(fid, "file_info",
-                   "Output distribution function data from the moment_kinetics code")
+        # write a header to the output file
+        add_attribute!(fid, "file_info",
+                       "Output distribution function data from the moment_kinetics code")
 
-    # write some overview information to the hdf5 file
-    write_overview!(fid, composition, collisions)
+        # write some overview information to the hdf5 file
+        write_overview!(fid, composition, collisions, parallel_io)
 
-    ### define coordinate dimensions ###
-    coords_group = define_spatial_coordinates!(fid, z, r)
-    add_vspace_coordinates!(coords_group, vz, vr, vzeta, vpa, vperp)
+        ### define coordinate dimensions ###
+        coords_group = define_spatial_coordinates!(fid, z, r, parallel_io)
+        add_vspace_coordinates!(coords_group, vz, vr, vzeta, vpa, vperp, parallel_io)
 
-    ### create variables for time-dependent quantities and store them ###
-    ### in a struct for later access ###
-    io_dfns = define_dynamic_dfn_variables!(
-        fid, r, z, vperp, vpa, vzeta, vr, vz, composition.n_ion_species,
-        composition.n_neutral_species, parallel_io)
+        ### create variables for time-dependent quantities and store them ###
+        ### in a struct for later access ###
+        io_dfns = define_dynamic_dfn_variables!(
+            fid, r, z, vperp, vpa, vzeta, vr, vz, composition.n_ion_species,
+            composition.n_neutral_species, parallel_io)
 
-    return io_dfns
+        return io_dfns
+    end
+
+    # For processes other than the root process of each shared-memory group...
+    return nothing
 end
 
 """
-    append_to_dynamic_var(io_var, data, t_idx)
+    append_to_dynamic_var(io_var, data, t_idx, coords...)
 
 Append `data` to the dynamic variable `io_var`. The time-index of the data being appended
-is `t_idx`. 
+is `t_idx`. `coords...` is used to get the ranges to write from/to (needed for parallel
+I/O) - the entries in the `coords` tuple can be either `coordinate` instances or integers
+(for an integer `n` the range is `1:n`).
 """
 function append_to_dynamic_var() end
 
@@ -460,7 +544,7 @@ function append_to_dynamic_var() end
 write time-dependent moments data to the binary output file
 """
 function write_moments_data_to_binary(moments, fields, t, n_ion_species,
-                                      n_neutral_species, io_moments, t_idx)
+                                      n_neutral_species, io_moments, t_idx, r, z)
     @serial_region begin
         # Only read/write from first process in each 'block'
 
@@ -468,22 +552,32 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
         append_to_dynamic_var(io_moments.time, t, t_idx)
 
         # add the electrostatic potential and electric field components at this time slice to the hdf5 file
-        append_to_dynamic_var(io_moments.phi, fields.phi, t_idx)
-        append_to_dynamic_var(io_moments.Er, fields.Er, t_idx)
-        append_to_dynamic_var(io_moments.Ez, fields.Ez, t_idx)
+        append_to_dynamic_var(io_moments.phi, fields.phi, t_idx, z, r)
+        append_to_dynamic_var(io_moments.Er, fields.Er, t_idx, z, r)
+        append_to_dynamic_var(io_moments.Ez, fields.Ez, t_idx, z, r)
 
         # add the density data at this time slice to the output file
-        append_to_dynamic_var(io_moments.density, moments.charged.dens, t_idx)
-        append_to_dynamic_var(io_moments.parallel_flow, moments.charged.upar, t_idx)
-        append_to_dynamic_var(io_moments.parallel_pressure, moments.charged.ppar, t_idx)
-        append_to_dynamic_var(io_moments.parallel_heat_flux, moments.charged.qpar, t_idx)
-        append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth, t_idx)
+        append_to_dynamic_var(io_moments.density, moments.charged.dens, t_idx, z, r,
+                              n_ion_species)
+        append_to_dynamic_var(io_moments.parallel_flow, moments.charged.upar, t_idx, z, r,
+                              n_ion_species)
+        append_to_dynamic_var(io_moments.parallel_pressure, moments.charged.ppar, t_idx,
+                              z, r, n_ion_species)
+        append_to_dynamic_var(io_moments.parallel_heat_flux, moments.charged.qpar, t_idx,
+                              z, r, n_ion_species)
+        append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth, t_idx, z, r,
+                              n_ion_species)
         if n_neutral_species > 0
-            append_to_dynamic_var(io_moments.density_neutral, moments.neutral.dens, t_idx)
-            append_to_dynamic_var(io_moments.uz_neutral, moments.neutral.uz, t_idx)
-            append_to_dynamic_var(io_moments.pz_neutral, moments.neutral.pz, t_idx)
-            append_to_dynamic_var(io_moments.qz_neutral, moments.neutral.qz, t_idx)
-            append_to_dynamic_var(io_moments.thermal_speed_neutral, moments.neutral.vth, t_idx)
+            append_to_dynamic_var(io_moments.density_neutral, moments.neutral.dens, t_idx,
+                                  z, r, n_neutral_species)
+            append_to_dynamic_var(io_moments.uz_neutral, moments.neutral.uz, t_idx, z, r,
+                                  n_neutral_species)
+            append_to_dynamic_var(io_moments.pz_neutral, moments.neutral.pz, t_idx, z, r,
+                                  n_neutral_species)
+            append_to_dynamic_var(io_moments.qz_neutral, moments.neutral.qz, t_idx, z, r,
+                                  n_neutral_species)
+            append_to_dynamic_var(io_moments.thermal_speed_neutral, moments.neutral.vth,
+                                  t_idx, z, r, n_neutral_species)
         end
     end
     return nothing
@@ -493,7 +587,7 @@ end
 write time-dependent distribution function data to the binary output file
 """
 function write_dfns_data_to_binary(ff, ff_neutral, t, n_ion_species, n_neutral_species,
-                                   io_dfns, t_idx)
+                                   io_dfns, t_idx, r, z, vperp, vpa, vzeta, vr, vz)
     @serial_region begin
         # Only read/write from first process in each 'block'
 
@@ -501,9 +595,10 @@ function write_dfns_data_to_binary(ff, ff_neutral, t, n_ion_species, n_neutral_s
         append_to_dynamic_var(io_dfns.time, t, t_idx)
 
         # add the distribution function data at this time slice to the output file
-        append_to_dynamic_var(io_dfns.f, ff, t_idx)
+        append_to_dynamic_var(io_dfns.f, ff, t_idx, vpa, vperp, z, r, n_ion_species)
         if n_neutral_species > 0
-            append_to_dynamic_var(io_dfns.f_neutral, ff_neutral, t_idx)
+            append_to_dynamic_var(io_dfns.f_neutral, ff_neutral, t_idx, vz, vr, vzeta, z,
+                                  r, n_neutral_species)
         end
     end
     return nothing
@@ -513,7 +608,7 @@ end
     # Special versions when using DebugMPISharedArray to avoid implicit conversion to
     # Array, which is forbidden.
     function write_moments_data_to_binary(moments, fields, t, n_ion_species,
-            n_neutral_species, io_moments, t_idx)
+            n_neutral_species, io_moments, t_idx, r, z)
         @serial_region begin
             # Only read/write from first process in each 'block'
 
@@ -521,22 +616,33 @@ end
             append_to_dynamic_var(io_moments.time, t, t_idx)
 
             # add the electrostatic potential and electric field components at this time slice to the hdf5 file
-            append_to_dynamic_var(io_moments.phi.data, field.phi, t_idx)
-            append_to_dynamic_var(io_moments.Er.data, field.Er, t_idx)
-            append_to_dynamic_var(io_moments.Ez.data, field.Ez, t_idx)
+            append_to_dynamic_var(io_moments.phi.data, fields.phi, t_idx, z, r)
+            append_to_dynamic_var(io_moments.Er.data, fields.Er, t_idx, z, r)
+            append_to_dynamic_var(io_moments.Ez.data, fields.Ez, t_idx, z, r)
 
             # add the density data at this time slice to the output file
-            append_to_dynamic_var(io_moments.density.data, moments.charged.dens, t_idx)
-            append_to_dynamic_var(io_moments.parallel_flow.data, moments.charged.upar, t_idx)
-            append_to_dynamic_var(io_moments.parallel_pressure.data, moments.charged.ppar, t_idx)
-            append_to_dynamic_var(io_moments.parallel_heat_flux.data, moments.charged.qpar, t_idx)
-            append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth.data, t_idx)
+            append_to_dynamic_var(io_moments.density.data, moments.charged.dens, t_idx, z,
+                                  r, n_ion_species)
+            append_to_dynamic_var(io_moments.parallel_flow.data, moments.charged.upar,
+                                  t_idx, z, r, n_ion_species)
+            append_to_dynamic_var(io_moments.parallel_pressure.data, moments.charged.ppar,
+                                  t_idx, z, r, n_ion_species)
+            append_to_dynamic_var(io_moments.parallel_heat_flux.data,
+                                  moments.charged.qpar, t_idx, z, r, n_ion_species)
+            append_to_dynamic_var(io_moments.thermal_speed.data, moments.charged.vth,
+                                  t_idx, z, r, n_ion_species)
             if n_neutral_species > 0
-                append_to_dynamic_var(io_moments.density_neutral, moments.neutral.dens.data, t_idx)
-                append_to_dynamic_var(io_moments.uz_neutral, moments.neutral.uz.data, t_idx)
-                append_to_dynamic_var(io_moments.pz_neutral, moments.neutral.pz.data, t_idx)
-                append_to_dynamic_var(io_moments.qz_neutral, moments.neutral.qz.data, t_idx)
-                append_to_dynamic_var(io_moments.thermal_speed_neutral, moments.neutral.vth.data, t_idx)
+                append_to_dynamic_var(io_moments.density_neutral.data,
+                                      moments.neutral.dens, t_idx, z, r,
+                                      n_neutral_species)
+                append_to_dynamic_var(io_moments.uz_neutral.data, moments.neutral.uz,
+                                      t_idx, z, r, n_neutral_species)
+                append_to_dynamic_var(io_moments.pz_neutral.data, moments.neutral.pz,
+                                      t_idx, z, r, n_neutral_species)
+                append_to_dynamic_var(io_moments.qz_neutral.data, moments.neutral.qz,
+                                      t_idx, z, r, n_neutral_species)
+                append_to_dynamic_var(io_moments.thermal_speed_neutral.data,
+                                      moments.neutral.vth, t_idx, z, r, n_neutral_species)
             end
         end
         return nothing
@@ -547,7 +653,8 @@ end
     # Special versions when using DebugMPISharedArray to avoid implicit conversion to
     # Array, which is forbidden.
     function write_dfns_data_to_binary(ff::DebugMPISharedArray, ff_neutral::DebugMPISharedArray,
-            t, n_ion_species, n_neutral_species, h5::hdf5_dfns_info, t_idx)
+            t, n_ion_species, n_neutral_species, h5::hdf5_dfns_info, t_idx, r, z, vperp,
+            vpa, vzeta, vr, vz)
         @serial_region begin
             # Only read/write from first process in each 'block'
 
@@ -555,9 +662,12 @@ end
             append_to_dynamic_var(io_dfns.time, t, t_idx)
 
             # add the distribution function data at this time slice to the output file
-            append_to_dynamic_var(io_dfns.f, ff.data, t_idx)
+            # add the distribution function data at this time slice to the output file
+            append_to_dynamic_var(io_dfns.f, ff.data, t_idx, vpa, vperp, z, r,
+                                  n_ion_species)
             if n_neutral_species > 0
-                append_to_dynamic_var(io_dfns.f_neutral, ff_neutral.data, t_idx)
+                append_to_dynamic_var(io_dfns.f_neutral, ff_neutral.data, t_idx, vz, vr,
+                                      vzeta, z, r, n_neutral_species)
             end
         end
         return nothing
@@ -798,25 +908,27 @@ function debug_dump(vz::coordinate, vr::coordinate, vzeta::coordinate, vpa::coor
                            "This is a file containing debug output from the moment_kinetics code")
 
             ### define coordinate dimensions ###
-            coords_group = define_spatial_coordinates!(fid, z, r)
-            add_vspace_coordinates!(coords_group, vz, vr, vzeta, vpa, vperp)
+            coords_group = define_spatial_coordinates!(fid, z, r, false)
+            add_vspace_coordinates!(coords_group, vz, vr, vzeta, vpa, vperp, false)
 
             ### create variables for time-dependent quantities and store them ###
             ### in a struct for later access ###
             io_moments = define_dynamic_moment_variables!(fid, composition.n_ion_species,
                                                           composition.n_neutral_species,
-                                                          r, z)
+                                                          r, z, false)
             io_dfns = define_dynamic_dfn_variables!(
                 fid, r, z, vperp, vpa, vzeta, vr, vz, composition.n_ion_species,
-                composition.n_neutral_species)
+                composition.n_neutral_species, false)
 
             # create the "istage" variable, used to identify the rk stage where
             # `debug_dump()` was called
             dynamic = fid["dynamic_data"]
             io_istage = create_dynamic_variable!(dynamic, "istage", mk_int;
+                                                 parallel_io=parallel_io,
                                                  description="rk istage")
             # create the "label" variable, used to identify the `debug_dump()` call-site
             io_label = create_dynamic_variable!(dynamic, "label", String;
+                                                parallel_io=parallel_io,
                                                 description="call-site label")
 
             # create a struct that stores the variables and other info needed for

--- a/src/file_io_hdf5.jl
+++ b/src/file_io_hdf5.jl
@@ -2,6 +2,10 @@
 
 using HDF5
 
+function io_has_parallel(::Val{hdf5})
+    return HDF5.has_parallel()
+end
+
 function open_output_file_hdf5(prefix)
     # the hdf5 file will be given by output_dir/run_name with .h5 appended
     filename = string(prefix, ".h5")

--- a/src/file_io_netcdf.jl
+++ b/src/file_io_netcdf.jl
@@ -7,7 +7,9 @@ function io_has_parallel(::Val{netcdf})
     return false
 end
 
-function open_output_file_netcdf(prefix)
+function open_output_file_netcdf(prefix, parallel_io, io_comm)
+    parallel_io && error("NetCDF interface does not support parallel I/O")
+
     # the netcdf file will be given by output_dir/run_name with .cdf appended
     filename = string(prefix, ".cdf")
     # if a netcdf file with the requested name already exists, remove it
@@ -127,7 +129,8 @@ function create_dynamic_variable!(file_or_group::NCDataset, name, type,
 end
 
 function append_to_dynamic_var(io_var::NCDatasets.CFVariable,
-                               data::Union{Number,AbstractArray{T,N}}, t_idx) where {T,N}
+                               data::Union{Number,AbstractArray{T,N}}, t_idx,
+                               coords...) where {T,N}
 
     if isa(data, Number)
         io_var[t_idx] = data

--- a/src/file_io_netcdf.jl
+++ b/src/file_io_netcdf.jl
@@ -49,7 +49,7 @@ end
 
 function write_single_value!(file_or_group::NCDataset, name,
                              value::Union{Number, AbstractArray{T,N}},
-                             coords::coordinate...; description=nothing) where {T,N}
+                             coords::coordinate...; parallel_io, description=nothing) where {T,N}
     if description !== nothing
         attributes = Dict("description" => description)
     else
@@ -74,7 +74,7 @@ function write_single_value!(file_or_group::NCDataset, name,
 end
 
 function create_dynamic_variable!(file_or_group::NCDataset, name, type,
-                                  coords::coordinate...;
+                                  coords::coordinate...; parallel_io,
                                   n_ion_species=0, n_neutral_species=0,
                                   description=nothing, units=nothing)
 

--- a/src/file_io_netcdf.jl
+++ b/src/file_io_netcdf.jl
@@ -2,6 +2,11 @@
 
 using NCDatasets
 
+function io_has_parallel(::Val{netcdf})
+    # NCDatasets.jl does not support parallel I/O yet
+    return false
+end
+
 function open_output_file_netcdf(prefix)
     # the netcdf file will be given by output_dir/run_name with .cdf appended
     filename = string(prefix, ".cdf")

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -17,6 +17,8 @@ export geometry_input
 
 using ..type_definitions: mk_float, mk_int
 
+using MPI
+
 """
 """
 mutable struct evolve_moments_options
@@ -144,8 +146,8 @@ struct grid_input
     bc::String
     # struct containing advection speed options
     advection::advection_input
-	# MPI communicator
-	comm::T where T
+    # MPI communicator
+    comm::MPI.Comm
 end
 
 """

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -325,6 +325,7 @@ Base.@kwdef struct io_input
     run_name::String
     ascii_output::Bool
     binary_format::binary_format_type
+    parallel_io::Bool
 end
 
 """

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -228,9 +228,10 @@ function setup_moment_kinetics(input_dict::Dict;
     # write initial data to binary file (netcdf)
 
     write_moments_data_to_binary(moments, fields, code_time, composition.n_ion_species,
-        composition.n_neutral_species, io_moments, 1)
+        composition.n_neutral_species, io_moments, 1, r, z)
     write_dfns_data_to_binary(pdf.charged.unnorm, pdf.neutral.unnorm, code_time,
-        composition.n_ion_species, composition.n_neutral_species, io_dfns, 1)
+        composition.n_ion_species, composition.n_neutral_species, io_dfns, 1, r, z, vperp,
+        vpa, vzeta, vr, vz)
 
     begin_s_r_z_vperp_region()
 

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -172,21 +172,21 @@ function setup_moment_kinetics(input_dict::Dict;
         composition, species, collisions,
         geometry, drive_input, num_diss_params  = input
     # initialize z grid and write grid point locations to file
-    z = define_coordinate(z_input)
+    z = define_coordinate(z_input, io_input.parallel_io)
     # initialize r grid and write grid point locations to file
-    r = define_coordinate(r_input)
+    r = define_coordinate(r_input, io_input.parallel_io)
     # initialize vpa grid and write grid point locations to file
-    vpa = define_coordinate(vpa_input)
+    vpa = define_coordinate(vpa_input, io_input.parallel_io)
     # initialize vperp grid and write grid point locations to file
-    vperp = define_coordinate(vperp_input)
+    vperp = define_coordinate(vperp_input, io_input.parallel_io)
     # initialize gyrophase grid and write grid point locations to file
-    gyrophase = define_coordinate(gyrophase_input)
+    gyrophase = define_coordinate(gyrophase_input, io_input.parallel_io)
     # initialize vz grid and write grid point locations to file
-    vz = define_coordinate(vz_input)
+    vz = define_coordinate(vz_input, io_input.parallel_io)
     # initialize vr grid and write grid point locations to file
-    vr = define_coordinate(vr_input)
+    vr = define_coordinate(vr_input, io_input.parallel_io)
     # initialize vr grid and write grid point locations to file
-    vzeta = define_coordinate(vzeta_input)
+    vzeta = define_coordinate(vzeta_input, io_input.parallel_io)
     # Create loop range variables for shared-memory-parallel loops
     if composition.n_neutral_species == 0
         n_neutral_loop_size = 1 # Need this to have looping setup. Avoid neutral loops with if statements.

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -172,21 +172,21 @@ function setup_moment_kinetics(input_dict::Dict;
         composition, species, collisions,
         geometry, drive_input, num_diss_params  = input
     # initialize z grid and write grid point locations to file
-    z = define_coordinate(z_input, composition)
+    z = define_coordinate(z_input)
     # initialize r grid and write grid point locations to file
-    r = define_coordinate(r_input, composition)
+    r = define_coordinate(r_input)
     # initialize vpa grid and write grid point locations to file
-    vpa = define_coordinate(vpa_input, composition)
+    vpa = define_coordinate(vpa_input)
     # initialize vperp grid and write grid point locations to file
-    vperp = define_coordinate(vperp_input, composition)
+    vperp = define_coordinate(vperp_input)
     # initialize gyrophase grid and write grid point locations to file
-    gyrophase = define_coordinate(gyrophase_input, composition)
+    gyrophase = define_coordinate(gyrophase_input)
     # initialize vz grid and write grid point locations to file
-    vz = define_coordinate(vz_input, composition)
+    vz = define_coordinate(vz_input)
     # initialize vr grid and write grid point locations to file
-    vr = define_coordinate(vr_input, composition)
+    vr = define_coordinate(vr_input)
     # initialize vr grid and write grid point locations to file
-    vzeta = define_coordinate(vzeta_input, composition)
+    vzeta = define_coordinate(vzeta_input)
     # Create loop range variables for shared-memory-parallel loops
     if composition.n_neutral_species == 0
         n_neutral_loop_size = 1 # Need this to have looping setup. Avoid neutral loops with if statements.

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -431,6 +431,7 @@ function mk_input(scan_input=Dict())
     io_settings = copy(get(scan_input, "output", Dict{String,Any}()))
     io_settings["ascii_output"] = get(io_settings, "ascii_output", false)
     io_settings["binary_format"] = get(io_settings, "binary_format", hdf5)
+    io_settings["parallel_io"] = get(io_settings, "parallel_io", true)
     io_immutable = io_input(; output_dir=output_dir, run_name=run_name,
                               Dict(Symbol(k)=>v for (k,v) in io_settings)...)
 

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -10,7 +10,7 @@ export read_input_file
 using ..type_definitions: mk_float, mk_int
 using ..array_allocation: allocate_float
 using ..communication
-using ..file_io: input_option_error, open_ascii_output_file
+using ..file_io: io_has_parallel, input_option_error, open_ascii_output_file
 using ..finite_differences: fd_check_option
 using ..input_structs
 using ..numerical_dissipation: setup_numerical_dissipation
@@ -431,7 +431,8 @@ function mk_input(scan_input=Dict())
     io_settings = copy(get(scan_input, "output", Dict{String,Any}()))
     io_settings["ascii_output"] = get(io_settings, "ascii_output", false)
     io_settings["binary_format"] = get(io_settings, "binary_format", hdf5)
-    io_settings["parallel_io"] = get(io_settings, "parallel_io", true)
+    io_settings["parallel_io"] = get(io_settings, "parallel_io",
+                                     io_has_parallel(Val(io_settings["binary_format"])))
     io_immutable = io_input(; output_dir=output_dir, run_name=run_name,
                               Dict(Symbol(k)=>v for (k,v) in io_settings)...)
 

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -358,27 +358,27 @@ function mk_input(scan_input=Dict())
 	# assign dummy values to nrank, irank and comm of coord struct
     vpa_advection_immutable = advection_input(vpa.advection.option, vpa.advection.constant_speed,
         vpa.advection.frequency, vpa.advection.oscillation_amplitude)
-    vpa_immutable = grid_input("vpa", vpa.ngrid, vpa.nelement_global, vpa.nelement_local, 0, 0, vpa.L,
+    vpa_immutable = grid_input("vpa", vpa.ngrid, vpa.nelement_global, vpa.nelement_local, 1, 0, vpa.L,
         vpa.discretization, vpa.fd_option, vpa.bc, vpa_advection_immutable, MPI.COMM_NULL)
     vperp_advection_immutable = advection_input(vperp.advection.option, vperp.advection.constant_speed,
         vperp.advection.frequency, vperp.advection.oscillation_amplitude)
-    vperp_immutable = grid_input("vperp", vperp.ngrid, vperp.nelement_global, vperp.nelement_local, 0, 0, vperp.L,
+    vperp_immutable = grid_input("vperp", vperp.ngrid, vperp.nelement_global, vperp.nelement_local, 1, 0, vperp.L,
         vperp.discretization, vperp.fd_option, vperp.bc, vperp_advection_immutable, MPI.COMM_NULL)
     gyrophase_advection_immutable = advection_input(gyrophase.advection.option, gyrophase.advection.constant_speed,
         gyrophase.advection.frequency, gyrophase.advection.oscillation_amplitude)
-    gyrophase_immutable = grid_input("gyrophase", gyrophase.ngrid, gyrophase.nelement_global, gyrophase.nelement_local, 0, 0, gyrophase.L,
+    gyrophase_immutable = grid_input("gyrophase", gyrophase.ngrid, gyrophase.nelement_global, gyrophase.nelement_local, 1, 0, gyrophase.L,
         gyrophase.discretization, gyrophase.fd_option, gyrophase.bc, gyrophase_advection_immutable, MPI.COMM_NULL)
     vz_advection_immutable = advection_input(vz.advection.option, vz.advection.constant_speed,
         vz.advection.frequency, vz.advection.oscillation_amplitude)
-    vz_immutable = grid_input("vz", vz.ngrid, vz.nelement_global, vz.nelement_local, 0, 0, vz.L,
+    vz_immutable = grid_input("vz", vz.ngrid, vz.nelement_global, vz.nelement_local, 1, 0, vz.L,
         vz.discretization, vz.fd_option, vz.bc, vz_advection_immutable, MPI.COMM_NULL)
     vr_advection_immutable = advection_input(vr.advection.option, vr.advection.constant_speed,
         vr.advection.frequency, vr.advection.oscillation_amplitude)
-    vr_immutable = grid_input("vr", vr.ngrid, vr.nelement_global, vr.nelement_local, 0, 0, vr.L,
+    vr_immutable = grid_input("vr", vr.ngrid, vr.nelement_global, vr.nelement_local, 1, 0, vr.L,
         vr.discretization, vr.fd_option, vr.bc, vr_advection_immutable, MPI.COMM_NULL)
     vzeta_advection_immutable = advection_input(vzeta.advection.option, vzeta.advection.constant_speed,
         vzeta.advection.frequency, vzeta.advection.oscillation_amplitude)
-    vzeta_immutable = grid_input("vzeta", vzeta.ngrid, vzeta.nelement_global, vzeta.nelement_local, 0, 0, vzeta.L,
+    vzeta_immutable = grid_input("vzeta", vzeta.ngrid, vzeta.nelement_global, vzeta.nelement_local, 1, 0, vzeta.L,
         vzeta.discretization, vzeta.fd_option, vzeta.bc, vzeta_advection_immutable, MPI.COMM_NULL)
     
     species_charged_immutable = Array{species_parameters,1}(undef,n_ion_species)

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -15,6 +15,7 @@ using ..finite_differences: fd_check_option
 using ..input_structs
 using ..numerical_dissipation: setup_numerical_dissipation
 
+using MPI
 using TOML
 
 @enum RunType single performance_test scan
@@ -358,27 +359,27 @@ function mk_input(scan_input=Dict())
     vpa_advection_immutable = advection_input(vpa.advection.option, vpa.advection.constant_speed,
         vpa.advection.frequency, vpa.advection.oscillation_amplitude)
     vpa_immutable = grid_input("vpa", vpa.ngrid, vpa.nelement_global, vpa.nelement_local, 0, 0, vpa.L,
-        vpa.discretization, vpa.fd_option, vpa.bc, vpa_advection_immutable, false)
+        vpa.discretization, vpa.fd_option, vpa.bc, vpa_advection_immutable, MPI.COMM_NULL)
     vperp_advection_immutable = advection_input(vperp.advection.option, vperp.advection.constant_speed,
         vperp.advection.frequency, vperp.advection.oscillation_amplitude)
     vperp_immutable = grid_input("vperp", vperp.ngrid, vperp.nelement_global, vperp.nelement_local, 0, 0, vperp.L,
-        vperp.discretization, vperp.fd_option, vperp.bc, vperp_advection_immutable, false)
+        vperp.discretization, vperp.fd_option, vperp.bc, vperp_advection_immutable, MPI.COMM_NULL)
     gyrophase_advection_immutable = advection_input(gyrophase.advection.option, gyrophase.advection.constant_speed,
         gyrophase.advection.frequency, gyrophase.advection.oscillation_amplitude)
     gyrophase_immutable = grid_input("gyrophase", gyrophase.ngrid, gyrophase.nelement_global, gyrophase.nelement_local, 0, 0, gyrophase.L,
-        gyrophase.discretization, gyrophase.fd_option, gyrophase.bc, gyrophase_advection_immutable, false)
+        gyrophase.discretization, gyrophase.fd_option, gyrophase.bc, gyrophase_advection_immutable, MPI.COMM_NULL)
     vz_advection_immutable = advection_input(vz.advection.option, vz.advection.constant_speed,
         vz.advection.frequency, vz.advection.oscillation_amplitude)
     vz_immutable = grid_input("vz", vz.ngrid, vz.nelement_global, vz.nelement_local, 0, 0, vz.L,
-        vz.discretization, vz.fd_option, vz.bc, vz_advection_immutable, false)
+        vz.discretization, vz.fd_option, vz.bc, vz_advection_immutable, MPI.COMM_NULL)
     vr_advection_immutable = advection_input(vr.advection.option, vr.advection.constant_speed,
         vr.advection.frequency, vr.advection.oscillation_amplitude)
     vr_immutable = grid_input("vr", vr.ngrid, vr.nelement_global, vr.nelement_local, 0, 0, vr.L,
-        vr.discretization, vr.fd_option, vr.bc, vr_advection_immutable, false)
+        vr.discretization, vr.fd_option, vr.bc, vr_advection_immutable, MPI.COMM_NULL)
     vzeta_advection_immutable = advection_input(vzeta.advection.option, vzeta.advection.constant_speed,
         vzeta.advection.frequency, vzeta.advection.oscillation_amplitude)
     vzeta_immutable = grid_input("vzeta", vzeta.ngrid, vzeta.nelement_global, vzeta.nelement_local, 0, 0, vzeta.L,
-        vzeta.discretization, vzeta.fd_option, vzeta.bc, vzeta_advection_immutable, false)
+        vzeta.discretization, vzeta.fd_option, vzeta.bc, vzeta_advection_immutable, MPI.COMM_NULL)
     
     species_charged_immutable = Array{species_parameters,1}(undef,n_ion_species)
     species_neutral_immutable = Array{species_parameters,1}(undef,n_neutral_species)

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -671,7 +671,8 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
                                 composition.n_ion_species, composition.n_neutral_species,
                                 ascii_io)
             write_moments_data_to_binary(moments, fields, t, composition.n_ion_species,
-                                         composition.n_neutral_species, io_moments, iwrite_moments)
+                                         composition.n_neutral_species, io_moments,
+                                         iwrite_moments, r, z)
             iwrite_moments += 1
             begin_s_r_z_vperp_region()
             @debug_detect_redundant_block_synchronize begin
@@ -694,7 +695,8 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
             end
             write_dfns_data_to_binary(pdf.charged.unnorm, pdf.neutral.unnorm, t,
                                       composition.n_ion_species,
-                                      composition.n_neutral_species, io_dfns, iwrite_dfns)
+                                      composition.n_neutral_species, io_dfns, iwrite_dfns,
+                                      r, z, vperp, vpa, vzeta, vr, vz)
             iwrite_dfns += 1
             begin_s_r_z_vperp_region()
             @debug_detect_redundant_block_synchronize begin

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/calculus_tests.jl
+++ b/test/calculus_tests.jl
@@ -7,6 +7,7 @@ using moment_kinetics.coordinates: define_coordinate
 using moment_kinetics.chebyshev: setup_chebyshev_pseudospectral
 using moment_kinetics.calculus: derivative!, second_derivative!, integral
 
+using MPI
 using Random
 
 fd_fake_setup(x) = return false
@@ -41,7 +42,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     discretization, fd_option, bc, adv_input, comm)
@@ -92,7 +93,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "finite_difference", fd_option, bc, adv_input, comm)
@@ -139,7 +140,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "finite_difference", fd_option, bc, adv_input, comm)
@@ -182,7 +183,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "finite_difference", fd_option, bc, adv_input, comm)
@@ -233,7 +234,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "finite_difference", fd_option, bc, adv_input, comm)
@@ -441,7 +442,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "chebyshev_pseudospectral", fd_option, bc, adv_input, comm)
@@ -639,7 +640,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "chebyshev_pseudospectral", fd_option, bc, adv_input, comm)
@@ -685,7 +686,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "chebyshev_pseudospectral", fd_option, bc, adv_input, comm)
@@ -739,7 +740,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value 
+				comm = MPI.COMM_NULL # dummy value 
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "chebyshev_pseudospectral", fd_option, bc, adv_input, comm)
@@ -956,7 +957,7 @@ function runtests()
                 nelement_local = nelement
 				nrank_per_block = 0 # dummy value
 				irank = 0 # dummy value
-				comm = false # dummy value
+				comm = MPI.COMM_NULL # dummy value
 				input = grid_input("coord", ngrid, nelement,
                     nelement_local, nrank_per_block, irank, L,
                     "chebyshev_pseudospectral", fd_option, bc, adv_input, comm)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -8,6 +8,8 @@ using moment_kinetics.chebyshev: setup_chebyshev_pseudospectral
 using moment_kinetics.interpolation:
     interpolate_to_grid_1d, interpolate_to_grid_z, interpolate_to_grid_vpa
 
+using MPI
+
 fd_fake_setup(z) = return false
 
 # periodic test function
@@ -37,7 +39,7 @@ function runtests()
 			nelement_local = nelement
 			nrank_per_block = 0 # dummy value
 			irank = 0 # dummy value
-			comm = false # dummy value 
+			comm = MPI.COMM_NULL # dummy value 
 			input = grid_input("coord", ngrid, nelement,
 				nelement_local, nrank_per_block, irank, L,
 				discretization, fd_option, bc, adv_input, comm)

--- a/test/nonlinear_sound_wave_tests.jl
+++ b/test/nonlinear_sound_wave_tests.jl
@@ -3,6 +3,7 @@ module NonlinearSoundWaveTests
 include("setup.jl")
 
 using Base.Filesystem: tempname
+using MPI
 using TimerOutputs
 
 using moment_kinetics.chebyshev: setup_chebyshev_pseudospectral
@@ -306,7 +307,7 @@ function run_test(test_input, rtol; args...)
         adv_input = advection_input("default", 1.0, 0.0, 0.0)
         nrank_per_block = 0 # dummy value
 		irank = 0 # dummy value
-		comm = false # dummy value 
+		comm = MPI.COMM_NULL # dummy value 
 		input = grid_input("coord", test_input["z_ngrid"], test_input["z_nelement"], 
                            test_input["z_nelement"], nrank_per_block, irank,
 						   z_L, test_input["z_discretization"], "",

--- a/test/wall_bc_tests.jl
+++ b/test/wall_bc_tests.jl
@@ -6,6 +6,7 @@ module WallBC
 include("setup.jl")
 
 using Base.Filesystem: tempname
+using MPI
 using TimerOutputs
 
 using moment_kinetics.chebyshev: setup_chebyshev_pseudospectral
@@ -186,7 +187,7 @@ function run_test(test_input, expected_phi, tolerance; args...)
         adv_input = advection_input("default", 1.0, 0.0, 0.0)
 		nrank_per_block = 0 # dummy value
 		irank = 0 # dummy value
-		comm = false # dummy value 
+		comm = MPI.COMM_NULL # dummy value 
         input = grid_input("coord", test_input["z_ngrid"], test_input["z_nelement"], 
 						   test_input["z_nelement"], nrank_per_block, irank, 1.0,
                            test_input["z_discretization"], "", test_input["z_bc"],


### PR DESCRIPTION
Implementation of parallel I/O for the HDF5 output interface.

* Parallel output is now the default if it is supported by the back-end.
* Parallel I/O requires the linked HDF5 library to have been compiled with MPI - the same MPI as is used to run `moment_kinetics`. See notes in `README.md`.