### PR TITLE
Restart from most recent output file by default

### DIFF
--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -118,7 +118,7 @@ function setup_file_io(io_input, boundary_distributions, vz, vr, vzeta, vpa, vpe
         # check to see if output_dir exists in the current directory
         # if not, create it
         isdir(io_input.output_dir) || mkdir(io_input.output_dir)
-        out_prefix = string(io_input.output_dir, "/", io_input.run_name)
+        out_prefix = joinpath(io_input.output_dir, io_input.run_name)
 
         if io_input.ascii_output
             #ff_io = open_ascii_output_file(out_prefix, "f_vs_t")

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -174,7 +174,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     run_name = get(scan_input, "run_name", "wallBC")
     # this is the directory where the simulation data will be stored
     base_directory = get(scan_input, "base_directory", "runs")
-    output_dir = string(base_directory, "/", run_name)
+    output_dir = joinpath(base_directory, run_name)
     # if evolve_moments.density = true, evolve density via continuity eqn
     # and g = f/n via modified drift kinetic equation
     evolve_moments.density = get(scan_input, "evolve_moments_density", false)


### PR DESCRIPTION
Make the `restart_filename` argument to `restart_moment_kinetics()` optional. By default, restart from the most recent output file in the run directory (the one with no `_<i>` suffix in the name).

This required re-ordering the arguments of `restart_moment_kinetics` so that `input_filename` is first, and `restart_filename` is second.