### PR TITLE
Small fixes for makie_post_processing

### DIFF
--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -1044,31 +1044,31 @@ function postproc_load_variable(run_info, variable_name; it=nothing, is=nothing,
                 tinds = collect(i - local_it_start + 1 + offset for i ∈ it
                                 if local_it_start <= i <= local_it_end)
                 # Convert tinds to slice, as we know the spacing is constant
-                if length(tinds) == 0
-                    # Nothing to do in this file
-                    continue
-                elseif length(tinds) > 1
-                    tstep = tinds[2] - tinds[begin]
-                else
-                    tstep = 1
-                end
-                tinds = tinds[begin]:tstep:tinds[end]
-                global_it_end = global_it_start + length(tinds) - 1
+                if length(tinds) != 0
+                    # There is some data in this file
+                    if length(tinds) > 1
+                        tstep = tinds[2] - tinds[begin]
+                    else
+                        tstep = 1
+                    end
+                    tinds = tinds[begin]:tstep:tinds[end]
+                    global_it_end = global_it_start + length(tinds) - 1
 
-                if nd == 3
-                    selectdim(result, ndims(result), global_it_start:global_it_end) .= v[iz,ir,tinds]
-                elseif nd == 4
-                    selectdim(result, ndims(result), global_it_start:global_it_end) .= v[iz,ir,is,tinds]
-                elseif nd == 6
-                    selectdim(result, ndims(result), global_it_start:global_it_end) .= v[ivpa,ivperp,iz,ir,is,tinds]
-                elseif nd == 7
-                    selectdim(result, ndims(result), global_it_start:global_it_end) .= v[ivz,ivr,ivzeta,iz,ir,is,tinds]
-                else
-                    error("Unsupported combination nd=$nd, ir=$ir, iz=$iz, ivperp=$ivperp "
-                          * "ivpa=$ivpa, ivzeta=$ivzeta, ivr=$ivr, ivz=$ivz.")
-                end
+                    if nd == 3
+                        selectdim(result, ndims(result), global_it_start:global_it_end) .= v[iz,ir,tinds]
+                    elseif nd == 4
+                        selectdim(result, ndims(result), global_it_start:global_it_end) .= v[iz,ir,is,tinds]
+                    elseif nd == 6
+                        selectdim(result, ndims(result), global_it_start:global_it_end) .= v[ivpa,ivperp,iz,ir,is,tinds]
+                    elseif nd == 7
+                        selectdim(result, ndims(result), global_it_start:global_it_end) .= v[ivz,ivr,ivzeta,iz,ir,is,tinds]
+                    else
+                        error("Unsupported combination nd=$nd, ir=$ir, iz=$iz, ivperp=$ivperp "
+                              * "ivpa=$ivpa, ivzeta=$ivzeta, ivr=$ivr, ivz=$ivz.")
+                    end
 
-                global_it_start = global_it_end + 1
+                    global_it_start = global_it_end + 1
+                end
             end
 
             local_it_start = local_it_end + 1

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -1278,7 +1278,7 @@ function plots_for_variable(run_info, variable_name; plot_prefix, is_1D=false,
                 plot_vs_z(run_info, variable_name, is=is, data=variable, input=input,
                           outfile=variable_prefix * "vs_z.pdf")
             end
-            if input.plot_vs_z_r
+            if !is_1D && input.plot_vs_z_r
                 plot_vs_z_r(run_info, variable_name, is=is, data=variable, input=input,
                             outfile=variable_prefix * "vs_z_r.pdf")
             end


### PR DESCRIPTION
* Add missing `!is_1D` to avoid making empty plot vs r from 1D run
* Fix for caching when animating output from long runs - was an error if the total number of time points was not a multiple of the number of time points per chunk
* Fix an error where `postproc_load_data()` would not actually load any data for a run with multiple restarts if the subset of time points being loaded did not include a point in the first restart's output file.