### PR TITLE
Increase memory limit for precompile job on archer

### DIFF
--- a/machines/archer/jobscript-precompile.template
+++ b/machines/archer/jobscript-precompile.template
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --mem=16G
+#SBATCH --mem=64G
 #SBATCH --time=1:00:00
 #SBATCH --account=ACCOUNT
 #SBATCH --partition=serial


### PR DESCRIPTION
The 16GB limit was leading to out-of-memory errors when precompiling with julia-1.8.5 (although not with julia-1.9.2), so increase limit to 64GB.