### PR TITLE
Close output files when not reading/writing

### DIFF
--- a/src/file_io_netcdf.jl
+++ b/src/file_io_netcdf.jl
@@ -7,17 +7,17 @@ function io_has_parallel(::Val{netcdf})
     return false
 end
 
-function open_output_file_netcdf(prefix, parallel_io, io_comm)
+function open_output_file_netcdf(prefix, parallel_io, io_comm, mode="c")
     parallel_io && error("NetCDF interface does not support parallel I/O")
 
     # the netcdf file will be given by output_dir/run_name with .cdf appended
     filename = string(prefix, ".cdf")
     # if a netcdf file with the requested name already exists, remove it
-    isfile(filename) && rm(filename)
+    mode == "c" && isfile(filename) && rm(filename)
     # create the new NetCDF file
-    fid = NCDataset(filename,"c")
+    fid = NCDataset(filename, mode)
 
-    return fid
+    return fid, (filename, parallel_io, io_comm)
 end
 
 function create_io_group(parent::NCDataset, name; description=nothing)

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -410,9 +410,7 @@ end
 """
 Clean up after a run
 """
-function cleanup_moment_kinetics!(ascii_io::Union{file_io.ascii_ios,Nothing},
-                                  io_moments::Union{file_io.io_moments_info,Nothing},
-                                  io_dfns::Union{file_io.io_dfns_info,Nothing})
+function cleanup_moment_kinetics!(ascii_io, io_moments, io_dfns)
     @debug_detect_redundant_block_synchronize begin
         # Disable check for redundant _block_synchronize() during finalization, as this
         # only runs once so any failure is not important.


### PR DESCRIPTION
Previously, when a simulation crashed it would corrupt the output files. Prevent this by closing the output files once writing of one step is finished, and re-open them each output step.

It would be easy to make this feature something we could switch on/off with an input option, but unless opening the HDF5/NetCDF files becomes a significant performance bottleneck I think this new version is just better, so no need to add another input parameter.
If we did want to implement, all that should need to be done is to, if the switch is set, return the I/O info structs (like it was before this PR) from `setup_file_io()` instead of filenames. Everything else should 'just work'.