### PR TITLE
Precompile fixes and improvements

### DIFF
--- a/machines/archer/jobscript-postprocess-plotsjl.template
+++ b/machines/archer/jobscript-postprocess-plotsjl.template
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#SBATCH --mem=POSTPROCMEMORY
+#SBATCH --time=POSTPROCTIME
+#SBATCH --account=ACCOUNT
+#SBATCH --partition=serial
+#SBATCH --qos=serial
+#SBATCH --output=RUNDIRslurm-post-%j.out
+
+set -e
+
+cd $SLURM_SUBMIT_DIR
+
+# Get setup for Julia
+source julia.env
+
+# Workaround as cpus-per-task no longer inherited by srun from sbatch.
+# See https://docs.archer2.ac.uk/faq/upgrade-2023/
+export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
+
+echo "post-processing (with original post_processing) RUNDIR $(date)"
+bin/julia -Jmoment_kinetics.so --project run_post_processing.jl RUNDIR
+
+echo "finished post-processing RUNDIR $(date)"

--- a/machines/archer/jobscript-postprocess.template
+++ b/machines/archer/jobscript-postprocess.template
@@ -19,7 +19,6 @@ source julia.env
 export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 echo "post-processing RUNDIR $(date)"
-#bin/julia -Jmoment_kinetics.so --project -O3 --check-bounds=no run_post_processing.jl RUNDIR
-bin/julia -Jmakie_postproc.so --project run_post_processing.jl RUNDIR
+bin/julia -Jmakie_postproc.so --project run_makie_post_processing.jl RUNDIR
 
 echo "finished post-processing RUNDIR $(date)"

--- a/machines/archer/jobscript-precompile-no-run.template
+++ b/machines/archer/jobscript-precompile-no-run.template
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH --mem=64G
-#SBATCH --ntasks=2
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --time=1:00:00
 #SBATCH --account=ACCOUNT
@@ -21,11 +21,7 @@ source julia.env
 export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 echo "precompiling $(date)"
-#bin/julia --project -O3 --check-bounds=no precompile.jl &
-#bin/julia --project precompile-makie-post-processing.jl &
-#
-#wait
+
 bin/julia --project -O3 --check-bounds=no precompile-no-run.jl
-bin/julia --project precompile-makie-post-processing.jl
 
 echo "finished!"

--- a/machines/archer/jobscript-precompile-no-run.template
+++ b/machines/archer/jobscript-precompile-no-run.template
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#SBATCH --mem=64G
+#SBATCH --ntasks=2
+#SBATCH --cpus-per-task=1
+#SBATCH --time=1:00:00
+#SBATCH --account=ACCOUNT
+#SBATCH --partition=serial
+#SBATCH --qos=serial
+#SBATCH --output=PRECOMPILEDIRslurm-%j.out
+
+set -e
+
+cd $SLURM_SUBMIT_DIR
+
+# Get setup for Julia
+source julia.env
+
+# Workaround as cpus-per-task no longer inherited by srun from sbatch.
+# See https://docs.archer2.ac.uk/faq/upgrade-2023/
+export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
+
+echo "precompiling $(date)"
+#bin/julia --project -O3 --check-bounds=no precompile.jl &
+#bin/julia --project precompile-makie-post-processing.jl &
+#
+#wait
+bin/julia --project -O3 --check-bounds=no precompile-no-run.jl
+bin/julia --project precompile-makie-post-processing.jl
+
+echo "finished!"

--- a/machines/archer/jobscript-precompile-postprocessing.template
+++ b/machines/archer/jobscript-precompile-postprocessing.template
@@ -20,8 +20,8 @@ source julia.env
 # See https://docs.archer2.ac.uk/faq/upgrade-2023/
 export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
-echo "precompiling $(date)"
+echo "precompiling post-processing $(date)"
 
-bin/julia --project -O3 --check-bounds=no precompile.jl
+bin/julia --project precompile-makie-post-processing.jl
 
 echo "finished!"

--- a/machines/archer/jobscript-precompile.template
+++ b/machines/archer/jobscript-precompile.template
@@ -21,8 +21,12 @@ source julia.env
 export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 echo "precompiling $(date)"
-bin/julia --project -O3 --check-bounds=no precompile.jl &
-bin/julia --project precompile-makie-post-processing.jl &
+#bin/julia --project -O3 --check-bounds=no precompile.jl &
+#bin/julia --project precompile-makie-post-processing.jl &
+#
+#wait
+bin/julia --project -O3 --check-bounds=no precompile.jl
+bin/julia --project precompile-makie-post-processing.jl
 
 wait
 

--- a/machines/marconi/jobscript-postprocess-plotsjl.template
+++ b/machines/marconi/jobscript-postprocess-plotsjl.template
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#SBATCH --ntasks=1
+#SBATCH --time=POSTPROCTIME
+#SBATCH --account=ACCOUNT
+#SBATCH --partition=skl_fua_dbg
+#SBATCH --output=RUNDIRslurm-post-%j.out
+
+set -e
+
+cd $SLURM_SUBMIT_DIR
+
+# Get setup for Julia
+source julia.env
+
+echo "post-processing (with original post_processing) RUNDIR $(date)"
+bin/julia -Jmoment_kinetics.so --project run_post_processing.jl RUNDIR
+
+echo "finished post-processing RUNDIR $(date)"

--- a/machines/marconi/jobscript-postprocess.template
+++ b/machines/marconi/jobscript-postprocess.template
@@ -14,7 +14,6 @@ cd $SLURM_SUBMIT_DIR
 source julia.env
 
 echo "post-processing RUNDIR $(date)"
-#bin/julia -Jmoment_kinetics.so --project -O3 --check-bounds=no run_post_processing.jl RUNDIR
-bin/julia -Jmakie_postproc.so --project run_post_processing.jl RUNDIR
+bin/julia -Jmakie_postproc.so --project run_makie_post_processing.jl RUNDIR
 
 echo "finished post-processing RUNDIR $(date)"

--- a/machines/marconi/jobscript-precompile-no-run.template
+++ b/machines/marconi/jobscript-precompile-no-run.template
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --ntasks=2
+#SBATCH --ntasks=1
 #SBATCH --time=1:00:00
 #SBATCH --account=ACCOUNT
 #SBATCH --partition=skl_fua_dbg
@@ -14,9 +14,7 @@ cd $SLURM_SUBMIT_DIR
 source julia.env
 
 echo "precompiling $(date)"
-bin/julia --project -O3 --check-bounds=no precompile-no-run.jl
-bin/julia --project precompile-makie-post-processing.jl
 
-wait
+bin/julia --project -O3 --check-bounds=no precompile-no-run.jl
 
 echo "finished!"

--- a/machines/marconi/jobscript-precompile-no-run.template
+++ b/machines/marconi/jobscript-precompile-no-run.template
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#SBATCH --ntasks=2
+#SBATCH --time=1:00:00
+#SBATCH --account=ACCOUNT
+#SBATCH --partition=skl_fua_dbg
+#SBATCH --output=PRECOMPILEDIRslurm-%j.out
+
+set -e
+
+cd $SLURM_SUBMIT_DIR
+
+# Get setup for Julia
+source julia.env
+
+echo "precompiling $(date)"
+bin/julia --project -O3 --check-bounds=no precompile-no-run.jl
+bin/julia --project precompile-makie-post-processing.jl
+
+wait
+
+echo "finished!"

--- a/machines/marconi/jobscript-precompile-postprocessing.template
+++ b/machines/marconi/jobscript-precompile-postprocessing.template
@@ -15,6 +15,6 @@ source julia.env
 
 echo "precompiling $(date)"
 
-bin/julia --project -O3 --check-bounds=no precompile.jl
+bin/julia --project precompile-makie-post-processing.jl
 
 echo "finished!"

--- a/precompile-makie-post-processing.jl
+++ b/precompile-makie-post-processing.jl
@@ -15,4 +15,5 @@ create_sysimage(packages;
                 sysimage_path="makie_postproc.so",
                 precompile_execution_file="util/precompile_makie_plots.jl",
                 include_transitive_dependencies=false, # This is needed to make MPI work, see https://github.com/JuliaParallel/MPI.jl/issues/518
+                sysimage_build_args=`-O3`, # Assume if we are precompiling we want an optimized, production build. No `--check-bounds=no` because Makie doesn' like it https://github.com/MakieOrg/Makie.jl/issues/3132
                )

--- a/precompile-makie-post-processing.jl
+++ b/precompile-makie-post-processing.jl
@@ -5,14 +5,11 @@ Pkg.activate(".")
 
 using PackageCompiler
 
-packages = [:moment_kinetics, :PackageCompiler, :ArgParse, :CairoMakie, :Combinatorics, :DelimitedFiles, :FFTW, :Glob, :HDF5, :IJulia, :LinearAlgebra, :LsqFit, :MPI, :NaturalSort, :NCDatasets, :OrderedCollections, :Primes, :Roots, :SHA, :SpecialFunctions, :Statistics, :TOML, :TimerOutputs]
-
 # Create the sysimage 'makie_postproc.so' in the base moment_kinetics source directory
 # with both moment_kinetics and the dependencies listed above precompiled.
 # Warning: editing the code will not affect what runs when using this .so, you
 # need to re-precompile if you change anything.
-create_sysimage(packages;
-                sysimage_path="makie_postproc.so",
+create_sysimage(; sysimage_path="makie_postproc.so",
                 precompile_execution_file="util/precompile_makie_plots.jl",
                 include_transitive_dependencies=false, # This is needed to make MPI work, see https://github.com/JuliaParallel/MPI.jl/issues/518
                 sysimage_build_args=`-O3`, # Assume if we are precompiling we want an optimized, production build. No `--check-bounds=no` because Makie doesn' like it https://github.com/MakieOrg/Makie.jl/issues/3132

--- a/precompile-no-run.jl
+++ b/precompile-no-run.jl
@@ -5,19 +5,11 @@ Pkg.activate(".")
 
 using PackageCompiler
 
-using TOML
-project_file = TOML.parsefile("Project.toml")
-deps = (Symbol(d) for d ∈ keys(project_file["deps"]))
-
-packages = [:moment_kinetics, :PackageCompiler, deps...]
-println("precompling $packages")
-
 # Create the sysimage 'moment_kinetics.so' in the base moment_kinetics source directory
 # with both moment_kinetics and the dependencies listed above precompiled.
 # Warning: editing the code will not affect what runs when using this .so, you
 # need to re-precompile if you change anything.
-create_sysimage(packages;
-                sysimage_path="moment_kinetics.so",
+create_sysimage(; sysimage_path="moment_kinetics.so",
                 include_transitive_dependencies=false, # This is needed to make MPI work, see https://github.com/JuliaParallel/MPI.jl/issues/518
                 sysimage_build_args=`-O3 --check-bounds=no`, # Assume if we are precompiling we want an optimized, production build
                )

--- a/precompile-no-run.jl
+++ b/precompile-no-run.jl
@@ -1,0 +1,23 @@
+using Pkg
+
+# Activate the moment_kinetics package
+Pkg.activate(".")
+
+using PackageCompiler
+
+using TOML
+project_file = TOML.parsefile("Project.toml")
+deps = (Symbol(d) for d ∈ keys(project_file["deps"]))
+
+packages = [:moment_kinetics, :PackageCompiler, deps...]
+println("precompling $packages")
+
+# Create the sysimage 'moment_kinetics.so' in the base moment_kinetics source directory
+# with both moment_kinetics and the dependencies listed above precompiled.
+# Warning: editing the code will not affect what runs when using this .so, you
+# need to re-precompile if you change anything.
+create_sysimage(packages;
+                sysimage_path="moment_kinetics.so",
+                include_transitive_dependencies=false, # This is needed to make MPI work, see https://github.com/JuliaParallel/MPI.jl/issues/518
+                sysimage_build_args=`-O3 --check-bounds=no`, # Assume if we are precompiling we want an optimized, production build
+               )

--- a/precompile-submit.sh
+++ b/precompile-submit.sh
@@ -2,13 +2,27 @@
 
 set -e
 
+# Parse command line options
+NO_PRECOMPILE_RUN=1
+while getopts "hn" opt; do
+  case $opt in
+    h)
+      echo "Submit job to precompile moment kinetics
+-h             Print help and exit
+-n             No 'precompile run' - i.e. call precompile-no-run.jl instead of precompile.jl"
+      exit 1
+      ;;
+    n)
+      NO_PRECOMPILE_RUN=0
+      ;;
+  esac
+done
+
 # job settings for the run
 ##########################
 
 # Get setup for Julia
 source julia.env
-
-echo "Submitting precompile job..."
 
 JOBINFO=($(util/get-precompile-info.jl))
 MACHINE=${JOBINFO[0]}
@@ -19,7 +33,14 @@ mkdir -p $PRECOMPILEDIR
 
 # Create a submission script for the run
 JOBSCRIPT=${PRECOMPILEDIR}precompile.job
-sed -e "s|ACCOUNT|$ACCOUNT|" -e "s|PRECOMPILEDIR|$PRECOMPILEDIR|" machines/$MACHINE/jobscript-precompile.template > $JOBSCRIPT
+if [[ NO_PRECOMPILE_RUN -eq 0 ]]; then
+  echo "Submitting precompile job (no precompile run)..."
+  TEMPLATE_NAME=jobscript-precompile-no-run.template
+else
+  echo "Submitting precompile job..."
+  TEMPLATE_NAME=jobscript-precompile.template
+fi
+sed -e "s|ACCOUNT|$ACCOUNT|" -e "s|PRECOMPILEDIR|$PRECOMPILEDIR|" machines/$MACHINE/$TEMPLATE_NAME > $JOBSCRIPT
 
 JOBID=$(sbatch --parsable $JOBSCRIPT)
 echo "Precompile: $JOBID"

--- a/precompile-submit.sh
+++ b/precompile-submit.sh
@@ -31,7 +31,7 @@ ACCOUNT=${JOBINFO[1]}
 PRECOMPILEDIR=precompile-temp/
 mkdir -p $PRECOMPILEDIR
 
-# Create a submission script for the run
+# Create a submission script for the precompilation
 JOBSCRIPT=${PRECOMPILEDIR}precompile.job
 if [[ NO_PRECOMPILE_RUN -eq 0 ]]; then
   echo "Submitting precompile job (no precompile run)..."
@@ -44,6 +44,14 @@ sed -e "s|ACCOUNT|$ACCOUNT|" -e "s|PRECOMPILEDIR|$PRECOMPILEDIR|" machines/$MACH
 
 JOBID=$(sbatch --parsable $JOBSCRIPT)
 echo "Precompile: $JOBID"
+echo "In the queue" > $PRECOMPILEDIR/slurm-$JOBID.out
+
+# Create a submission script for the post-processing precompilation
+POSTPROCESSINGJOBSCRIPT=${PRECOMPILEDIR}precompile-postprocessing.job
+sed -e "s|ACCOUNT|$ACCOUNT|" -e "s|PRECOMPILEDIR|$PRECOMPILEDIR|" machines/$MACHINE/jobscript-precompile-postprocessing.template > $POSTPROCESSINGJOBSCRIPT
+
+JOBID=$(sbatch --parsable $POSTPROCESSINGJOBSCRIPT)
+echo "Precompile postprocessing: $JOBID"
 echo "In the queue" > $PRECOMPILEDIR/slurm-$JOBID.out
 
 echo "Done"

--- a/precompile.jl
+++ b/precompile.jl
@@ -5,14 +5,11 @@ Pkg.activate(".")
 
 using PackageCompiler
 
-packages = [:moment_kinetics, :PackageCompiler, :ArgParse, :Combinatorics, :DelimitedFiles, :FFTW, :Glob, :IJulia, :LinearAlgebra, :LsqFit, :MPI, :NaturalSort, :NCDatasets, :OrderedCollections, :Plots, :Primes, :Roots, :SHA, :SpecialFunctions, :Statistics, :TOML, :TimerOutputs]
-
 # Create the sysimage 'moment_kinetics.so' in the base moment_kinetics source directory
 # with both moment_kinetics and the dependencies listed above precompiled.
 # Warning: editing the code will not affect what runs when using this .so, you
 # need to re-precompile if you change anything.
-create_sysimage(packages;
-                sysimage_path="moment_kinetics.so",
+create_sysimage(; sysimage_path="moment_kinetics.so",
                 precompile_execution_file="util/precompile_run.jl",
                 include_transitive_dependencies=false, # This is needed to make MPI work, see https://github.com/JuliaParallel/MPI.jl/issues/518
                 sysimage_build_args=`-O3 --check-bounds=no`, # Assume if we are precompiling we want an optimized, production build

--- a/precompile_dependencies.jl
+++ b/precompile_dependencies.jl
@@ -5,12 +5,13 @@ Pkg.activate(".")
 
 using PackageCompiler
 
-packages = [:PackageCompiler, :ArgParse, :Combinatorics, :DelimitedFiles, :FFTW, :Glob, :IJulia, :LinearAlgebra, :LsqFit, :MPI, :NaturalSort, :NCDatasets, :OrderedCollections, :Plots, :Primes, :Roots, :SHA, :SpecialFunctions, :Statistics, :TOML, :TimerOutputs]
+using TOML
+project_file = TOML.parsefile("Project.toml")
+packages = collect(Symbol(d) for d ∈ keys(project_file["deps"]))
 
 # create the sysimage 'dependencies.so' in the base moment_kinetics source directory
 # with the above pre-compiled packages
-create_sysimage(packages;
-                sysimage_path="dependencies.so",
+create_sysimage(packages; sysimage_path="dependencies.so",
                 precompile_execution_file="util/precompile_run_short.jl",
                 include_transitive_dependencies=false, # This is needed to make MPI work, see https://github.com/JuliaParallel/MPI.jl/issues/518
                 sysimage_build_args=`-O3 --check-bounds=no`, # Assume if we are precompiling we want an optimized, production build

--- a/submit-run.sh
+++ b/submit-run.sh
@@ -22,34 +22,36 @@ QOS=${JOBINFO[7]}
 # [See e.g. https://www.stackchief.com/tutorials/Bash%20Tutorial%3A%20getopts
 # for examples of how to use Bash's getopts]
 POSTPROC=0
+SUBMIT=0
 FOLLOWFROM=""
-while getopts "ht:n:u:m:p:q:af:" opt; do
+while getopts "haf:m:n:p:q:st:u:" opt; do
   case $opt in
     h)
       echo "Submit jobs for a simulation (using INPUT_FILE for input) and post-processing to the queue
 Usage: submit-run.sh [option] INPUT_FILE
 -h             Print help and exit
--t TIME        The run time, e.g. 24:00:00
--n NODES       The number of nodes to use for the simulation
--u TIME        The run time for the post-processing, e.g. 1:00:00
+-a             Do not submit post-processing job after the run
+-f JOBID       Make this job start after JOBID finishes successfully
 -m MEM         The requested memory for post-processing
+-n NODES       The number of nodes to use for the simulation
 -p PARTITION   The 'partition' (passed to 'sbatch --partition')
 -q QOS         The 'quality of service' (passed to 'sbatch --qos')
--a             Do not submit post-processing job after the run
--f JOBID       Make this job start after JOBID finishes successfully"
+-s             Only create submission scripts, do not actually submit jobs
+-t TIME        The run time, e.g. 24:00:00
+-u TIME        The run time for the post-processing, e.g. 1:00:00"
       exit 1
       ;;
-    t)
-      RUNTIME=$OPTARG
+    a)
+      POSTPROC=1
       ;;
-    n)
-      NODES=$OPTARG
-      ;;
-    u)
-      POSTPROCTIME=$OPTARG
+    f)
+      FOLLOWFROM="-d afterok:$OPTARG"
       ;;
     m)
       POSTPROCMEM=$OPTARG
+      ;;
+    n)
+      NODES=$OPTARG
       ;;
     p)
       PARTITION=$OPTARG
@@ -57,11 +59,14 @@ Usage: submit-run.sh [option] INPUT_FILE
     q)
       QOS=$OPTARG
       ;;
-    a)
-      POSTPROC=1
+    s)
+      SUBMIT=1
       ;;
-    f)
-      FOLLOWFROM="-d afterok:$OPTARG"
+    t)
+      RUNTIME=$OPTARG
+      ;;
+    u)
+      POSTPROCTIME=$OPTARG
       ;;
   esac
 done
@@ -89,18 +94,22 @@ mkdir -p $RUNDIR
 RUNJOBSCRIPT=${RUNDIR}$RUNNAME.job
 sed -e "s|NODES|$NODES|" -e "s|RUNTIME|$RUNTIME|" -e "s|ACCOUNT|$ACCOUNT|" -e "s|PARTITION|$PARTITION|" -e "s|QOS|$QOS|" -e "s|RUNDIR|$RUNDIR|" -e "s|INPUTFILE|$INPUTFILE|" machines/$MACHINE/jobscript-run.template > $RUNJOBSCRIPT
 
-JOBID=$(sbatch $FOLLOWFROM --parsable $RUNJOBSCRIPT)
-echo "Run: $JOBID"
-echo "In the queue" > ${RUNDIR}slurm-$JOBID.out
+if [[ $SUBMIT -eq 0 ]]; then
+  JOBID=$(sbatch $FOLLOWFROM --parsable $RUNJOBSCRIPT)
+  echo "Run: $JOBID"
+  echo "In the queue" > ${RUNDIR}slurm-$JOBID.out
+fi
 
 if [[ $POSTPROC -eq 0 ]]; then
   # Create a submission script for post-processing
   POSTPROCJOBSCRIPT=${RUNDIR}$RUNNAME-post.job
   sed -e "s|POSTPROCMEMORY|$POSTPROCMEMORY|" -e "s|POSTPROCTIME|$POSTPROCTIME|" -e "s|ACCOUNT|$ACCOUNT|" -e "s|RUNDIR|$RUNDIR|" machines/$MACHINE/jobscript-postprocess.template > $POSTPROCJOBSCRIPT
 
-  POSTID=$(sbatch -d afterany:$JOBID --parsable $POSTPROCJOBSCRIPT)
-  echo "Postprocess: $POSTID"
-  echo "In the queue" > ${RUNDIR}slurm-post-$POSTID.out
+  if [[ $SUBMIT -eq 0 ]]; then
+    POSTID=$(sbatch -d afterany:$JOBID --parsable $POSTPROCJOBSCRIPT)
+    echo "Postprocess: $POSTID"
+    echo "In the queue" > ${RUNDIR}slurm-post-$POSTID.out
+  fi
 fi
 
 echo "Done"

--- a/submit-run.sh
+++ b/submit-run.sh
@@ -24,7 +24,8 @@ QOS=${JOBINFO[7]}
 POSTPROC=0
 SUBMIT=0
 FOLLOWFROM=""
-while getopts "haf:m:n:p:q:st:u:" opt; do
+MAKIEPOSTPROCESS=1
+while getopts "haf:m:n:p:oq:st:u:" opt; do
   case $opt in
     h)
       echo "Submit jobs for a simulation (using INPUT_FILE for input) and post-processing to the queue
@@ -34,6 +35,7 @@ Usage: submit-run.sh [option] INPUT_FILE
 -f JOBID       Make this job start after JOBID finishes successfully
 -m MEM         The requested memory for post-processing
 -n NODES       The number of nodes to use for the simulation
+-o             Use original post_processing, instead of makie_post_processing, for the post-processing job
 -p PARTITION   The 'partition' (passed to 'sbatch --partition')
 -q QOS         The 'quality of service' (passed to 'sbatch --qos')
 -s             Only create submission scripts, do not actually submit jobs
@@ -52,6 +54,9 @@ Usage: submit-run.sh [option] INPUT_FILE
       ;;
     n)
       NODES=$OPTARG
+      ;;
+    o)
+      MAKIEPOSTPROCESS=0
       ;;
     p)
       PARTITION=$OPTARG
@@ -103,7 +108,12 @@ fi
 if [[ $POSTPROC -eq 0 ]]; then
   # Create a submission script for post-processing
   POSTPROCJOBSCRIPT=${RUNDIR}$RUNNAME-post.job
-  sed -e "s|POSTPROCMEMORY|$POSTPROCMEMORY|" -e "s|POSTPROCTIME|$POSTPROCTIME|" -e "s|ACCOUNT|$ACCOUNT|" -e "s|RUNDIR|$RUNDIR|" machines/$MACHINE/jobscript-postprocess.template > $POSTPROCJOBSCRIPT
+  if [[ MAKIEPOSTPROCESS -eq 1 ]]; then
+    POSTPROCESSTEMPLATE=jobscript-postprocess.template
+  else
+    POSTPROCESSTEMPLATE=jobscript-postprocess-plotsjl.template
+  fi
+  sed -e "s|POSTPROCMEMORY|$POSTPROCMEMORY|" -e "s|POSTPROCTIME|$POSTPROCTIME|" -e "s|ACCOUNT|$ACCOUNT|" -e "s|RUNDIR|$RUNDIR|" machines/$MACHINE/$POSTPROCESSTEMPLATE > $POSTPROCJOBSCRIPT
 
   if [[ $SUBMIT -eq 0 ]]; then
     POSTID=$(sbatch -d afterany:$JOBID --parsable $POSTPROCJOBSCRIPT)

--- a/util/precompile_makie_plots.jl
+++ b/util/precompile_makie_plots.jl
@@ -6,10 +6,11 @@ using moment_kinetics
 
 # Create a temporary directory for test output
 test_output_directory = tempname()
+run_name = "precompilation"
 mkpath(test_output_directory)
 
 input_dict = Dict("nstep"=>1,
-                  "run_name"=>"precompilation",
+                  "run_name"=>run_name,
                   "base_directory" => test_output_directory,
                   "dt" => 0.0,
                   "r_ngrid" => 5,
@@ -58,5 +59,5 @@ for (k,v) ∈ precompile_postproc_options
     end
 end
 
-moment_kinetics.makie_post_processing.makie_post_process(test_output_directory,
-                                                         precompile_postproc_options)
+moment_kinetics.makie_post_processing.makie_post_process(
+    joinpath(test_output_directory, run_name), precompile_postproc_options)


### PR DESCRIPTION
* There was a bug in `util/precompile_makie_plots.jl` which meant that precompiling makie_post_processing would fail.
* Add an option in `submit-run.sh` and `submit-restart.sh` to just create submission scripts, not actually submit the jobs. This is useful if you want to edit the submission scripts by hand for some reason.
* Uses `run_makie_post_processing.jl` in the cluster post-processing job. ~~(To change this locally, edit `machines/archer/jobscript-postprocess.template`, etc.)~~ To use the original `post_processing.jl` instead, pass the flag `-o` to the `submit-run.sh` or `submit-restart.sh` scripts.
* Adds the `-O3` flag when compiling the sysimage for post-processing. This should not have any negative consequences (unlike `--check-bounds=no), and might speed things up.
* To avoid timeouts when running sysimage-compiling jobs:
    * Separates the sysimage-compiling for the simulation code and the post-processing into separate jobs (they are different sysimages because simulations use optimized flags, while post-processing should not use `--bounds-check=no`).
    * Adds an option to make a sysimage with just the precompilation step done, without an test simulations being run to compile functions used in the code. This should be faster (in case the sysimage-compile job is timing out) at the cost of increasing compile time at the beginning of each simulation.