### PR TITLE
Calculate and check steady state residuals

### DIFF
--- a/docs/src/input_options.md
+++ b/docs/src/input_options.md
@@ -12,3 +12,15 @@ and a brief description.
 | `base_directory` | "runs" | directory where the simulation data will be stored |
 
 ## Model Options
+
+## Special cases
+
+Some options apply only for certain types of run, etc. These special cases are
+described in the following subsections.
+
+### Steady state runs
+
+| Option name | Default value | Description |
+| :---------- | :------------ | :---------- |
+| `steady_state_residual` | `false` | Set to `true` to print out the maximum residual ``r(t) = \frac{\left\| n(t)-n(t-\delta t)\right\| }{\delta t}`` of the density for each species at each output step |
+| `converged_residual_value` | -1.0 | If `steady_state_residual = true` and `converged_residual_value` is set to a positive value, then the simulation will be stopped if all the density residuals are less than `converged_residual_value`. Note the residuals are only calculated and checked at time steps where output for moment variables is written. |

--- a/docs/src/input_options.md
+++ b/docs/src/input_options.md
@@ -1,11 +1,14 @@
 # Input Options
 
-This page describes the input options that can be specified in moment_kinetics_input.jl.
-The input variable name is given first, followed by its default value and a brief description.
+This page describes the input options that can be specified in `.toml` input
+files.  The input variable name is given first, followed by its default value
+and a brief description.
 
 ## File I/O
 
-`run_name` ::  :: prefix for all output files associated with this run
-`base_directory` :: "runs" :: directory where the simulation data will be stored
+| Option name | Default value | Description |
+| :---------- | :------------ | :---------- |
+| `run_name` |  | prefix for all output files associated with this run, defaults to the name of the input `.toml` file |
+| `base_directory` | "runs" | directory where the simulation data will be stored |
 
 ## Model Options

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -541,14 +541,26 @@ By default runs in serial, but if `use_mpi=true` is passed, assume MPI has been
 initialised, and that `variable` has r and z dimensions but no species dimension, and use
 `@loop_*` macros. In this case the result is returned only on global rank 0. When using
 distributed-memory MPI, this routine will double-count the points on block boundaries.
+
+If `only_max_abs=true` is passed, then only calculate the 'maxium absolute residual'. In
+this case the OrderedDict returned will have only one entry, for `"max absolute
+residual"`.
 """
 function steady_state_residuals(variable, variable_at_previous_time, dt;
-                                epsilon=default_epsilon, use_mpi=false)
+                                epsilon=default_epsilon, use_mpi=false,
+                                only_max_abs=false)
     square_residual_norms =
         steady_state_square_residuals(variable, variable_at_previous_time, dt;
-                                      epsilon=epsilon, use_mpi=use_mpi)
+                                      epsilon=epsilon, use_mpi=use_mpi,
+                                      only_max_abs=only_max_abs)
     if global_rank[] == 0
-        return OrderedDict(k=>sqrt.(v) for (k,v) ∈ square_residual_norms)
+        if only_max_abs
+            # In this case as an optimisation the residual was not squared, so do not need
+            # to square-root here
+            return square_residual_norms
+        else
+            return OrderedDict(k=>sqrt.(v) for (k,v) ∈ square_residual_norms)
+        end
     else
         return nothing
     end
@@ -557,7 +569,7 @@ end
 """
     steady_state_square_residuals(variable, variable_at_previous_time, dt;
                                   variable_max=nothing, epsilon=1.0e-4,
-                                  use_mpi=false)
+                                  use_mpi=false, only_max_abs=false)
 
 Used to calculate the mean square residual for [`steady_state_residuals`](@ref).
 
@@ -571,7 +583,7 @@ this function.
 """
 function steady_state_square_residuals(variable, variable_at_previous_time, dt;
                                        variable_max=nothing, epsilon=default_epsilon,
-                                       use_mpi=false)
+                                       use_mpi=false, only_max_abs=false)
     if ndims(dt) == 0
         t_dim = ndims(variable) + 1
     else
@@ -579,7 +591,7 @@ function steady_state_square_residuals(variable, variable_at_previous_time, dt;
     end
     if use_mpi
         begin_r_z_region()
-        if variable_max === nothing
+        if !only_max_abs && variable_max === nothing
             local_max = 0.0
             @loop_r_z ir iz begin
                 this_slice = selectdim(selectdim(variable, t_dim - 1, ir), t_dim - 2, iz)
@@ -592,36 +604,56 @@ function steady_state_square_residuals(variable, variable_at_previous_time, dt;
         else
             reshaped_dt = dt
         end
-        local_total_absolute_square = zeros(size(dt))
-        local_max_absolute_square = zeros(size(dt))
-        local_total_relative_square = zeros(size(dt))
-        local_max_relative_square = zeros(size(dt))
+        if only_max_abs
+            local_max_absolute = zeros(size(dt))
+        else
+            local_total_absolute_square = zeros(size(dt))
+            local_max_absolute_square = zeros(size(dt))
+            local_total_relative_square = zeros(size(dt))
+            local_max_relative_square = zeros(size(dt))
+        end
         @loop_r_z ir iz begin
             this_slice = selectdim(selectdim(variable, t_dim - 1, ir), t_dim - 2, iz)
             this_slice_previous_time = selectdim(selectdim(variable_at_previous_time,
                                                            t_dim - 1, ir), t_dim - 2, iz)
 
-            absolute_square_residual, relative_square_residual =
-                _steady_state_square_residual(variable, variable_at_previous_time,
-                                              reshaped_dt, epsilon, variable_max)
-            # Need to wrap the sum(...) or maximum(...) in a call to vec(...) so that we
-            # return a Vector, not an N-dimensional array where the first (N-1) dimensions
-            # all have size 1.
-            local_total_absolute_square .+= vec(sum(absolute_square_residual,
-                                                    dims=tuple((1:t_dim-1)...)))
-            local_max_absolute_square = max.(local_max_absolute_square,
-                                             vec(maximum(absolute_square_residual,
-                                                         dims=tuple((1:t_dim-1)...))))
-            local_total_relative_square .+= vec(sum(relative_square_residual,
-                                                    dims=tuple((1:t_dim-1)...)))
-            local_max_relative_square = max.(local_max_relative_square,
-                                             vec(maximum(relative_square_residual,
-                                                         dims=tuple((1:t_dim-1)...))))
+            if only_max_abs
+                absolute_residual =
+                    _steady_state_absolute_residual(variable, variable_at_previous_time,
+                                                    reshaped_dt)
+                # Need to wrap the maximum(...) in a call to vec(...) so that we return a
+                # Vector, not an N-dimensional array where the first (N-1) dimensions all
+                # have size 1.
+                local_max_absolute = max.(local_max_absolute,
+                                          vec(maximum(absolute_residual,
+                                                      dims=tuple((1:t_dim-1)...))))
+            else
+                absolute_square_residual, relative_square_residual =
+                    _steady_state_square_residual(variable, variable_at_previous_time,
+                                                  reshaped_dt, epsilon, variable_max)
+                # Need to wrap the sum(...) or maximum(...) in a call to vec(...) so that
+                # we return a Vector, not an N-dimensional array where the first (N-1)
+                # dimensions all have size 1.
+                local_total_absolute_square .+= vec(sum(absolute_square_residual,
+                                                        dims=tuple((1:t_dim-1)...)))
+                local_max_absolute_square = max.(local_max_absolute_square,
+                                                 vec(maximum(absolute_square_residual,
+                                                             dims=tuple((1:t_dim-1)...))))
+                local_total_relative_square .+= vec(sum(relative_square_residual,
+                                                        dims=tuple((1:t_dim-1)...)))
+                local_max_relative_square = max.(local_max_relative_square,
+                                                 vec(maximum(relative_square_residual,
+                                                             dims=tuple((1:t_dim-1)...))))
+            end
         end
 
         # Pack results together so we only need one communication
-        packed_results = hcat(local_total_absolute_square, local_max_absolute_square,
-                              local_total_relative_square, local_max_relative_square)
+        if only_max_abs
+            packed_results = local_max_absolute
+        else
+            packed_results = hcat(local_total_absolute_square, local_max_absolute_square,
+                                  local_total_relative_square, local_max_relative_square)
+        end
         gathered_results = MPI.Gather(packed_results, 0, comm_block[])
 
         if block_rank[] == 0
@@ -631,18 +663,24 @@ function steady_state_square_residuals(variable, variable_at_previous_time, dt;
 
             # Finish calculating block-local mean/max
             packed_block_results = similar(packed_results)
-            @boundscheck ndims(packed_results) == 2
-            @boundscheck ndims(gathered_results) == 3
-            packed_block_results[:,1] = sum(@view(gathered_results[:,1,:]), dims=2)
-            packed_block_results[:,2] = maximum(@view(gathered_results[:,2,:]), dims=2)
-            packed_block_results[:,3] = sum(@view(gathered_results[:,3,:]), dims=2)
-            packed_block_results[:,4] = maximum(@view(gathered_results[:,4,:]), dims=2)
+            if only_max_abs
+                @boundscheck ndims(packed_results) == 1
+                @boundscheck ndims(gathered_results) == 2
+                packed_block_results .= maximum(gathered_results, dims=2)
+            else
+                @boundscheck ndims(packed_results) == 2
+                @boundscheck ndims(gathered_results) == 3
+                packed_block_results[:,1] = sum(@view(gathered_results[:,1,:]), dims=2)
+                packed_block_results[:,2] = maximum(@view(gathered_results[:,2,:]), dims=2)
+                packed_block_results[:,3] = sum(@view(gathered_results[:,3,:]), dims=2)
+                packed_block_results[:,4] = maximum(@view(gathered_results[:,4,:]), dims=2)
 
-            #block_mean_square = block_total_square / (prod(size(variable)) / prod(size(dt)))
-            @boundscheck prod(size(variable)) % prod(size(dt)) == 0
-            block_npoints = prod(size(variable)) ÷ prod(size(dt))
-            packed_block_results[:,1] /= block_npoints
-            packed_block_results[:,3] /= block_npoints
+                #block_mean_square = block_total_square / (prod(size(variable)) / prod(size(dt)))
+                @boundscheck prod(size(variable)) % prod(size(dt)) == 0
+                block_npoints = prod(size(variable)) ÷ prod(size(dt))
+                packed_block_results[:,1] /= block_npoints
+                packed_block_results[:,3] /= block_npoints
+            end
 
             gathered_block_results = MPI.Gather(packed_block_results, 0, comm_inter_block[])
         end
@@ -651,35 +689,51 @@ function steady_state_square_residuals(variable, variable_at_previous_time, dt;
             gathered_block_results = reshape(gathered_block_results,
                                              (size(packed_results)..., n_blocks[]))
 
-            return OrderedDict(
-                       "RMS absolute residual"=>mean(@view(gathered_block_results[:,1,:]), dims=2),
-                       "max absolute residual"=>maximum(@view(gathered_block_results[:,2,:]), dims=2),
-                       "RMS relative residual"=>mean(@view(gathered_block_results[:,3,:]), dims=2),
-                       "max relative residual"=>maximum(@view(gathered_block_results[:,4,:]), dims=2))
+            if only_max_abs
+                return OrderedDict(
+                           "max absolute residual"=>maximum(gathered_block_results, dims=2))
+            else
+                return OrderedDict(
+                           "RMS absolute residual"=>mean(@view(gathered_block_results[:,1,:]), dims=2),
+                           "max absolute residual"=>maximum(@view(gathered_block_results[:,2,:]), dims=2),
+                           "RMS relative residual"=>mean(@view(gathered_block_results[:,3,:]), dims=2),
+                           "max relative residual"=>maximum(@view(gathered_block_results[:,4,:]), dims=2))
+            end
         else
             return nothing
         end
     else
-        if variable_max === nothing
+        if !only_max_abs && variable_max === nothing
             variable_max = maximum(variable)
         end
         reshaped_dt = reshape(dt, tuple((1 for _ ∈ 1:t_dim-1)..., size(dt)...))
 
-        absolute_square_residual, relative_square_residual =
-            _steady_state_square_residual(variable, variable_at_previous_time,
-                                          reshaped_dt, epsilon, variable_max)
-        # Need to wrap the mean(...) or maximum(...) in a call to vec(...) so that we
-        # return a Vector, not an N-dimensional array where the first (N-1) dimensions all
-        # have size 1.
-        return OrderedDict(
-                   "RMS absolute residual"=>vec(mean(absolute_square_residual;
-                                                     dims=tuple((1:t_dim-1)...))),
-                   "max absolute residual"=>vec(maximum(absolute_square_residual;
-                                                        dims=tuple((1:t_dim-1)...))),
-                   "RMS relative residual"=>vec(mean(relative_square_residual;
-                                                     dims=tuple((1:t_dim-1)...))),
-                   "max relative residual"=>vec(maximum(relative_square_residual;
-                                                        dims=tuple((1:t_dim-1)...))))
+        if only_max_abs
+            absolute_residual =
+                _steady_state_residual(variable, variable_at_previous_time, reshaped_dt)
+            # Need to wrap the maximum(...) in a call to vec(...) so that we return a
+            # Vector, not an N-dimensional array where the first (N-1) dimensions all have
+            # size 1.
+            return OrderedDict(
+                       "max absolute residual"=>vec(maximum(absolute_residual;
+                                                            dims=tuple((1:t_dim-1)...))))
+        else
+            absolute_square_residual, relative_square_residual =
+                _steady_state_square_residual(variable, variable_at_previous_time,
+                                              reshaped_dt, epsilon, variable_max)
+            # Need to wrap the mean(...) or maximum(...) in a call to vec(...) so that we
+            # return a Vector, not an N-dimensional array where the first (N-1) dimensions all
+            # have size 1.
+            return OrderedDict(
+                       "RMS absolute residual"=>vec(mean(absolute_square_residual;
+                                                         dims=tuple((1:t_dim-1)...))),
+                       "max absolute residual"=>vec(maximum(absolute_square_residual;
+                                                            dims=tuple((1:t_dim-1)...))),
+                       "RMS relative residual"=>vec(mean(relative_square_residual;
+                                                         dims=tuple((1:t_dim-1)...))),
+                       "max relative residual"=>vec(maximum(relative_square_residual;
+                                                            dims=tuple((1:t_dim-1)...))))
+        end
     end
 end
 
@@ -691,6 +745,13 @@ function _steady_state_square_residual(variable, variable_at_previous_time, resh
     relative_square_residual = @. absolute_square_residual /
                                   ((abs(variable) + epsilon*variable_max))^2
     return absolute_square_residual, relative_square_residual
+end
+
+# Utility function for the steady-state absolute residual to avoid code duplication in
+# steady_state_mean_square_residual(), used only when only_max_abs=true
+function _steady_state_absolute_residual(variable, variable_at_previous_time, reshaped_dt)
+    absolute_residual = @. abs((variable - variable_at_previous_time) / reshaped_dt)
+    return absolute_residual
 end
 
 end

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -12,7 +12,7 @@ loop ranges), as at the moment we only run with 1 ion species and 1 neutral spec
 """
 module communication
 
-export allocate_shared, block_rank, block_size, comm_block, comm_inter_block,
+export allocate_shared, block_rank, block_size, n_blocks, comm_block, comm_inter_block,
        iblock_index, comm_world, finalize_comms!, initialize_comms!, global_rank,
        MPISharedArray, global_size
 export setup_distributed_memory_MPI
@@ -70,6 +70,10 @@ const block_rank = Ref{mk_int}()
 """
 """
 const block_size = Ref{mk_int}()
+
+"""
+"""
+const n_blocks = Ref{mk_int}()
 
 """
 """
@@ -143,6 +147,7 @@ function setup_distributed_memory_MPI(z_nelement_global,z_nelement_local,r_nelem
     iblock_index[] = iblock
     block_rank[] = irank_block
     block_size[] = nrank_per_zr_block
+    n_blocks[] = nblocks
     # construct a communicator for intra-block communication
     comm_block[] = MPI.Comm_split(comm_world,iblock,irank_block)
     # MPI.Comm_split(comm,color,key)

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -40,6 +40,7 @@ struct time_input
     split_operators::Bool
     runtime_plots::Bool
     steady_state_residual::Bool
+    converged_residual_value::mk_float
     use_manufactured_solns_for_advance::Bool
 end
 

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -39,6 +39,7 @@ struct time_input
     n_rk_stages::mk_int
     split_operators::Bool
     runtime_plots::Bool
+    steady_state_residual::Bool
     use_manufactured_solns_for_advance::Bool
 end
 

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -295,6 +295,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     n_rk_stages = get(scan_input, "n_rk_stages", 4)
     split_operators = get(scan_input, "split_operators", false)
     runtime_plots = get(scan_input, "runtime_plots", false)
+    steady_state_residual = get(scan_input, "steady_state_residual", false)
 
     use_for_init_is_default = !(("manufactured_solns" ∈ keys(scan_input)) &&
                                 ("use_for_init" ∈ keys(scan_input["manufactured_solns"])))
@@ -478,7 +479,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     #nrank_z = 0
 
     t_input = time_input(nstep, dt, nwrite_moments, nwrite_dfns, n_rk_stages,
-                         split_operators, runtime_plots,
+                         split_operators, runtime_plots, steady_state_residual,
                          manufactured_solns_input.use_for_advance)
     # replace mutable structures with immutable ones to optimize performance
     # and avoid possible misunderstandings	

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -296,6 +296,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     split_operators = get(scan_input, "split_operators", false)
     runtime_plots = get(scan_input, "runtime_plots", false)
     steady_state_residual = get(scan_input, "steady_state_residual", false)
+    converged_residual_value = get(scan_input, "converged_residual_value", -1.0)
 
     use_for_init_is_default = !(("manufactured_solns" ∈ keys(scan_input)) &&
                                 ("use_for_init" ∈ keys(scan_input["manufactured_solns"])))
@@ -480,6 +481,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
 
     t_input = time_input(nstep, dt, nwrite_moments, nwrite_dfns, n_rk_stages,
                          split_operators, runtime_plots, steady_state_residual,
+                         converged_residual_value,
                          manufactured_solns_input.use_for_advance)
     # replace mutable structures with immutable ones to optimize performance
     # and avoid possible misunderstandings	

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -795,7 +795,7 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
                     @loop_sn isn begin
                         residual_nn =
                             steady_state_residuals(scratch[end].density_neutral[:,:,isn],
-                                                   scratch[1].density[:,:,isn],
+                                                   scratch[1].density_neutral[:,:,isn],
                                                    t_input.dt; use_mpi=true,
                                                    only_max_abs=true)
                         if global_rank[] == 0

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -772,27 +772,30 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
                 begin_r_z_region()
                 result_string = ""
                 @loop_s is begin
-                    @views residuals_ni =
+                    @views residual_ni =
                         steady_state_residuals(scratch[end].density[:,:,is],
                                                scratch[1].density[:,:,is], t_input.dt;
-                                               use_mpi=true)
+                                               use_mpi=true, only_max_abs=true)
                     if global_rank[] == 0
-                        for r ∈ values(residuals_ni)
+                        result_string *= "  density "
+                        for r ∈ values(residual_ni)
                             #result_string *= lpad(string(r[1]), 24)
-                            result_string *= lpad(string(round(r[1]; sigdigits=4)), 11)
+                            result_string *= rpad(string(round(r[1]; sigdigits=4)), 11)
                         end
                     end
                 end
                 if composition.n_neutral_species > 0
                     @loop_sn isn begin
-                        residuals_nn =
+                        residual_nn =
                             steady_state_residuals(scratch[end].density_neutral[:,:,isn],
                                                    scratch[1].density[:,:,isn],
-                                                   t_input.dt; use_mpi=true)
+                                                   t_input.dt; use_mpi=true,
+                                                   only_max_abs=true)
                         if global_rank[] == 0
-                            for r ∈ values(residuals_nn)
+                            result_string *= " density_neutral "
+                            for r ∈ values(residual_nn)
                                 #result_string *= lpad(string(r[1]), 24)
-                                result_string *= lpad(string(round(r[1]; sigdigits=4)), 11)
+                                result_string *= rpad(string(round(r[1]; sigdigits=4)), 11)
                             end
                         end
                     end


### PR DESCRIPTION
When running a simulation to steady state, it is useful to be able to check how close it is to converging to steady state (#106).

Define an 'absolute residual' for some variable $a$
```math
r_{\mathrm{abs}}(t,x) = \frac{|a(t,x) - a(t-\delta t,x)|}{\delta t}
```
and a 'relative residual'
```math
r_{\mathrm{rel}}(t,x) = \left(\frac{a(t,x) - a(t-\delta t,x)}{\delta t (\left|a(t,x)\right| + \epsilon)}\right)^2
```

This PR adds functionality for calculating and checking these residuals:
* In post-processing, calculate the maximum and RMS (over the spatial dimensions $x$) of both absolute and relative residuals for any field and moment variables, if `steady_state_residual = true` is set in the post-processing input file. The 4 residuals are written to a text file in the run directory, and plotted vs. time.
* During a simulation, if `steady_state_residual = true` is passed in the input, calculate and print the 'maximum absolute residual' for the density of each ion and neutral species at each output step.
    * The current choice is to calculate a minimal number of residuals for speed and simplicity. The density is chosen as it is always relevant (phi might also have been a good choice, but it was less convenient to get phi from the previous timestep). The 'maximum absolute residual' is chosen as a good robust, rough measure of convergence. The 'relative residual' can be over-sensitive to very small values of the variable (even with the $\epsilon$ to cut off zeros), on the other hand the RMS might partially hide small parts of the grid where the solution is still changing rapidly. We can update this choice in the future when we get some experience of what is a good measure of a converged simulation!
* When `steady_state_residual = true` so residuals are calculated during a simulation, `converged_residual_value` can be set to stop the simulation when all calculated residuals are below the specified value.
    * When the simulation is stopped by this 'convergence test', both moments and distribution functions are written from the final time point.

Worth noting: in post-processing the $\delta t$ used to calculate the residuals is the time between output steps; when residuals are calculated during a simulation $\delta t$ is the timestep.

Calculation of residuals for the distribution function(s) has not been added yet. It is supported by the `analysis.steady_state_residuals()` function, but to avoid running out of memory would need to work on chunks of the output in a similar way to the calculation of the MMS norms https://github.com/mabarnes/moment_kinetics/blob/0a1787ec130fbe82869a37638397d67c79440991/src/makie_post_processing.jl#L4411-L4458

Resolves #106.