### PR TITLE
Flush stdout after printing progress messages

### DIFF
--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -347,6 +347,11 @@ function setup_moment_kinetics(input_dict::Dict; restart_prefix_iblock=nothing,
     # Set up MPI
     initialize_comms!()
 
+    if global_rank[] == 0
+        println("Starting setup   ", Dates.format(now(), dateformat"H:MM:SS"))
+        flush(stdout)
+    end
+
     input = mk_input(input_dict; save_inputs_to_txt=true, ignore_MPI=false)
     # obtain input options from moment_kinetics_input.jl
     # and check input to catch errors

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -736,6 +736,7 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
     @serial_region begin
         if global_rank[] == 0
              println("beginning time advance   ", Dates.format(now(), dateformat"H:MM:SS"))
+             flush(stdout)
         end
     end
 
@@ -771,6 +772,7 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
             if isfile(t_input.stopfile)
                 # Stop cleanly if a file called 'stop' was created
                 println("Found 'stop' file $(t_input.stopfile), aborting run")
+                flush(stdout)
                 finish_now = true
             end
         end
@@ -829,12 +831,14 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
                 end
                 if global_rank[] == 0
                     println("    residuals:", result_string)
+                    flush(stdout)
                 end
                 if t_input.converged_residual_value > 0.0
                     if global_rank[] == 0
                         if all(r < t_input.converged_residual_value for r ∈ all_residuals)
                             println("Run converged! All tested residuals less than ",
                                     t_input.converged_residual_value)
+                            flush(stdout)
                             finish_now = true
                         end
                     end
@@ -843,6 +847,7 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
             else
                 if global_rank[] == 0
                     println()
+                    flush(stdout)
                 end
             end
 
@@ -972,6 +977,7 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
                 if global_rank[] == 0
                     println("writing distribution functions at step ", i,"  ",
                                    Dates.format(now(), dateformat"H:MM:SS"))
+                    flush(stdout)
                 end
             end
             write_dfns_data_to_binary(pdf.charged.norm, pdf.neutral.norm, moments, fields,


### PR DESCRIPTION
When running as a batch job, status messages often do not get flushed immediately by default, so force this.

Also add a message for when setup_moment_kinetics() starts, so if the code hangs we can see if it was during compilation or during the actual initialization.