### PR TITLE
A generalised kinetic Chodura condition with radial dependence

### DIFF
--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -1044,14 +1044,14 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
         if z.irank == 0 # lower wall 
             append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower, t_idx, r,
                               n_ion_species)
-        else
+        elseif io_moments.chodura_integral_lower !== nothing
             append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower, t_idx, 0,
                               n_ion_species)
         end
         if z.irank == z.nrank - 1 # upper wall
             append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper, t_idx, r,
                               n_ion_species)
-        else
+        elseif io_moments.chodura_integral_upper !== nothing
             append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper, t_idx, 0,
                               n_ion_species)
         end

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -44,7 +44,7 @@ end
 structure containing the data/metadata needed for binary file i/o
 moments & fields only
 """
-struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Tchodura, Texti1, Texti2, Textn1, Textn2}
+struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Tchodura_lower, Tchodura_upper, Texti1, Texti2, Textn1, Textn2}
     # file identifier for the binary file to which data is written
     fid::Tfile
     # handle for the time variable
@@ -68,9 +68,9 @@ struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Tchodura, Texti1, Texti
     # handle for the charged species thermal speed
     thermal_speed::Tmomi
     # handle for chodura diagnostic (lower)
-    chodura_integral_lower::Tchodura
+    chodura_integral_lower::Tchodura_lower
     # handle for chodura diagnostic (upper)
-    chodura_integral_upper::Tchodura
+    chodura_integral_upper::Tchodura_upper
     # handle for the neutral species density
     density_neutral::Tmomn
     uz_neutral::Tmomn
@@ -626,21 +626,27 @@ function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
                                           parallel_io=parallel_io,
                                           description="charged species thermal speed",
                                           units="c_ref")
-
-        # io_chodura_lower is the handle for the ion thermal speed
-        io_chodura_lower = create_dynamic_variable!(dynamic, "chodura_integral_lower", mk_float, r;
-                                          n_ion_species=n_ion_species,
-                                          parallel_io=parallel_io,
-                                          description="Generalised Chodura integral lower sheath entrance",
-                                          units="c_ref")
-
-        # io_chodura_upper is the handle for the ion thermal speed
-        io_chodura_upper = create_dynamic_variable!(dynamic, "chodura_integral_upper", mk_float, r;
-                                          n_ion_species=n_ion_species,
-                                          parallel_io=parallel_io,
-                                          description="Generalised Chodura integral upper sheath entrance",
-                                          units="c_ref")
-
+        
+        if parallel_io || z.irank == 0
+            # io_chodura_lower is the handle for the ion thermal speed
+            io_chodura_lower = create_dynamic_variable!(dynamic, "chodura_integral_lower", mk_float, r;
+                                              n_ion_species=n_ion_species,
+                                              parallel_io=parallel_io,
+                                              description="Generalised Chodura integral lower sheath entrance",
+                                              units="c_ref")
+        else
+            io_chodura_lower = nothing
+        end
+        if parallel_io || z.irank == z.nrank - 1
+            # io_chodura_upper is the handle for the ion thermal speed
+            io_chodura_upper = create_dynamic_variable!(dynamic, "chodura_integral_upper", mk_float, r;
+                                              n_ion_species=n_ion_species,
+                                              parallel_io=parallel_io,
+                                              description="Generalised Chodura integral upper sheath entrance",
+                                              units="c_ref")
+        else
+            io_chodura_upper = nothing
+        end
         # io_density_neutral is the handle for the neutral particle density
         io_density_neutral = create_dynamic_variable!(dynamic, "density_neutral", mk_float, z, r;
                                                       n_neutral_species=n_neutral_species,
@@ -1035,10 +1041,20 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
                               z, r, n_ion_species)
         append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth, t_idx, z, r,
                               n_ion_species)
-        append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower, t_idx, r,
+        if z.irank == 0 # lower wall 
+            append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower, t_idx, r,
                               n_ion_species)
-        append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper, t_idx, r,
+        else
+            append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower, t_idx, 0,
                               n_ion_species)
+        end
+        if z.irank == z.nrank - 1 # upper wall
+            append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper, t_idx, r,
+                              n_ion_species)
+        else
+            append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper, t_idx, 0,
+                              n_ion_species)
+        end
         if io_moments.external_source_amplitude !== nothing
             append_to_dynamic_var(io_moments.external_source_amplitude,
                                   moments.charged.external_source_amplitude, t_idx, z, r)

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -44,7 +44,7 @@ end
 structure containing the data/metadata needed for binary file i/o
 moments & fields only
 """
-struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Texti1, Texti2, Textn1, Textn2}
+struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Tchodura, Texti1, Texti2, Textn1, Textn2}
     # file identifier for the binary file to which data is written
     fid::Tfile
     # handle for the time variable
@@ -67,7 +67,10 @@ struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Texti1, Texti2, Textn1,
     parallel_heat_flux::Tmomi
     # handle for the charged species thermal speed
     thermal_speed::Tmomi
-
+    # handle for chodura diagnostic (lower)
+    chodura_integral_lower::Tchodura
+    # handle for chodura diagnostic (upper)
+    chodura_integral_upper::Tchodura
     # handle for the neutral species density
     density_neutral::Tmomn
     uz_neutral::Tmomn
@@ -624,6 +627,20 @@ function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
                                           description="charged species thermal speed",
                                           units="c_ref")
 
+        # io_chodura_lower is the handle for the ion thermal speed
+        io_chodura_lower = create_dynamic_variable!(dynamic, "chodura_integral_lower", mk_float, r;
+                                          n_ion_species=n_ion_species,
+                                          parallel_io=parallel_io,
+                                          description="Generalised Chodura integral lower sheath entrance",
+                                          units="c_ref")
+
+        # io_chodura_upper is the handle for the ion thermal speed
+        io_chodura_upper = create_dynamic_variable!(dynamic, "chodura_integral_upper", mk_float, r;
+                                          n_ion_species=n_ion_species,
+                                          parallel_io=parallel_io,
+                                          description="Generalised Chodura integral upper sheath entrance",
+                                          units="c_ref")
+
         # io_density_neutral is the handle for the neutral particle density
         io_density_neutral = create_dynamic_variable!(dynamic, "density_neutral", mk_float, z, r;
                                                       n_neutral_species=n_neutral_species,
@@ -714,7 +731,7 @@ function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
         end
 
         return io_moments_info(fid, io_time, io_phi, io_Er, io_Ez, io_density, io_upar,
-                               io_ppar, io_pperp, io_qpar, io_vth, io_density_neutral, io_uz_neutral,
+                               io_ppar, io_pperp, io_qpar, io_vth, io_chodura_lower, io_chodura_upper, io_density_neutral, io_uz_neutral,
                                io_pz_neutral, io_qz_neutral, io_thermal_speed_neutral,
                                external_source_amplitude,
                                external_source_controller_integral,
@@ -860,7 +877,8 @@ function reopen_moments_io(file_info)
                                getvar("Ez"), getvar("density"), getvar("parallel_flow"),
                                getvar("parallel_pressure"), getvar("perpendicular_pressure"),
                                getvar("parallel_heat_flux"),
-                               getvar("thermal_speed"), getvar("density_neutral"),
+                               getvar("thermal_speed"), getvar("chodura_integral_lower"),
+                               getvar("chodura_integral_upper"), getvar("density_neutral"),
                                getvar("uz_neutral"), getvar("pz_neutral"),
                                getvar("qz_neutral"), getvar("thermal_speed_neutral"),
                                getvar("external_source_amplitude"),
@@ -951,7 +969,8 @@ function reopen_dfns_io(file_info)
                                      getvar("parallel_flow"), getvar("parallel_pressure"),
                                      getvar("perpendicular_pressure"),
                                      getvar("parallel_heat_flux"),
-                                     getvar("thermal_speed"), getvar("density_neutral"),
+                                     getvar("thermal_speed"), getvar("chodura_integral_lower"),
+                                     getvar("chodura_integral_upper"), getvar("density_neutral"),
                                      getvar("uz_neutral"), getvar("pz_neutral"),
                                      getvar("qz_neutral"),
                                      getvar("thermal_speed_neutral"),
@@ -1015,6 +1034,10 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
         append_to_dynamic_var(io_moments.parallel_heat_flux, moments.charged.qpar, t_idx,
                               z, r, n_ion_species)
         append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth, t_idx, z, r,
+                              n_ion_species)
+        append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower, t_idx, r,
+                              n_ion_species)
+        append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper, t_idx, r,
                               n_ion_species)
         if io_moments.external_source_amplitude !== nothing
             append_to_dynamic_var(io_moments.external_source_amplitude,
@@ -1137,6 +1160,10 @@ end
                                   moments.charged.qpar.data, t_idx, z, r, n_ion_species)
             append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth.data,
                                   t_idx, z, r, n_ion_species)
+            append_to_dynamic_var(io_moments.chodura_integral_lower, moments.charged.chodura_integral_lower.data,
+                                  t_idx, r, n_ion_species)
+            append_to_dynamic_var(io_moments.chodura_integral_upper, moments.charged.chodura_integral_upper.data,
+                                  t_idx, r, n_ion_species)
             if io_moments.external_source_amplitude !== nothing
                 append_to_dynamic_var(io_moments.external_source_amplitude,
                                       moments.charged.external_source_amplitude.data,

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -470,6 +470,8 @@ struct pp_input
     plot_parallel_temperature_vs_r_z::Bool
     # if animate_parallel_temperature_vs_r_z = true animate parallel_temperature vs r z
     animate_parallel_temperature_vs_r_z::Bool
+    # if plot_chodura_integral = true then plots of the in-simulation Chodura integrals are generated
+    plot_chodura_integral::Bool
     # if plot_wall_pdf = true then plot the ion distribution (vpa,vperp,z,r) in the element nearest the wall at the last timestep 
     plot_wall_pdf::Bool
     # run analysis for a 2D (in R-Z) linear mode?

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -379,12 +379,14 @@ function load_rank_data(fid; printout=false)
     coords = get_group(fid, "coords")
     z_irank = load_variable(get_group(coords, "z"), "irank")
     r_irank = load_variable(get_group(coords, "r"), "irank")
+    z_nrank = load_variable(get_group(coords, "z"), "nrank")
+    r_nrank = load_variable(get_group(coords, "r"), "nrank")
     
     if printout
         println("done.")
     end
 
-    return z_irank, r_irank
+    return z_irank, z_nrank, r_irank, r_nrank
 end
 
 """
@@ -1867,7 +1869,7 @@ function load_distributed_charged_pdf_slice(run_names::Tuple, nblocks::Tuple, t_
         for iblock in 0:nb-1
             fid = open_readonly_output_file(run_name, "dfns", iblock=iblock, printout=false)
 
-            z_irank, r_irank = load_rank_data(fid)
+            z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid)
 
             # max index set to avoid double assignment of repeated points
             # nr/nz if irank = nrank-1, (nr-1)/(nz-1) otherwise
@@ -2082,7 +2084,7 @@ function load_distributed_neutral_pdf_slice(run_names::Tuple, nblocks::Tuple, t_
         for iblock in 0:nb-1
             fid = open_readonly_output_file(run_name, "dfns", iblock=iblock, printout=false)
 
-            z_irank, r_irank = load_rank_data(fid)
+            z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid)
 
             # max index set to avoid double assignment of repeated points
             # nr/nz if irank = nrank-1, (nr-1)/(nz-1) otherwise

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -682,6 +682,10 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
             moments.charged.qpar .= load_moment("parallel_heat_flux")
             moments.charged.qpar_updated .= true
             moments.charged.vth .= load_moment("thermal_speed")
+                moments.charged.chodura_integral_lower .= load_slice(dynamic, "chodura_integral_lower",
+                                                  r_range, :, time_index)
+                moments.charged.chodura_integral_upper .= load_slice(dynamic, "chodura_integral_upper",
+                                                  r_range, :, time_index)
 
             if "external_source_controller_integral" ∈ get_variable_keys(dynamic) &&
                     length(moments.charged.external_source_controller_integral) == 1
@@ -956,7 +960,18 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
             end
 
             pdf.charged.norm .= load_charged_pdf()
-
+                if z.irank == 0
+                    moments.charged.chodura_integral_lower .= load_slice(dynamic, "chodura_integral_lower", :, :,
+                                                  time_index)
+                else
+                    moments.charged.chodura_integral_lower .= 0.0
+                end
+                if z.irank == z.nrank - 1
+                    moments.charged.chodura_integral_upper .= load_slice(dynamic, "chodura_integral_upper", :, :,
+                                                  time_index)
+                else
+                    moments.charged.chodura_integral_upper .= 0.0
+                end
             boundary_distributions_io = get_group(fid, "boundary_distributions")
 
             function load_charged_boundary_pdf(var_name, ir)

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -123,7 +123,7 @@ function trygif(anim, outfile; kwargs...)
 end
 
 """
-Read data
+Read data which is a function of (z,r,t) or (z,r,species,t)
 
 run_names is a tuple. If it has more than one entry, this means that there are multiple
 restarts (which are sequential in time), so concatenate the data from each entry together.
@@ -167,7 +167,7 @@ function read_distributed_zr_data!(var::Array{mk_float,N}, var_name::String,
             local_tind_end = local_tind_start + ntime_local - 1
             global_tind_end = global_tind_start + length(offset:iskip:ntime_local) - 1
 
-            z_irank, r_irank = load_rank_data(fid)
+            z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid)
 
             # min index set to avoid double assignment of repeated points
             # 1 if irank = 0, 2 otherwise
@@ -2995,7 +2995,7 @@ function compare_charged_pdf_symbolic_test(run_name,manufactured_solns_list,spec
     pdf_norm = zeros(mk_float,ntime)
     for iblock in 0:nblocks-1
         fid_pdfs = open_readonly_output_file(run_name,"dfns",iblock=iblock, printout=false)
-        z_irank, r_irank = load_rank_data(fid_pdfs,printout=false)
+        z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid_pdfs,printout=false)
         pdf = load_pdf_data(fid_pdfs, printout=false)
         # local local grid data on iblock=0
         z_local, _ = load_coordinate_data(fid_pdfs, "z")
@@ -3020,10 +3020,10 @@ function compare_charged_pdf_symbolic_test(run_name,manufactured_solns_list,spec
 
     # plot distribution at lower wall boundary
     # find the number of ranks
-    z_nrank, r_nrank = get_nranks(run_name,nblocks,"dfns")
+    #z_nrank, r_nrank = get_nranks(run_name,nblocks,"dfns")
     for iblock in 0:nblocks-1
         fid_pdfs = open_readonly_output_file(run_name,"dfns",iblock=iblock, printout=false)
-        z_irank, r_irank = load_rank_data(fid_pdfs,printout=false)
+        z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid_pdfs,printout=false)
         if (z_irank == 0 || z_irank == z_nrank - 1) && r_irank == 0
             pdf = load_pdf_data(fid_pdfs, printout=false)
             # local local grid data on iblock=0
@@ -3077,7 +3077,7 @@ function compare_neutral_pdf_symbolic_test(run_name,manufactured_solns_list,spec
     pdf_norm = zeros(mk_float,ntime)
     for iblock in 0:nblocks-1
         fid_pdfs = open_readonly_output_file(run_name,"dfns",iblock=iblock, printout=false)
-        z_irank, r_irank = load_rank_data(fid_pdfs,printout=false)
+        z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid_pdfs,printout=false)
         pdf = load_neutral_pdf_data(fid_pdfs, printout=false)
         # load local grid data
         z_local, _ = load_coordinate_data(fid_pdfs, "z", printout=false)

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -193,6 +193,77 @@ function read_distributed_zr_data!(var::Array{mk_float,N}, var_name::String,
     end
 end
 
+"""
+Read data which is a function of (r,t) or (r,species,t) and associated to one of the wall boundaries
+
+run_names is a tuple. If it has more than one entry, this means that there are multiple
+restarts (which are sequential in time), so concatenate the data from each entry together.
+"""
+function read_distributed_zwallr_data!(var::Array{mk_float,N}, var_name::String,
+   run_names::Tuple, file_key::String, nblocks::Tuple,
+   nr_local::mk_int,iskip::mk_int,wallopt::String) where N
+    # dimension of var is [z,r,species,t]
+
+    local_tind_start = 1
+    local_tind_end = -1
+    global_tind_start = 1
+    global_tind_end = -1
+    for (run_name, nb) in zip(run_names, nblocks)
+        for iblock in 0:nb-1
+            fid = open_readonly_output_file(run_name,file_key,iblock=iblock,printout=false)
+            z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid)
+            # determine if data is on this block
+            if (wallopt == "lower" && z_irank == 0) || (wallopt == "upper" && z_irank == z_nrank - 1)
+                group = get_group(fid, "dynamic_data")
+                var_local = load_variable(group, var_name)
+
+                ntime_local = size(var_local, N)
+
+                # offset is the amount we have to skip at the beginning of this restart to
+                # line up properly with having outputs every iskip since the beginning of the
+                # first restart.
+                # Note: use rem(x,y,RoundDown) here because this gives a result that's
+                # definitely between 0 and y, whereas rem(x,y) or mod(x,y) give negative
+                # results for negative x.
+                offset = rem(1 - (local_tind_start-1), iskip, RoundDown)
+                if offset == 0
+                    # Actually want offset in the range [1,iskip], so correct if rem()
+                    # returned 0
+                    offset = iskip
+                end
+                if local_tind_start > 1
+                    # The run being loaded is a restart (as local_tind_start=1 for the first
+                    # run), so skip the first point, as this is a duplicate of the last point
+                    # of the previous restart
+                    offset += 1
+                end
+
+                local_tind_end = local_tind_start + ntime_local - 1
+                global_tind_end = global_tind_start + length(offset:iskip:ntime_local) - 1
+
+            #z_irank, z_nrank, r_irank, r_nrank = load_rank_data(fid)
+            #if (wallopt == "lower" && z_irank == 0) || (wallopt == "upper" && z_irank == z_nrank - 1)
+                # min index set to avoid double assignment of repeated points
+                # 1 if irank = 0, 2 otherwise
+                imin_r = min(1,r_irank) + 1
+                for ir_local in imin_r:nr_local
+                        ir_global = iglobal_func(ir_local,r_irank,nr_local)
+                        if N == 3
+                            var[ir_global,:,global_tind_start:global_tind_end] .= var_local[ir_local,:,offset:iskip:end]
+                        elseif N == 2
+                            var[ir_global,global_tind_start:global_tind_end] .= var_local[ir_local,offset:iskip:end]
+                        else
+                            error("Unsupported number of dimensions: $N")
+                        end
+                end
+            end
+            close(fid)
+        end
+        local_tind_start = local_tind_end + 1
+        global_tind_start = global_tind_end + 1
+    end
+end
+
 function construct_global_zr_coords(r_local, z_local)
 
     function make_global_input(coord_local)
@@ -226,7 +297,9 @@ function allocate_global_zr_charged_moments(nz_global,nr_global,n_ion_species,nt
     perpendicular_pressure = allocate_float(nz_global,nr_global,n_ion_species,ntime)
     parallel_heat_flux = allocate_float(nz_global,nr_global,n_ion_species,ntime)
     thermal_speed = allocate_float(nz_global,nr_global,n_ion_species,ntime)
-    return density, parallel_flow, parallel_pressure, perpendicular_pressure, parallel_heat_flux, thermal_speed
+    chodura_integral_lower = allocate_float(nr_global,n_ion_species,ntime)
+    chodura_integral_upper = allocate_float(nr_global,n_ion_species,ntime)
+    return density, parallel_flow, parallel_pressure, perpendicular_pressure, parallel_heat_flux, thermal_speed, chodura_integral_lower, chodura_integral_upper
 end
 
 function allocate_global_zr_charged_dfns(nvpa_global, nvperp_global, nz_global, nr_global,
@@ -489,7 +562,7 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
                                              Tuple(this_z.n_global for this_z ∈ z),
                                              Tuple(this_r.n_global for this_r ∈ r),
                                              ntime)
-    density, parallel_flow, parallel_pressure, perpendicular_pressure, parallel_heat_flux, thermal_speed =
+    density, parallel_flow, parallel_pressure, perpendicular_pressure, parallel_heat_flux, thermal_speed, chodura_integral_lower, chodura_integral_upper =
         get_tuple_of_return_values(allocate_global_zr_charged_moments,
                                    Tuple(this_z.n_global for this_z ∈ z),
                                    Tuple(this_r.n_global for this_r ∈ r),
@@ -544,6 +617,12 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
                                run_names, "moments", nblocks,
                                Tuple(this_z.n for this_z ∈ z),
                                Tuple(this_r.n for this_r ∈ r), iskip)
+    get_tuple_of_return_values(read_distributed_zwallr_data!, chodura_integral_lower, "chodura_integral_lower",
+                               run_names, "moments", nblocks,
+                               Tuple(this_r.n for this_r ∈ r), iskip, "lower")
+    get_tuple_of_return_values(read_distributed_zwallr_data!, chodura_integral_upper, "chodura_integral_upper",
+                               run_names, "moments", nblocks,
+                               Tuple(this_r.n for this_r ∈ r), iskip, "upper")
     # neutral particle moments
     if has_neutrals
         get_tuple_of_return_values(read_distributed_zr_data!, neutral_density,
@@ -599,7 +678,8 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
                                    Tuple(this_z.n_global for this_z ∈ z),
                                    Tuple(this_r.n_global for this_r ∈ r), ntime_pdfs)
     density_at_pdf_times, parallel_flow_at_pdf_times, parallel_pressure_at_pdf_times,
-    parallel_heat_flux_at_pdf_times, thermal_speed_at_pdf_times =
+    parallel_heat_flux_at_pdf_times, thermal_speed_at_pdf_times, chodura_integral_lower_at_pdf_times,
+    chodura_integral_upper_at_pdf_times =
         get_tuple_of_return_values(allocate_global_zr_charged_moments,
                                    Tuple(this_z.n_global for this_z ∈ z),
                                    Tuple(this_r.n_global for this_r ∈ r), n_ion_species,
@@ -646,6 +726,12 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
                                "thermal_speed", run_names, "dfns", nblocks,
                                Tuple(this_z.n for this_z ∈ z),
                                Tuple(this_r.n for this_r ∈ r), iskip_pdfs)
+    get_tuple_of_return_values(read_distributed_zwallr_data!, chodura_integral_lower_at_pdf_times, "chodura_integral_lower",
+                               run_names, "dfns", nblocks,
+                               Tuple(this_r.n for this_r ∈ r), iskip, "lower")
+    get_tuple_of_return_values(read_distributed_zwallr_data!, chodura_integral_upper_at_pdf_times, "chodura_integral_upper",
+                               run_names, "dfns", nblocks,
+                               Tuple(this_r.n for this_r ∈ r), iskip, "upper")
     # neutral particle moments
     if has_neutrals
         get_tuple_of_return_values(read_distributed_zr_data!,
@@ -1020,6 +1106,8 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
     perpendicular_pressure = perpendicular_pressure[1]
     parallel_heat_flux = parallel_heat_flux[1]
     thermal_speed = thermal_speed[1]
+    chodura_integral_lower = chodura_integral_lower[1]
+    chodura_integral_upper = chodura_integral_upper[1]
     time = time[1]
     ntime = ntime[1]
     time_pdfs = time_pdfs[1]
@@ -1058,7 +1146,8 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
 
     if !is_1D1V
         # make plots and animations of the phi, Ez and Er
-        plot_charged_moments_2D(density, parallel_flow, parallel_pressure, time,
+        plot_charged_moments_2D(density, parallel_flow, parallel_pressure, 
+                                chodura_integral_lower, chodura_integral_upper, time,
                                 z_global.grid, r_global.grid, iz0, ir0, n_ion_species,
                                 itime_min, itime_max, nwrite_movie, run_name_label, pp)
         # make plots and animations of the phi, Ez and Er
@@ -1265,7 +1354,8 @@ function calculate_differences(prefix...)
                                              Tuple(this_z.n_global for this_z ∈ z),
                                              Tuple(this_r.n_global for this_r ∈ r),
                                              ntime)
-    density, parallel_flow, parallel_pressure, parallel_heat_flux, thermal_speed =
+    density, parallel_flow, parallel_pressure, parallel_heat_flux, thermal_speed,
+    chodura_integral_lower, chodura_integral_upper =
         get_tuple_of_return_values(allocate_global_zr_charged_moments,
                                    Tuple(this_z.n_global for this_z ∈ z),
                                    Tuple(this_r.n_global for this_r ∈ r),
@@ -1369,7 +1459,8 @@ function calculate_differences(prefix...)
                                    Tuple(this_z.n_global for this_z ∈ z),
                                    Tuple(this_r.n_global for this_r ∈ r), ntime_pdfs)
     density_at_pdf_times, parallel_flow_at_pdf_times, parallel_pressure_at_pdf_times,
-    parallel_heat_flux_at_pdf_times, thermal_speed_at_pdf_times =
+    parallel_heat_flux_at_pdf_times, thermal_speed_at_pdf_times, chodura_integral_lower_at_pdf_times,
+    chodura_integral_upper_at_pdf_times =
         get_tuple_of_return_values(allocate_global_zr_charged_moments,
                                    Tuple(this_z.n_global for this_z ∈ z),
                                    Tuple(this_r.n_global for this_r ∈ r), n_ion_species,
@@ -3423,7 +3514,8 @@ function plot_fields_2D(phi, Ez, Er, time, z, r, iz0, ir0,
     println("done.")
 end
 
-function plot_charged_moments_2D(density, parallel_flow, parallel_pressure, time, z, r, iz0, ir0, n_ion_species,
+function plot_charged_moments_2D(density, parallel_flow, parallel_pressure, 
+    chodura_integral_lower, chodura_integral_upper, time, z, r, iz0, ir0, n_ion_species,
     itime_min, itime_max, nwrite_movie, run_name, pp)
     nr = size(r,1)
     print("Plotting charged moments data...")
@@ -3540,6 +3632,23 @@ function plot_charged_moments_2D(density, parallel_flow, parallel_pressure, time
                     outfile = string(run_name, "_temperature"*description*"_vs_r_z.pdf")
                     trysavefig(outfile)
                 end
+        if pp.plot_chodura_integral
+            # plot the Chodura condition integrals calculated at run time 
+            @views plot(r, chodura_integral_lower[:,is,end], xlabel=L"r/L_r", ylabel="", label = "Chodura lower")
+            outfile = string(run_name, "_chodura_integral_lower"*description*"_vs_r.pdf")
+            trysavefig(outfile)
+            @views heatmap(time, r, chodura_integral_lower[:,is,:], xlabel=L"t", ylabel=L"r", c = :deep, interpolation = :cubic,
+                              windowsize = (360,240), margin = 15pt)
+            outfile = string(run_name, "_chodura_integral_lower"*description*"_vs_r_t.pdf")
+            trysavefig(outfile)
+            @views plot(r, chodura_integral_upper[:,is,end], xlabel=L"r/L_r", ylabel="", label = "Chodura upper")
+            outfile = string(run_name, "_chodura_integral_upper"*description*"_vs_r.pdf")
+            trysavefig(outfile)
+            @views heatmap(time, r, chodura_integral_upper[:,is,:], xlabel=L"t", ylabel=L"r", c = :deep, interpolation = :cubic,
+                              windowsize = (360,240), margin = 15pt)
+            outfile = string(run_name, "_chodura_integral_upper"*description*"_vs_r_t.pdf")
+            trysavefig(outfile)
+        end
 	end
     println("done.")
 end

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -3456,6 +3456,11 @@ function plot_fields_2D(phi, Ez, Er, time, z, r, iz0, ir0,
         end
         outfile = string(run_name, "_phi"*description*"_vs_r_z.gif")
         trygif(anim, outfile, fps=5)
+        anim = @animate for i ∈ itime_min:nwrite_movie:itime_max
+            @views plot(r, phi[1,:,i], xlabel="r", ylabel=L"\widetilde{\phi}", ylims = (phimin,phimax))
+        end
+        outfile = string(run_name, "_phi(zwall-)_vs_r.gif")
+        trygif(anim, outfile, fps=5)
     elseif pp.animate_phi_vs_r_z && nr == 1 # make a gif animation of ϕ(z) at different times
         anim = @animate for i ∈ itime_min:nwrite_movie:itime_max
             @views plot(z, phi[:,1,i], xlabel="z", ylabel=L"\widetilde{\phi}", ylims = (phimin,phimax))
@@ -3471,8 +3476,8 @@ function plot_fields_2D(phi, Ez, Er, time, z, r, iz0, ir0,
         trysavefig(outfile)
     end
     if pp.plot_wall_Ez_vs_r && nr > 1 # plot last timestep Ez[z_wall,r]
-        @views plot(r, Ez[end,:,end], xlabel=L"r/L_r", ylabel=L"E_z")
-        outfile = string(run_name, "_Ez"*description*"(r,z_wall)_vs_r.pdf")
+        @views plot(r, Ez[1,:,end], xlabel=L"r/L_r", ylabel=L"E_z")
+        outfile = string(run_name, "_Ez"*description*"(r,z_wall-)_vs_r.pdf")
         trysavefig(outfile)
     end
     if pp.animate_Ez_vs_r_z && nr > 1
@@ -3482,9 +3487,12 @@ function plot_fields_2D(phi, Ez, Er, time, z, r, iz0, ir0,
         end
         outfile = string(run_name, "_Ez"*description*"_vs_r_z.gif")
         trygif(anim, outfile, fps=5)
+        anim = @animate for i ∈ itime_min:nwrite_movie:itime_max
+            @views plot(r, Ez[1,:,i], xlabel="r", ylabel=L"\widetilde{E}_z", ylims = (Ezmin,Ezmax))
+        end
+        outfile = string(run_name, "_Ez(zwall-)_vs_r.gif")
+        trygif(anim, outfile, fps=5)
     elseif pp.animate_Ez_vs_r_z && nr == 1
-        Ezmin = minimum(Ez)
-        Ezmax = maximum(Ez)
         anim = @animate for i ∈ itime_min:nwrite_movie:itime_max
             @views plot(z, Ez[:,1,i], xlabel="z", ylabel=L"\widetilde{E}_z", ylims = (Ezmin,Ezmax))
         end
@@ -3499,9 +3507,14 @@ function plot_fields_2D(phi, Ez, Er, time, z, r, iz0, ir0,
         trysavefig(outfile)
     end
     if pp.plot_wall_Er_vs_r && nr > 1 # plot last timestep Er[z_wall,r]
-        @views plot(r, Er[end,:,end], xlabel=L"r/L_r", ylabel=L"E_r")
-        outfile = string(run_name, "_Er"*description*"(r,z_wall)_vs_r.pdf")
+        @views plot(r, Er[1,:,end], xlabel=L"r/L_r", ylabel=L"E_r")
+        outfile = string(run_name, "_Er"*description*"(r,z_wall-)_vs_r.pdf")
         trysavefig(outfile)
+        anim = @animate for i ∈ itime_min:nwrite_movie:itime_max
+            @views plot(r, Er[1,:,i], xlabel="r", ylabel=L"\widetilde{E}_r", ylims = (Ermin,Ermax))
+        end
+        outfile = string(run_name, "_Er(zwall-)_vs_r.gif")
+        trygif(anim, outfile, fps=5)
     end
     if pp.animate_Er_vs_r_z && nr > 1
         # make a gif animation of ϕ(z) at different times

--- a/src/post_processing_input.jl
+++ b/src/post_processing_input.jl
@@ -109,6 +109,7 @@ const plot_parallel_temperature_vs_r0_z = true # plot last timestep parallel_tem
 const plot_wall_parallel_temperature_vs_r = true # plot last timestep parallel_temperature[z_wall,r]
 const plot_parallel_temperature_vs_r_z = true
 const animate_parallel_temperature_vs_r_z = true
+const plot_chodura_integral = true
 const plot_wall_pdf = true # plot last time step ion distribution function at the wall and in the element nearest the wall 
 const instability2D = false # run analysis for a 2D (in R-Z) linear mode
 const nwrite_movie = 1
@@ -170,7 +171,8 @@ pp = pp_input(calculate_frequencies, plot_phi0_vs_t, plot_phi_vs_z_t, animate_ph
     plot_parallel_pressure_vs_r0_z, plot_wall_parallel_pressure_vs_r,
     plot_parallel_pressure_vs_r_z, animate_parallel_pressure_vs_r_z,
     plot_parallel_temperature_vs_r0_z, plot_wall_parallel_temperature_vs_r,
-    plot_parallel_temperature_vs_r_z, animate_parallel_temperature_vs_r_z, plot_wall_pdf,
+    plot_parallel_temperature_vs_r_z, animate_parallel_temperature_vs_r_z, 
+    plot_chodura_integral, plot_wall_pdf,
     instability2D, nwrite_movie, itime_min, itime_max, itime_skip, nwrite_movie_pdfs,
     itime_min_pdfs, itime_max_pdfs, itime_skip_pdfs, ivpa0, ivperp0, iz0, ir0, ivz0, ivr0,
     ivzeta0, diagnostics_chodura_t, diagnostics_chodura_r)

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -842,7 +842,7 @@ function update_chodura_integral_species!(ff,dffdr,ff_dummy,vpa,vperp,z,r,compos
         # avoid divide by zero by making sure 
         # we are more than a vpa mimimum grid spacing away from 
         # the vz(vpa,r) = 0 velocity boundary
-        if abs(vz[ivpa,ivperp]) > 2.0*del_vpa
+        if abs(vz[ivpa,ivperp]) > 0.5*del_vpa
             ff_dummy[ivpa,ivperp] = (ff[ivpa,ivperp]*bzed^2/(vz[ivpa,ivperp]^2) + 
                                 geometry.rhostar*dffdr[ivpa,ivperp]/vz[ivpa,ivperp])
         else

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -23,6 +23,7 @@ export update_neutral_pz!
 export update_neutral_pr!
 export update_neutral_pzeta!
 export update_neutral_qz!
+export update_chodura!
 
 # for testing 
 export get_density
@@ -36,6 +37,7 @@ using ..array_allocation: allocate_shared_float, allocate_bool, allocate_float
 using ..calculus: integral
 using ..communication
 using ..derivatives: derivative_z!
+using ..derivatives: derivative_r!
 using ..looping
 
 #global tmpsum1 = 0.0
@@ -78,6 +80,9 @@ struct moments_charged_substruct
     qpar_updated::Vector{Bool}
     # this is the thermal speed based on the parallel temperature Tpar = ppar/dens: vth = sqrt(2*Tpar/m)
     vth::MPISharedArray{mk_float,3}
+    # generalised Chodura integrals for the lower and upper plates
+    chodura_integral_lower::MPISharedArray{mk_float,2}
+    chodura_integral_upper::MPISharedArray{mk_float,2}
     # if evolve_ppar = true, then the velocity variable is (vpa - upa)/vth, which introduces
     # a factor of vth for each power of wpa in velocity space integrals.
     # v_norm_fac accounts for this: it is vth if using the above definition for the parallel velocity,
@@ -211,6 +216,8 @@ function create_moments_charged(nz, nr, n_species, evolve_density, evolve_upar,
     # allocate array of Bools that indicate if the parallel flow is updated for each species
     # allocate array used for the thermal speed
     thermal_speed = allocate_shared_float(nz, nr, n_species)
+    chodura_integral_lower = allocate_shared_float(nr, n_species)
+    chodura_integral_upper = allocate_shared_float(nr, n_species)
     if evolve_ppar
         v_norm_fac = thermal_speed
     else
@@ -286,7 +293,8 @@ function create_moments_charged(nz, nr, n_species, evolve_density, evolve_upar,
     # return struct containing arrays needed to update moments
     return moments_charged_substruct(density, density_updated, parallel_flow,
         parallel_flow_updated, parallel_pressure, parallel_pressure_updated,perpendicular_pressure,
-        parallel_heat_flux, parallel_heat_flux_updated, thermal_speed, v_norm_fac,
+        parallel_heat_flux, parallel_heat_flux_updated, thermal_speed, 
+        chodura_integral_lower, chodura_integral_upper, v_norm_fac,
         ddens_dz_upwind, d2dens_dz2, dupar_dz, dupar_dz_upwind, d2upar_dz2, dppar_dz,
         dppar_dz_upwind, d2ppar_dz2, dqpar_dz, dvth_dz, external_source_amplitude,
         external_source_controller_integral)
@@ -760,6 +768,83 @@ function update_qpar_species!(qpar, density, upar, vth, ff, vpa, vperp, z, r, ev
         end
     end
     return nothing
+end
+
+"""
+runtime diagnostic routine for computing the Chodura ratio
+in a single species plasma with Z = 1
+"""
+
+function update_chodura!(moments,ff,vpa,vperp,z,r,r_spectral,composition,geometry,scratch_dummy,z_advect)
+    @boundscheck composition.n_ion_species == size(ff, 5) || throw(BoundsError(ff))
+    begin_s_z_vperp_vpa_region()
+    dffdr = scratch_dummy.buffer_vpavperpzrs_1
+    ff_dummy = scratch_dummy.buffer_vpavperpzrs_2
+    if r.n > 1
+    # first compute d f / d r using centred reconciliation and place in dummy array #1
+    derivative_r!(dffdr, ff[:,:,:,:,:],
+                  scratch_dummy.buffer_vpavperpzs_1, scratch_dummy.buffer_vpavperpzs_2,
+                  scratch_dummy.buffer_vpavperpzs_3,scratch_dummy.buffer_vpavperpzs_4,
+                  r_spectral,r)
+    else
+        @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
+            dffdr[ivpa,ivperp,iz,ir,is] = 0.0
+        end
+    end 
+    begin_s_r_region()
+    @loop_s_r is ir begin
+        if z.irank == 0
+            @views moments.charged.chodura_integral_lower[ir,is] = update_chodura_integral_species!(ff[:,:,1,ir,is],dffdr[:,:,1,ir,is],
+            ff_dummy[:,:,1,ir,is],vpa,vperp,z,r,composition,geometry,z_advect[is].speed[1,:,:,ir],moments.charged.dens[1,ir,is])
+        else # we do not save this Chodura integral to the output file
+            moments.charged.chodura_integral_lower[ir,is] = 0.0
+        end
+        if z.irank == z.nrank - 1
+            @views moments.charged.chodura_integral_upper[ir,is] = update_chodura_integral_species!(ff[:,:,end,ir,is],dffdr[:,:,end,ir,is],
+            ff_dummy[:,:,end,ir,is],vpa,vperp,z,r,composition,geometry,z_advect[is].speed[end,:,:,ir],moments.charged.dens[end,ir,is])
+        else # we do not save this Chodura integral to the output file
+            moments.charged.chodura_integral_upper[ir,is] =  0.0
+        end
+    end
+end
+"""
+
+compute the integral needed for the generalised Chodura condition
+
+ IChodura = (Z^2 vBohm^2 / cref^2) * int ( f bz^2 / vz^2 + dfdr*rhostar/vz )
+ vBohm = sqrt(Z Te/mi)
+ with Z = 1 and mref = mi
+ cref = sqrt(2Ti/mi)
+and normalise to the local ion density, appropriate to assessing the 
+Chodura condition 
+
+    IChodura <= (Te/e)d ne / dphi |(sheath entrance) = ni
+ to a single species plasma with Z = 1
+
+"""
+function update_chodura_integral_species!(ff,dffdr,ff_dummy,vpa,vperp,z,r,composition,geometry,vz,dens)
+    @boundscheck vpa.n == size(ff, 1) || throw(BoundsError(ff))
+    @boundscheck vperp.n == size(ff, 2) || throw(BoundsError(ff))
+    @boundscheck vpa.n == size(dffdr, 1) || throw(BoundsError(dffdr))
+    @boundscheck vperp.n == size(dffdr, 2) || throw(BoundsError(dffdr))
+    @boundscheck vpa.n == size(ff_dummy, 1) || throw(BoundsError(ff_dummy))
+    @boundscheck vperp.n == size(ff_dummy, 2) || throw(BoundsError(ff_dummy))
+    zero = 1.0e-8
+    bzed = geometry.bzed
+    @loop_vperp_vpa ivperp ivpa begin
+        # avoid divide by zero
+        if abs(vz[ivpa,ivperp]) > zero
+            ff_dummy[ivpa,ivperp] = (ff[ivpa,ivperp]*bzed^2/(vz[ivpa,ivperp]^2) + 
+                                geometry.rhostar*dffdr[ivpa,ivperp]/vz[ivpa,ivperp])
+        else
+            ff_dummy[ivpa,ivperp] = 0.0
+        end
+    end
+    chodura_integral = integrate_over_vspace(@view(ff_dummy[:,:]), vpa.grid, 0, vpa.wgts, vperp.grid, 0, vperp.wgts)
+    # multiply by Te factor from vBohm and divide by the local ion density
+    chodura_integral *= 0.5*composition.T_e/dens
+    #println("chodura_integral: ",chodura_integral)
+    return chodura_integral
 end
 
 """


### PR DESCRIPTION
This PR provides a generalised Chodura condition diagnostic in the main code (see, for example, eqn 104, A. Geraldini Plasma Phys. Control. Fusion 60 (2018) 125002). The output value should be less that 1 for a stable sheath to form at the boundary layer near the wall (outside the simulation domain here). The current version gives the correct result at the initial time for the 1D1V manufactured solution (1/3). The resulting integrals are computed separately at the upper and lower plates and stored as arrays of time and radius. 

Known problems:

-The current file i/o is not consistent with distributed memory MPI. This is because we can only compute the Chodura conditions at the ends of the domain in z, and we should only save the data in the output file that comes from these locations.

-The implementation has only been tested on the standard drift kinetic case with no split moments. 

To do:
- fix the code to be compatible with distributed memory MPI (done)
- test in a time-evolving simulation to check that the treatment of vz ~ 0 is adequate to give finite integrals (done).
- ensure that the implementation can cope with split moments.