### PR TITLE
`stop` file to stop a run cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ and see the error message
     
     
 this can be suppressed by setting 
-    ```
-    export QT_QPA_PLATFORM=offscreen
-    ```
+```
+export QT_QPA_PLATFORM=offscreen
+```
 in your `.bashrc` or `.bash_profile` files. 
 
 ## Parallel I/O

--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ export QT_QPA_PLATFORM=offscreen
 ```
 in your `.bashrc` or `.bash_profile` files. 
 
+### Stopping a run
+
+When running in the REPL (especially with MPI) interrupting a run using Ctrl-C
+can mess things up, and require you to restart Julia. There is also a chance
+that you might interrupt while writing the output files and corrupt them. To
+avoid these problems, you can stop the run cleanly (including writing the
+distribution functions at the last time point, so that it is possible to
+restart the run from where you stopped it), by creating an empty file called
+`stop` in the run directory. For example, if the name of your run is
+'my\_example'
+```shell
+$ touch runs/my_example/stop
+```
+`moment_kinetics` checks for this file when it is going to write output, and if
+it is present writes all output and then returns cleanly. The 'stop file' is
+deleted when a run is (re-)started, if present, so you do not have to manually
+delete it before (re-)starting the run again.
+
 ## Parallel I/O
 
 Note that to enable parallel I/O, you need to get HDF5.jl to use the system

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -42,6 +42,7 @@ struct time_input
     steady_state_residual::Bool
     converged_residual_value::mk_float
     use_manufactured_solns_for_advance::Bool
+    stopfile::String
 end
 
 """

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -295,6 +295,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     n_rk_stages = get(scan_input, "n_rk_stages", 4)
     split_operators = get(scan_input, "split_operators", false)
     runtime_plots = get(scan_input, "runtime_plots", false)
+    stopfile_name = joinpath(output_dir, "stop")
     steady_state_residual = get(scan_input, "steady_state_residual", false)
     converged_residual_value = get(scan_input, "converged_residual_value", -1.0)
 
@@ -482,7 +483,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     t_input = time_input(nstep, dt, nwrite_moments, nwrite_dfns, n_rk_stages,
                          split_operators, runtime_plots, steady_state_residual,
                          converged_residual_value,
-                         manufactured_solns_input.use_for_advance)
+                         manufactured_solns_input.use_for_advance, stopfile_name)
     # replace mutable structures with immutable ones to optimize performance
     # and avoid possible misunderstandings	
 	z_advection_immutable = advection_input(z.advection.option, z.advection.constant_speed,


### PR DESCRIPTION
When running in the REPL (especially with MPI) interrupting a run using Ctrl-C can mess things up, and require you to restart Julia. There is also a chance that you might interrupt while writing the output files and corrupt them. To
avoid these problems, this PR adds a feature to stop the run cleanly, by creating an empty file called `stop` in the run directory. For example, if the name of your run is 'my\_example'
```shell
$ touch runs/my_example/stop
```
`moment_kinetics` checks for this file when it is going to write output, and if it is present writes all output and then returns cleanly. The 'stop file' is deleted when a run is (re-)started, if present, so you do not have to manually delete it before (re-)starting the run again.