### PR TITLE
Add bc that sets zero only at the incoming boundary

### DIFF
--- a/docs/src/external_sources.md
+++ b/docs/src/external_sources.md
@@ -1,0 +1,6 @@
+`external_sources`
+==================
+
+```@autodocs
+Modules = [moment_kinetics.external_sources]
+```

--- a/docs/src/moment_kinetic_equations.md
+++ b/docs/src/moment_kinetic_equations.md
@@ -7,23 +7,25 @@ the Excalibur/Neptune reports. Equation references give the report number and
 equation number, e.g. (TN-04;1) is equation (1) from report TN-04.pdf.
 
 The drift kinetic equation (DKE), marginalised over $v_{\perp}$, for ions is,
-adding ionization to the form in (TN-04;1),
+adding ionization and a source term to the form in (TN-04;1),
 
 ```math
 \begin{equation}
   \frac{\partial f_{i}}{\partial t}
   +v_{\|}\frac{\partial f_{i}}{\partial z}
   -\frac{e}{m}\frac{\partial\phi}{\partial z}\frac{\partial f_{i}}{\partial v_{\|}}
-  = -R_{\mathrm{in}}\left(n_{n}f_{i}-n_{i}f_{n}\right)+R_{\mathrm{ion}}n_{i}f_{n},
+  = -R_{\mathrm{in}}\left(n_{n}f_{i}-n_{i}f_{n}\right)+R_{\mathrm{ion}}n_{i}f_{n}
+    + S_i,
 \end{equation}
 ```
 
-and for neutrals, adding ionization to (TN-04;2)
+and for neutrals, adding ionization and a source term to (TN-04;2)
 ```math
 \begin{equation}
   \frac{\partial f_{n}}{\partial t}
   +v_{\|}\frac{\partial f_{n}}{\partial z}
   = -R_{\mathrm{in}}\left(n_{i}f_{n}-n_{n}f_{i}\right)-R_{\mathrm{ion}}n_{i}f_{n}
+    + S_n.
 \end{equation}
 ```
 
@@ -39,6 +41,7 @@ Using the normalizations (TN04;5-11)
   \tilde{\phi} & \doteq\frac{e\phi}{T_{e}}\\
   \tilde{R}_{\mathrm{in}} & \doteq R_{\mathrm{in}}\frac{N_{e}L_{z}}{c_{s}}\\
   \tilde{R}_{\mathrm{ion}} & \doteq R_{\mathrm{ion}}\frac{N_{e}L_{z}}{c_{s}}
+  \tilde{S}_i = S_i \frac{c_s\sqrt{\pi}}{N_e} \frac{L_z}{c_s} = S_i \frac{L_z\sqrt{\pi}}{N_e}
 \end{align}
 ```
 
@@ -53,6 +56,7 @@ constant reference parameters, the ion DKE is
     \frac{\partial\tilde{f}_{i}}{\partial\tilde{v}_{\|}}
   = -\tilde{R}_{in}\left(\tilde{n}_{n}\tilde{f}_{i}-\tilde{n}_{i}\tilde{f}_{n}\right)
     + \tilde{R}_{\mathrm{ion}}\tilde{n}_{i}\tilde{f}_{n}
+    + \tilde{S}_i
 \end{equation}
 ```
 
@@ -64,6 +68,7 @@ and the neutral DKE is
   + v_{\|}\frac{\partial\tilde{f}_{n}}{\partial\tilde{z}}
   = -\tilde{R}_{in}\left(\tilde{n}_{i}\tilde{f}_{n}-\tilde{n}_{n}\tilde{f}_{i}\right)
     - \tilde{R}_{\mathrm{ion}}\tilde{n}_{i}\tilde{f}_{n}
+    + \tilde{S}_n.
 \end{equation}
 ```
 
@@ -130,9 +135,10 @@ tildes from here on)
 ```math
 \begin{align}
   \frac{\partial n_{i}}{\partial t}+\frac{\partial\left(n_{i}u_{i}\right)}{\partial z}
-  & = -R_{in}\left(n_{n}n_{i}-n_{i}n_{n}\right)+R_{\mathrm{ion}}n_{i}n_{n} \\
+  & = -R_{in}\left(n_{n}n_{i}-n_{i}n_{n}\right)+R_{\mathrm{ion}}n_{i}n_{n}
+      + \int dv_\parallel S_i\\
 
-  & = R_{\mathrm{ion}}n_{i}n_{n}
+  & = R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_i
 \end{align}
 ```
 
@@ -160,7 +166,8 @@ tildes from here on)
   & = -R_{in}\left(n_{n}n_{i}u_{i} - n_{i}n_{n}u_{n}\right)
       + R_{\mathrm{ion}}n_{i}n_{n}u_{n} \\
 
-  n_{i}\frac{\partial u_{i}}{\partial t} + u_{i}\left(R_{\mathrm{ion}}n_{i}n_{n}\right)
+  n_{i}\frac{\partial u_{i}}{\partial t}
+  + u_{i}\left(R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{i}\right)
   + \frac{\partial p_{\|,i}}{\partial z} + n_{i}u_{i}\frac{\partial u_{i}}{\partial z}
   + \frac{1}{2}\frac{\partial\phi}{\partial z}n_{i}
   & = -R_{in}\left(n_{n}n_{i}u_{i} - n_{i}n_{n}u_{n}\right)
@@ -178,6 +185,7 @@ tildes from here on)
   + u_{i}\frac{\partial u_{i}}{\partial z} + \frac{1}{2}\frac{\partial\phi}{\partial z}
   = -R_{in}n_{n}\left(u_{i}-u_{n}\right)
     + R_{\mathrm{ion}}\frac{n_{i}n_{n}}{n_{s}}\left(u_{n}-u_{i}\right)
+    - \frac{u_{i}}{n_{i}} \int dv_\parallel S_{i}
 \end{equation}
 ```
 
@@ -188,7 +196,8 @@ tildes from here on)
     + n_{i}u_{i}^{3}\right)}{\partial z} + \frac{\partial\phi}{\partial z}n_{i}u_{i} \\
   & = -R_{in}\left(n_{n}\left(p_{\|,i} + n_{i}u_{i}^{2}\right)
       - n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)\right)
-      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n}+n_{n}u_{n}^{2}\right) \\
+      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n}+n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{i} \\
 \end{align}
 ```
 
@@ -206,7 +215,8 @@ tildes from here on)
   + n_{i}u_{i}^{3}\right)}{\partial z} + \frac{\partial\phi}{\partial z}n_{i}u_{i}
   & = -R_{in}\left(n_{n}\left(p_{\|,i} + n_{i}u_{i}^{2}\right)
                    - n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)\right)
-      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) \\
+      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{i} \\
 
   \frac{p_{\|,i}}{\partial t} + 2u_{i}\frac{\partial n_{i}u_{i}}{\partial t}
   - u_{i}^{2}\frac{\partial n_{i}}{\partial t} + \frac{\partial\left(q_{\|,i}
@@ -214,7 +224,8 @@ tildes from here on)
   + \frac{\partial\phi}{\partial z}n_{i}u_{i}
   & = -R_{in}\left(n_{n}\left(p_{\|,i} + n_{i}u_{i}^{2}\right)
       - n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)\right)
-      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) \\
+      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{i} \\
 
   \frac{\partial p_{\|,i}}{\partial t} + 2u_{i}\left(-\frac{\partial p_{\|,i}}{\partial z}
   - \frac{\partial\left(n_{i}u_{i}^{2}\right)}{\partial z}
@@ -222,26 +233,30 @@ tildes from here on)
   - R_{in}\left(n_{n}n_{i}u_{i} - n_{i}n_{n}u_{n}\right)
   + R_{\mathrm{ion}}n_{i}n_{n}u_{n}\right) \\
   -u_{i}^{2}\left(-\frac{\partial\left(n_{i}u_{i}\right)}{\partial z}
-  + R_{\mathrm{ion}}n_{i}n_{n}\right) + \frac{\partial q_{\|,i}}{\partial z}
+  + R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{i}\right)
+  + \frac{\partial q_{\|,i}}{\partial z}
   + \frac{\partial\left(3u_{i}p_{\|,i}\right)}{\partial z}
   + \frac{\partial\left(n_{i}u_{i}^{3}\right)}{\partial z}
   + \frac{\partial\phi}{\partial z}n_{i}u_{i}
   & = -R_{in}\left(n_{n}\left(p_{\|,i} + n_{i}u_{i}^{2}\right)
       - n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)\right)
-      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) \\
+      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{i} \\
 
   \frac{\partial p_{\|,i}}{\partial t} + u_{i}\frac{\partial p_{\|,i}}{\partial z}
   + 3p_{\|,i}\frac{\partial u_{i}}{\partial z} + \frac{\partial q_{\|,i}}{\partial z}
   & = -R_{in}\left(n_{n}\left(p_{\|,i} + n_{i}u_{i}^{2}\right) - n_{i}\left(p_{\|,n}
       + n_{n}u_{n}^{2}\right) - 2u_{i}\left(n_{n}n_{i}u_{i} - n_{i}n_{n}u_{n}\right)\right) \\
       & \quad + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2} + n_{n}u_{i}^{2}
-      - 2n_{n}u_{i}u_{n}\right) \\
+      - 2n_{n}u_{i}u_{n}\right)
+      + \int dv_\parallel v_\parallel^2 S_{i} + u_{i}^2 \int dv_\parallel S_{i} \\
 
   \frac{\partial p_{\|,i}}{\partial t} + u_{i}\frac{\partial p_{\|,i}}{\partial z}
   + 3p_{\|,i}\frac{\partial u_{i}}{\partial z} + \frac{\partial q_{\|,i}}{\partial z}
   & = -R_{in}\left(n_{n}p_{\|,i} - n_{i}p_{\|,n} - n_{i}n_{n}\left(u_{i}^{2} + u_{n}^{2}
       - 2u_{i}u_{n}\right)\right) + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}\left(u_{n}
       - u_{i}\right)^{2}\right) \\
+      & \quad + \int dv_\parallel v_\parallel^2 S_{i} + u_{i}^2 \int dv_\parallel S_{i} \\
 \end{align*}
 ```
 
@@ -255,7 +270,8 @@ tildes from here on)
     + 3p_{\|,i}\frac{\partial u_{i}}{\partial z} + \frac{\partial q_{\|,i}}{\partial z} \\
   & = -R_{in}\left(n_{n}p_{\|,i} - n_{i}p_{\|,n}
       - n_{i}n_{n}\left(u_{i} - u_{n}\right)^{2}\right)
-      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}\left(u_{n} - u_{i}\right)^{2}\right)
+      + R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}\left(u_{n} - u_{i}\right)^{2}\right) \\
+      & \quad + \int dv_\parallel v_\parallel^2 S_{i} + u_{i}^2 \int dv_\parallel S_{i} \\
 \end{align}
 ```
 
@@ -264,9 +280,10 @@ and of the neutral DKE to give neutral moment equations
 ```math
 \begin{align}
   \frac{\partial n_{n}}{\partial t} + \frac{\partial\left(n_{n}u_{n}\right)}{\partial z}
-  & = -R_{i}\left(n_{i}n_{n} - n_{n}n_{i}\right) - R_{\mathrm{ion}}n_{i}n_{n} \\
+  & = -R_{i}\left(n_{i}n_{n} - n_{n}n_{i}\right) - R_{\mathrm{ion}}n_{i}n_{n}
+      + \int dv_\parallel S_{n} \\
 
-  & =-R_{\mathrm{ion}}n_{i}n_{n}
+  & =-R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{n}
 \end{align}
 ```
 
@@ -294,7 +311,8 @@ and of the neutral DKE to give neutral moment equations
       - R_{\mathrm{ion}}n_{i}n_{n}u_{n} \\
 
   n_{n}\frac{\partial u_{n}}{\partial t}
-  + u_{n}\left(-R_{\mathrm{ion}}n_{i}n_{n}\right) + \frac{\partial p_{\|,n}}{\partial z}
+  + u_{n}\left(-R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{n}\right)
+  + \frac{\partial p_{\|,n}}{\partial z}
   + n_{n}u_{s}\frac{\partial u_{n}}{\partial z}
   & = -R_{in}\left(n_{i}n_{n}u_{n} - n_{n}n_{i}u_{i}\right)
       - R_{\mathrm{ion}}n_{i}n_{n}u_{n} \\
@@ -309,7 +327,7 @@ and of the neutral DKE to give neutral moment equations
 \begin{equation}
   \frac{\partial u_{n}}{\partial t} + \frac{1}{n_{n}}\frac{\partial p_{\|,n}}{\partial z}
   + u_{n}\frac{\partial u_{n}}{\partial z}
-  = -R_{in}n_{i}\left(u_{n} - u_{i}\right)
+  = -R_{in}n_{i}\left(u_{n} - u_{i}\right) - \frac{u_{n}}{n_{n}} \int dv_\parallel S_{n}
 \end{equation}
 ```
 
@@ -320,7 +338,8 @@ and of the neutral DKE to give neutral moment equations
     + n_{n}u_{n}^{3}\right)}{\partial z} + q_{n}\frac{\partial\phi}{\partial z}n_{n}u_{n} \\
   & = -R_{in}\left(n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) - n_{n}\left(p_{\|,i}
       + n_{i}u_{i}^{2}\right)\right)
-      - R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) \\
+      - R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{n} \\
 \end{align}
 ```
 
@@ -338,7 +357,8 @@ and of the neutral DKE to give neutral moment equations
   + q_{n}\frac{\partial\phi}{\partial z}n_{n}u_{n}
   & =-R_{in}\left(n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) - n_{n}\left(p_{\|,i}
       + n_{i}u_{i}^{2}\right)\right)
-      - R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) \\
+      - R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{n} \\
 
   \frac{\partial p_{\|,n}}{\partial t} + 2u_{n}\frac{\partial n_{n}u_{n}}{\partial t}
   - u_{n}^{2}\frac{\partial n_{n}}{\partial t} + \frac{\partial\left(q_{\|,n}
@@ -346,7 +366,8 @@ and of the neutral DKE to give neutral moment equations
   + q_{n}\frac{\partial\phi}{\partial z}n_{n}u_{n}
   & = -R_{in}\left(n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) - n_{n}\left(p_{\|,i}
       + n_{i}u_{i}^{2}\right)\right) - R_{\mathrm{ion}}n_{i}\left(p_{\|,n}
-      + n_{n}u_{n}^{2}\right) \\
+      + n_{n}u_{n}^{2}\right)
+      + \int dv_\parallel v_\parallel^2 S_{n} \\
 
   \frac{\partial p_{\|,n}}{\partial t}
   + 2u_{n}\left(-\frac{\partial p_{\|,n}}{\partial z}
@@ -355,24 +376,28 @@ and of the neutral DKE to give neutral moment equations
   - R_{in}\left(n_{i}n_{n}u_{n} - n_{n}n_{i}u_{i}\right)
   - R_{\mathrm{ion}}n_{i}n_{n}u_{n}\right) \\
   - u_{n}^{2}\left(-\frac{\partial\left(n_{n}u_{n}\right)}{\partial z}
-  - R_{\mathrm{ion}}n_{i}n_{n}\right) + \frac{\partial q_{\|,n}}{\partial z}
+  - R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{n}\right)
+  + \frac{\partial q_{\|,n}}{\partial z}
   + \frac{\partial\left(3u_{n}p_{\|,n}\right)}{\partial z}
   + \frac{\partial\left(n_{n}u_{n}^{3}\right)}{\partial z}
   & = -R_{in}\left(n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) - n_{n}\left(p_{\|,i}
   + n_{i}u_{i}^{2}\right)\right)
-  - R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) \\
+  - R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right)
+  + \int dv_\parallel v_\parallel^2 S_{n} \\
 
   \frac{\partial p_{\|,n}}{\partial t} + u_{n}\frac{\partial p_{\|,n}}{\partial z}
   + 3p_{\|,n}\frac{\partial u_{n}}{\partial z} + \frac{\partial q_{\|,n}}{\partial z}
   & = -R_{in}\left(n_{i}\left(p_{\|,n} + n_{n}u_{n}^{2}\right) - n_{n}\left(p_{\|,i}
       + n_{i}u_{i}^{2}\right) - 2u_{n}\left(n_{i}n_{n}u_{n}
       - n_{n}n_{i}u_{i}\right)\right) - R_{\mathrm{ion}}n_{i}\left(p_{\|,n}
-      + n_{n}u_{n}^{2} + n_{n}u_{n}^{2} - 2n_{n}u_{n}u_{n}\right) \\
+      + n_{n}u_{n}^{2} + n_{n}u_{n}^{2} - 2n_{n}u_{n}u_{n}\right)
+      + \int dv_\parallel v_\parallel^2 S_{n} + u_{n}^2\int dv_\parallel S_{n} \\
 
   \frac{\partial p_{\|,n}}{\partial t} + u_{n}\frac{\partial p_{\|,n}}{\partial z}
   + 3p_{\|,n}\frac{\partial u_{n}}{\partial z} + \frac{\partial q_{\|,n}}{\partial z}
   & = -R_{in}\left(n_{i}p_{\|,n} - n_{n}p_{\|,i} - n_{n}n_{i}\left(u_{n}^{2} + u_{i}^{2}
-      - 2u_{n}u_{i}\right)\right) - R_{\mathrm{ion}}n_{i}p_{\|,n} \\
+      - 2u_{n}u_{i}\right)\right) - R_{\mathrm{ion}}n_{i}p_{\|,n}
+      + \int dv_\parallel v_\parallel^2 S_{n} + u_{n}^2\int dv_\parallel S_{n} \\
 \end{align*}
 ```
 
@@ -385,7 +410,8 @@ and of the neutral DKE to give neutral moment equations
   & \frac{\partial p_{\|,n}}{\partial t} + u_{n}\frac{\partial p_{\|,n}}{\partial z}
     + 3p_{\|,n}\frac{\partial u_{n}}{\partial z} + \frac{\partial q_{\|,n}}{\partial z} \\
   & = -R_{in}\left(n_{i}p_{\|,n} - n_{n}p_{\|,i}
-      - n_{n}n_{i}\left(u_{n} - u_{i}\right)^{2}\right) - R_{\mathrm{ion}}n_{i}p_{\|,n}
+      - n_{n}n_{i}\left(u_{n} - u_{i}\right)^{2}\right) - R_{\mathrm{ion}}n_{i}p_{\|,n} \\
+      & \quad + \int dv_\parallel v_\parallel^2 S_{n} + u_{n}^2\int dv_\parallel S_{n} \\
 \end{align}
 ```
 
@@ -490,7 +516,7 @@ equations for the moment)
     - \frac{w_{\|,i}}{2}\left(\frac{1}{p_{\|,i}}\frac{\partial p_{\|,i}}{\partial z}
     - \frac{1}{n_{i}}\frac{\partial n_{i}}{\partial z}\right)\frac{\partial f_{i}}{\partial w_{\|,i}}\right) \\
   & - \frac{1}{2v_{\mathrm{th},i}}\frac{\partial\phi}{\partial z}\frac{\partial f_{i}}{\partial w_{\|,i}} \\
-  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n}
+  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n} + S_{i}
 \end{align}
 ```
 
@@ -511,7 +537,7 @@ equations for the moment)
   - \frac{w_{\|,i}}{2}\left(\frac{1}{p_{\|,i}}\frac{\partial p_{\|,i}}{\partial z}
   - \frac{1}{n_{i}}\frac{\partial n_{i}}{\partial z}\right)\frac{\partial f_{i}}{\partial w_{\|,i}}\right)
   - \frac{1}{2v_{\mathrm{th},i}}\frac{\partial\phi}{\partial z}\frac{\partial f_{i}}{\partial w_{\|,i}}
-  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n} \\
+  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n} + S_{i} \\
 
   \frac{\partial f_{i}}{\partial t} + \left(v_{\mathrm{th},i}w_{\|,i}
   + u_{i}\right)\frac{\partial f_{i}}{\partial z}
@@ -523,8 +549,8 @@ equations for the moment)
   - \frac{w_{\|,i}}{2}\left(\frac{1}{p_{\|,i}}\frac{\partial p_{\|,i}}{\partial z}
   - \frac{1}{n_{i}}\frac{\partial n_{i}}{\partial z}\right)\right)
   - \frac{1}{2v_{\mathrm{th},i}}\frac{\partial\phi}{\partial z}\right]\frac{\partial f_{i}}{\partial w_{\|,i}}
-  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n} \\
-\end{align}
+  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n} + S_{i} \\
+\end{align*}
 ```
 
 ```@raw html
@@ -543,7 +569,7 @@ equations for the moment)
   & \qquad + \frac{w_{\|,i}}{2}\frac{1}{n_{i}}\left(\frac{\partial n_{i}}{\partial t}
           + \left(v_{\mathrm{th},i}w_{\|,i}
           + \left.u_{i}\right)\frac{\partial n_{i}}{\partial z}\right)\right]\frac{\partial f_{i}}{\partial w_{\|,i}} \\
-  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n}
+  & = -R_{in}\left(n_{n}f_{i} - n_{i}f_{n}\right) + R_{\mathrm{ion}}n_{i}f_{n} + S_{i}
 \end{align}
 ```
 
@@ -559,7 +585,7 @@ and the neutral DKE
     - \frac{1}{v_{\mathrm{th},n}}\frac{\partial u_{n}}{\partial z}\frac{\partial f_{n}}{\partial w_{\|,n}}
     - \frac{w_{\|,n}}{2}\left(\frac{1}{p_{\|,n}}\frac{\partial p_{\|,n}}{\partial z}
     - \frac{1}{n_{n}}\frac{\partial n_{n}}{\partial z}\right)\frac{\partial f_{n}}{\partial w_{\|,n}}\right) \\
-  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} \\
+  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} + S_{n} \\
 \end{align}
 ```
 
@@ -579,7 +605,7 @@ and the neutral DKE
   + u_{n}\right)\left(-\frac{1}{v_{\mathrm{th},n}}\frac{\partial u_{n}}{\partial z}\frac{\partial f_{n}}{\partial w_{\|,n}}
   - \frac{w_{\|,n}}{2}\left(\frac{1}{p_{\|,n}}\frac{\partial p_{\|,n}}{\partial z}
   - \frac{1}{n_{n}}\frac{\partial n_{n}}{\partial z}\right)\frac{\partial f_{n}}{\partial w_{\|,n}}\right)
-  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} \\
+  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} + S_{n} \\
 
   \frac{\partial f_{n}}{\partial t} + \left(v_{\mathrm{th},n}w_{\|,n}
   + u_{n}\right)\frac{\partial f_{n}}{\partial z}
@@ -589,7 +615,7 @@ and the neutral DKE
   + u_{n}\right)\left(-\frac{1}{v_{\mathrm{th},n}}\frac{\partial u_{n}}{\partial z}
   - \frac{w_{\|,n}}{2}\left(\frac{1}{p_{\|,n}}\frac{\partial p_{\|,n}}{\partial z}
   - \frac{1}{n_{n}}\frac{\partial n_{n}}{\partial z}\right)\right)\right]\frac{\partial f_{n}}{\partial w_{\|,n}}
-  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} \\
+  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} + S_{n} \\
 \end{align*}
 ```
 
@@ -608,7 +634,7 @@ and the neutral DKE
   & \qquad + \left.\frac{w_{\|,n}}{2}\frac{1}{n_{n}}\left(\frac{\partial n_{n}}{\partial t}
            + \left(v_{\mathrm{th},n}w_{\|,n}
            + u_{n}\right)\frac{\partial n_{n}}{\partial z}\right)\right]\frac{\partial f_{n}}{\partial w_{\|,n}} \\
-  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n}
+  & = -R_{in}\left(n_{i}f_{n} - n_{n}f_{i}\right) - R_{\mathrm{ion}}n_{i}f_{n} + S_{n}
 \end{align}
 ```
 
@@ -681,7 +707,8 @@ for the ion DKE and $-$'ve sign for the neutral DKE.
   + u_{s}\right)\frac{\partial n_{s}}{\partial z}\right)\right]\frac{n_{s}}{v_{\mathrm{th},s}}\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}\left(n_{s'}\frac{n_{s}}{v_{\mathrm{th},s}}g_{s}
       - n_{s}\frac{n_{s'}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
+      \pm R_{\mathrm{ion}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + S_{s} \\
 \end{align}
 ```
 
@@ -706,7 +733,8 @@ for the ion DKE and $-$'ve sign for the neutral DKE.
   + \left(v_{\mathrm{th},s}w_{\|,s}
   + u_{s}\right)\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s} \\
 
   \Rightarrow & \frac{\partial g_{s}}{\partial t}
   + \frac{v_{\mathrm{th},s}}{n_{s}}\left(v_{\mathrm{th},s}w_{\|,s}
@@ -727,7 +755,8 @@ for the ion DKE and $-$'ve sign for the neutral DKE.
   + \left(v_{\mathrm{th},s}w_{\|,s}
   + u_{s}\right)\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s} \\
 \end{align}
 ```
 
@@ -755,6 +784,7 @@ for the ion DKE and $-$'ve sign for the neutral DKE.
   + u_{s}\right)\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
       \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s}
 \end{align}
 ```
 
@@ -783,7 +813,8 @@ So then if we use the moment equations we can rewrite the DKE as
   + u_{s}\frac{\partial n_{s}}{\partial z}
   + v_{\mathrm{th},s}w_{\|,s}\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s} \\
 \end{align}
 ```
 
@@ -793,11 +824,11 @@ So then if we use the moment equations we can rewrite the DKE as
 ```
 
 ```math
-\begin{align}
+\begin{align*}
   \Rightarrow & \frac{\partial g_{s}}{\partial t}
   + \frac{v_{\mathrm{th},s}}{n_{s}}\left(v_{\mathrm{th},s}w_{\|,s}
   + u_{s}\right)\frac{\partial f_{s}}{\partial z}
-  + \frac{3g_{s}}{2n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n}
+  + \frac{3g_{s}}{2n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{s}
   - u_{s}\frac{\partial n_{s}}{\partial z}
   - n_{s}\frac{\partial u_{s}}{\partial z}\right) \\
   & -\frac{g_{s}}{2p_{\|,s}}\left(-u_{s}\frac{\partial p_{\|,s}}{\partial z}
@@ -805,14 +836,15 @@ So then if we use the moment equations we can rewrite the DKE as
   - 3p_{\|,s}\frac{\partial u_{s}}{\partial z}
   - R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - m_{s}n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
-  \pm R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + m_{s}n_{n}\left(u_{n} - u_{s}\right)^{2}\right)\right) \\
+  \pm R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + m_{s}n_{n}\left(u_{n} - u_{s}\right)^{2}\right)
+  + \int dv_\parallel v_\parallel^2 S_{s} + u_{s}^2 \int dv_\parallel S_{s} \right) \\
   & + \left[-\frac{1}{n_{s}v_{\mathrm{th},s}}\left(-\underbrace{\cancel{n_{s}u_{s}\frac{\partial u_{s}}{\partial z}}}_{A}
   - \frac{\partial p_{\|,s}}{\partial z}
   + R_{ss'}n_{s}n_{s'}\left(u_{s'} - u_{s}\right)
   \pm R_{\mathrm{ion}}n_{i}n_{n}u_{n}
   + v_{\mathrm{th},s}w_{\|,s}\left(\underbrace{\cancel{n_{s}\frac{\partial u_{s}}{\partial z}}}_{B}
   + \underbrace{\cancel{u_{s}\frac{\partial n_{s}}{\partial z}}}_{C}\right)\right)\right. \\
-  & \quad + \frac{u_{s}}{n_{s}v_{\mathrm{th},s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n}
+  & \quad + \frac{u_{s}}{n_{s}v_{\mathrm{th},s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{s}
   - \underbrace{\cancel{n_{s}\frac{\partial u_{s}}{\partial z}}}_{A}
   + \underbrace{\cancel{v_{\mathrm{th},s}w_{\|,s}\frac{\partial n_{s}}{\partial z}}}_{C}\right) \\
   & \quad-\frac{w_{\|,s}}{2}\frac{1}{p_{\|,s}}\left(-\frac{\partial q_{\|,s}}{\partial z}
@@ -820,71 +852,79 @@ So then if we use the moment equations we can rewrite the DKE as
   - R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - m_{s}n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
   \pm R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + m_{s}n_{n}\left(u_{n}
-  - u_{s}\right)^{2}\right) + v_{\mathrm{th},s}w_{\|,s}\frac{\partial p_{\|,s}}{\partial z}\right) \\
-  & \quad\left. + \frac{w_{\|,s}}{2}\frac{1}{n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n}
+  - u_{s}\right)^{2}\right) + \int dv_\parallel v_\parallel^2 S_{s} + u_{s}^2 \int dv_\parallel S_{s}
+  + v_{\mathrm{th},s}w_{\|,s}\frac{\partial p_{\|,s}}{\partial z}\right) \\
+  & \quad\left. + \frac{w_{\|,s}}{2}\frac{1}{n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{s}
   - \underbrace{\cancel{n_{s}\frac{\partial u_{s}}{\partial z}}}_{B}
   + v_{\mathrm{th},s}w_{\|,s}\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s} \\
 
   \Rightarrow & \frac{\partial g_{s}}{\partial t}
   + \frac{v_{\mathrm{th},s}}{n_{s}}\left(v_{\mathrm{th},s}w_{\|,s}
   + u_{s}\right)\frac{\partial f_{s}}{\partial z}
-  + \frac{3g_{s}}{2n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n}
+  + \frac{3g_{s}}{2n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{s}
   - u_{s}\frac{\partial n_{s}}{\partial z} - n_{s}\frac{\partial u_{s}}{\partial z}\right) \\
   & -\frac{g_{s}}{2p_{\|,s}}\left(-u_{s}\frac{\partial p_{\|,s}}{\partial z}
   - \frac{\partial q_{\|,s}}{\partial z} - 3p_{\|,s}\frac{\partial u_{s}}{\partial z}
   - R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - m_{s}n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
-  \pm R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + m_{s}n_{n}\left(u_{n} - u_{s}\right)^{2}\right)\right) \\
+  \pm R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + m_{s}n_{n}\left(u_{n} - u_{s}\right)^{2}\right)
+  + \int dv_\parallel v_\parallel^2 S_{s} + u_{s}^2 \int dv_\parallel S_{s}\right) \\
   & + \left[-\frac{1}{n_{s}v_{\mathrm{th},s}}\left(-\frac{\partial p_{\|,s}}{\partial z}
   + R_{ss'}n_{s}n_{s'}\left(u_{s'} - u_{s}\right)\pm R_{\mathrm{ion}}n_{i}n_{n}u_{n}\right)\right. \\
-  & \quad + \frac{u_{s}}{n_{s}v_{\mathrm{th},s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n}\right) \\
+  & \quad + \frac{u_{s}}{n_{s}v_{\mathrm{th},s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{s}\right) \\
   & \quad-\frac{w_{\|,s}}{2}\frac{1}{p_{\|,s}}\left(-\frac{\partial q_{\|,s}}{\partial z}
   - R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - m_{s}n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
   \pm R_{\mathrm{ion}}n_{i}\left(p_{\|,n} + m_{s}n_{n}\left(u_{n}
-  - u_{s}\right)^{2}\right) + v_{\mathrm{th},s}w_{\|,s}\frac{\partial p_{\|,s}}{\partial z}\right) \\
-  & \quad\left. + \frac{w_{\|,s}}{2}\frac{1}{n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n}
+  - u_{s}\right)^{2}\right) + \int dv_\parallel v_\parallel^2 S_{s} + u_{s}^2 \int dv_\parallel S_{s}
+  + v_{\mathrm{th},s}w_{\|,s}\frac{\partial p_{\|,s}}{\partial z}\right) \\
+  & \quad\left. + \frac{w_{\|,s}}{2}\frac{1}{n_{s}}\left(\pm R_{\mathrm{ion}}n_{i}n_{n} + \int dv_\parallel S_{s}
   + v_{\mathrm{th},s}w_{\|,s}\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s}\\
 
   \Rightarrow & \frac{\partial g_{s}}{\partial t}
   + \frac{v_{\mathrm{th},s}}{n_{s}}\left(v_{\mathrm{th},s}w_{\|,s}
   + u_{s}\right)\frac{\partial f_{s}}{\partial z}
   + g_{s}\left(\pm\frac{3}{2}R_{\mathrm{ion}}n_{i}\frac{n_{n}}{n_{s}}
+  + \frac{3}{2n_{s}}\int dv_\parallel S_{s}
   - \frac{3u_{s}}{2n_{s}}\frac{\partial n_{s}}{\partial z}\right) \\
   & + g_{s}\left(\frac{u_{s}}{2p_{\|,s}}\frac{\partial p_{\|,s}}{\partial z}
   + \frac{1}{2p_{\|,s}}\frac{\partial q_{\|,s}}{\partial z}
   + \frac{1}{2p_{\|,s}}R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
   \mp\frac{1}{2}R_{\mathrm{ion}}\frac{n_{i}}{p_{\|,s}}\left(p_{\|,n}
-  + n_{n}\left(u_{n} - u_{s}\right)^{2}\right)\right) \\
+  + n_{n}\left(u_{n} - u_{s}\right)^{2}\right)
+  - \frac{1}{2p_{\parallel,s}}\int dv_\parallel v_\parallel^2 S_{s} - \frac{u_{s}^2}{2p_{\parallel,s}}\int dv_\parallel S_{s}\right) \\
   & + \left[-\frac{1}{n_{s}v_{\mathrm{th},s}}\left(-\frac{\partial p_{\|,s}}{\partial z}
   + R_{ss'}n_{s}n_{s'}\left(u_{s'} - u_{s}\right)
-  \pm R_{\mathrm{ion}}n_{i}n_{n}\left(u_{n} - u_{s}\right)\right)\right. \\
+  \pm R_{\mathrm{ion}}n_{i}n_{n}\left(u_{n} - u_{s}\right) - u_{s}\int dv_\parallel S_{s}\right)\right. \\
   & \quad-\frac{w_{\|,s}}{2}\frac{1}{p_{\|,s}}\left(-\frac{\partial q_{\|,s}}{\partial z}
   - R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
+  + \int dv_\parallel v_\parallel^2 S_{s} + u_{s}^2 \int dv_\parallel S_{s}
   + v_{\mathrm{th},s}w_{\|,s}\frac{\partial p_{\|,s}}{\partial z}\right) \\
   & \quad\mp\frac{w_{\|,s}}{2}R_{\mathrm{ion}}n_{i}\left(\frac{p_{\|,n}}{p_{\|,s}}
   - \frac{n_{n}}{n_{s}} + \frac{n_{n}}{p_{\|,s}}\left(u_{n} - u_{s}\right)^{2}\right) \\
-  & \quad\left. + \frac{w_{\|,s}}{2}\frac{1}{n_{s}}\left(v_{\mathrm{th},s}w_{\|,s}\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
+  & \quad\left. + \frac{w_{\|,s}}{2}\frac{1}{n_{s}}\left(\int dv_\parallel S_{s} + v_{\mathrm{th},s}w_{\|,s}\frac{\partial n_{s}}{\partial z}\right)\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} \\
-\end{align}
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s}
+\end{align*}
 ```
 
 and finally using
 
 ```math
-\begin{align}
+\begin{align*}
   \frac{u_{s}}{v_{\mathrm{th},s}}\frac{\partial v_{\mathrm{th},s}}{\partial z}
   & =u_{s}\sqrt{\frac{n_{s}}{p_{\|,s}}}\frac{\partial}{\partial z}\sqrt{\frac{p_{\|,s}}{n_{s}}} \\
   & = \frac{u_{s}}{2}\left(\frac{1}{p_{\|,s}}\frac{\partial p_{\|,s}}{\partial z}
       - \frac{1}{n_{s}}\frac{\partial n_{s}}{\partial z}\right)
-\end{align}
+\end{align*}
 ```
 
 gives
@@ -899,25 +939,29 @@ gives
   + \frac{v_{\mathrm{th},s}}{n_{s}}\left(v_{\mathrm{th},s}w_{\|,s}
   + u_{s}\right)\frac{\partial f_{s}}{\partial z}
   + \left(\pm\frac{3}{2}R_{\mathrm{ion}}n_{i}\frac{n_{n}}{n_{s}}
+  + \frac{3}{2n_{s}} \int dv_\parallel S_{s}
   - \frac{u_{s}}{n_{s}}\frac{\partial n_{s}}{\partial z}\right)g_{s} \\
   & + \left(\frac{u_{s}}{v_{\mathrm{th},s}}\frac{\partial v_{\mathrm{th},s}}{\partial z}
   + \frac{1}{2p_{\|,s}}\frac{\partial q_{\|,s}}{\partial z}\right. \\
   & \qquad + \frac{1}{2p_{\|,s}}R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right) \\
   & \qquad \left.\mp\frac{1}{2}R_{\mathrm{ion}}\frac{n_{i}}{p_{\|,s}}\left(p_{\|,n}
-  + n_{n}\left(u_{n} - u_{s}\right)^{2}\right)\right)g_{s} \\
+  + n_{n}\left(u_{n} - u_{s}\right)^{2}\right)
+  - \frac{1}{2p_{\parallel,s}}\int dv_\parallel v_\parallel^2 S_{s} - \frac{u_{s}^2}{2p_{\parallel,s}}\int dv_\parallel S_{s}\right)g_{s} \\
   & + \left[-\frac{1}{n_{s}v_{\mathrm{th},s}}\left(-\frac{\partial p_{\|,s}}{\partial z}
   + R_{ss'}n_{s}n_{s'}\left(u_{s'} - u_{s}\right)
-  \pm R_{\mathrm{ion}}n_{i}n_{n}\left(u_{n} - u_{s}\right)\right)\right. \\
+  \pm R_{\mathrm{ion}}n_{i}n_{n}\left(u_{n} - u_{s}\right) - u_{s}\int dv_\parallel S_{s}\right)\right. \\
   & \qquad-\frac{w_{\|,s}}{2}\frac{1}{p_{\|,s}}\left(-\frac{\partial q_{\|,s}}{\partial z}
   - R_{ss'}\left(n_{s'}p_{\|,s} - n_{s}p_{\|,s'}
   - n_{s}n_{s'}\left(u_{s} - u_{s'}\right)^{2}\right)
+  + \int dv_\parallel v_\parallel^2 S_{s} + u_{s}^2 \int dv_\parallel S_{s}
   + v_{\mathrm{th},s}w_{\|,s}\frac{\partial p_{\|,s}}{\partial z}\right) \\
   & \qquad\mp\frac{w_{\|,s}}{2}R_{\mathrm{ion}}n_{i}\left(\frac{p_{\|,n}}{p_{\|,s}}
   - \frac{n_{n}}{n_{s}} + \frac{n_{n}}{p_{\|,s}}\left(u_{n} - u_{s}\right)^{2}\right) \\
-  & \qquad\left. + \frac{w_{\|,s}^{2}}{2}\frac{v_{\mathrm{th},s}}{n_{s}}\frac{\partial n_{s}}{\partial z}\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
+  & \qquad\left. + \frac{w_{\parallel,s}}{2}\frac{1}{n_{s}}\int dv_\parallel S_{s}
+  + \frac{w_{\|,s}^{2}}{2}\frac{v_{\mathrm{th},s}}{n_{s}}\frac{\partial n_{s}}{\partial z}\right]\frac{\partial g_{s}}{\partial w_{\|,s}} \\
   & = -R_{ss'}n_{s'}\left(g_{s} - \frac{v_{\mathrm{th},s}}{v_{\mathrm{th},s'}}g_{s'}\right)
-      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      \pm R_{\mathrm{ion}}\frac{v_{\mathrm{th},s}}{n_{s}}n_{i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} + \frac{v_{\mathrm{th},s}}{n_{s}} S_{s}
 \end{align}
 ```
 
@@ -928,26 +972,29 @@ Writing out the final result fully for ions
   & \frac{\partial g_{i}}{\partial t}
   + \frac{v_{\mathrm{th},i}}{n_{i}}\left(v_{\mathrm{th},i}w_{\|,i}
   + u_{i}\right)\frac{\partial f_{i}}{\partial z}
-  + \left(\frac{3}{2}R_{\mathrm{ion}}n_{n}
+  + \left(\frac{3}{2}R_{\mathrm{ion}}n_{n} + \frac{3}{2n_{i}}\int dv_\parallel S_{i}
   - \frac{u_{i}}{n_{i}}\frac{\partial n_{i}}{\partial z}\right)g_{i} \\
   & + \left(\frac{u_{i}}{v_{\mathrm{th},i}}\frac{\partial v_{\mathrm{th},i}}{\partial z}
   + \frac{1}{2p_{\|,i}}\frac{\partial q_{\|,i}}{\partial z}\right. \\
   & \qquad + \frac{1}{2p_{\|,i}}R_{in}\left(n_{n}p_{\|,i} - n_{i}p_{\|,n}
   - n_{i}n_{n}\left(u_{i} - u_{n}\right)^{2}\right) \\
   & \qquad \left. - \frac{1}{2}R_{\mathrm{ion}}\frac{n_{i}}{p_{\|,i}}\left(p_{\|,n}
-  + n_{n}\left(u_{n} - u_{i}\right)^{2}\right)\right)g_{i} \\
+  + n_{n}\left(u_{n} - u_{i}\right)^{2}\right)
+  - \frac{1}{2p_{\parallel,i}}\int dv_\parallel v_\parallel^2 S_{i} - \frac{u_{i}^2}{2p_{\parallel,i}}\int dv_\parallel S_{i}\right)g_{i} \\
   & + \left[-\frac{1}{n_{i}v_{\mathrm{th},i}}\left(-\frac{\partial p_{\|,i}}{\partial z}
   + R_{in}n_{i}n_{n}\left(u_{n} - u_{i}\right)
-  + R_{\mathrm{ion}}n_{i}n_{n}\left(u_{n} - u_{i}\right)\right)\right. \\
+  + R_{\mathrm{ion}}n_{i}n_{n}\left(u_{n} - u_{i}\right) - u_{i}\int dv_\parallel S_{i}\right)\right. \\
   & \qquad-\frac{w_{\|,i}}{2}\frac{1}{p_{\|,i}}\left(-\frac{\partial q_{\|,i}}{\partial z}
   - R_{in}\left(n_{n}p_{\|,i} - n_{i}p_{\|,n}
   - n_{i}n_{n}\left(u_{i} - u_{n}\right)^{2}\right)
+  + \int dv_\parallel v_\parallel^2 S_{i} + u_{i}^2 \int dv_\parallel S_{i}
   + v_{\mathrm{th},i}w_{\|,i}\frac{\partial p_{\|,i}}{\partial z}\right) \\
   & \qquad - \frac{w_{\|,i}}{2}R_{\mathrm{ion}}n_{i}\left(\frac{p_{\|,n}}{p_{\|,i}}
   - \frac{n_{n}}{n_{i}} + \frac{n_{n}}{p_{\|,i}}\left(u_{n} - u_{i}\right)^{2}\right) \\
-  & \qquad\left. + \frac{w_{\|,i}^{2}}{2}\frac{v_{\mathrm{th},i}}{n_{i}}\frac{\partial n_{i}}{\partial z}\right]\frac{\partial g_{i}}{\partial w_{\|,i}} \\
+  & \qquad\left. + \frac{w_{\parallel,i}}{2} \frac{1}{n_{i}}\int dv_\parallel S_{i}
+  + \frac{w_{\|,i}^{2}}{2}\frac{v_{\mathrm{th},i}}{n_{i}}\frac{\partial n_{i}}{\partial z}\right]\frac{\partial g_{i}}{\partial w_{\|,i}} \\
   & = -R_{in}n_{n}\left(g_{i} - \frac{v_{\mathrm{th},i}}{v_{\mathrm{th},n}}g_{n}\right)
-      + R_{\mathrm{ion}}v_{\mathrm{th},i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n}
+      + R_{\mathrm{ion}}v_{\mathrm{th},i}\frac{n_{n}}{v_{\mathrm{th},n}}g_{n} + \frac{v_{\mathrm{th},i}}{n_{i}} S_{i}
 \end{align}
 ```
 
@@ -958,21 +1005,24 @@ and for neutrals where several of the ionization terms cancel
   \Rightarrow & \frac{\partial g_{n}}{\partial t}
   + \frac{v_{\mathrm{th},n}}{n_{n}}\left(v_{\mathrm{th},n}w_{\|,n}
   + u_{n}\right)\frac{\partial f_{n}}{\partial z}
-  + \left(-\frac{3}{2}R_{\mathrm{ion}}n_{i}
+  + \left(-\frac{3}{2}R_{\mathrm{ion}}n_{i} + \frac{3}{2n_{n}}\int dv_\parallel S_{n}
   - \frac{u_{n}}{n_{n}}\frac{\partial n_{n}}{\partial z}\right)g_{n} \\
   & + \left(\frac{u_{n}}{v_{\mathrm{th},n}}\frac{\partial v_{\mathrm{th},n}}{\partial z}
   + \frac{1}{2p_{\|,n}}\frac{\partial q_{\|,n}}{\partial z}\right. \\
   & \qquad \left. + \frac{1}{2p_{\|,n}}R_{in}\left(n_{i}p_{\|,n} - n_{n}p_{\|,i}
   - n_{n}n_{i}\left(u_{n} - u_{i}\right)^{2}\right)
-  + \frac{1}{2}R_{\mathrm{ion}}n_{i}\right)g_{n} \\
+  + \frac{1}{2}R_{\mathrm{ion}}n_{i}
+  - \frac{1}{2p_{\parallel,n}}\int dv_\parallel v_\parallel^2 S_{n} - \frac{u_{n}^2}{2p_{\parallel,n}}\int dv_\parallel S_{n}\right)g_{n} \\
   & + \left[-\frac{1}{n_{n}v_{\mathrm{th},n}}\left(-\frac{\partial p_{\|,n}}{\partial z}
-  + R_{in}n_{n}n_{i}\left(u_{i} - u_{n}\right)\right)\right. \\
+  + R_{in}n_{n}n_{i}\left(u_{i} - u_{n}\right) - u_{n}\int dv_\parallel S_{n}\right)\right. \\
   & \qquad-\frac{w_{\|,n}}{2}\frac{1}{p_{\|,n}}\left(-\frac{\partial q_{\|,n}}{\partial z}
   - R_{in}\left(n_{i}p_{\|,n} - n_{n}p_{\|,i}
   - n_{n}n_{i}\left(u_{n} - u_{i}\right)^{2}\right)
+  + \int dv_\parallel S_{n} + u_{n}^2\int dv_\parallel v_\parallel^2 S_{n}
   + v_{\mathrm{th},n}w_{\|,n}\frac{\partial p_{\|,n}}{\partial z}\right) \\
-  & \qquad\left. + \frac{w_{\|,n}^{2}}{2}\frac{v_{\mathrm{th},n}}{n_{n}}\frac{\partial n_{n}}{\partial z}\right]\frac{\partial g_{n}}{\partial w_{\|,n}} \\
+  & \qquad\left. + \frac{w_{\parallel,n}}{2}\frac{1}{n_{n}}\int dv_\parallel S_{n}
+  + \frac{w_{\|,n}^{2}}{2}\frac{v_{\mathrm{th},n}}{n_{n}}\frac{\partial n_{n}}{\partial z}\right]\frac{\partial g_{n}}{\partial w_{\|,n}} \\
   & = -R_{in}n_{i}\left(g_{n} - \frac{v_{\mathrm{th},n}}{v_{\mathrm{th},i}}g_{i}\right)
-      - R_{\mathrm{ion}}n_{i}g_{n}
+      - R_{\mathrm{ion}}n_{i}g_{n} + \frac{v_{\mathrm{th},n}}{n_{n}} S_{n}
 \end{align}
 ```

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -123,7 +123,7 @@ function second_derivative!(d2f, f, Q, coord, spectral)
                                                         coord.scratch2_2d[:,ielement])
     end
 
-    if coord.bc ∈ ("wall", "zero", "both_zero")
+    if coord.bc ∈ ("wall", "zero", "both_zero", "incoming_zero")
         # For stability don't contribute to evolution at boundaries, in case these
         # points are not set by a boundary condition.
         # Full grid may be across processes and bc only applied to extreme ends of the

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -125,8 +125,12 @@ function setup_distributed_memory_MPI(z_nelement_global,z_nelement_local,r_nelem
     end
 	# throw an error if user specified information is inconsistent
     if (nrank_per_zr_block*nblocks < nrank_global)
-        error("ERROR: You must choose global number of processes to be an integer multiple of the number of \n
-               nblocks = (r_nelement_global/r_nelement_local)*(z_nelement_global/z_nelement_local)")
+        error("ERROR: You must choose global number of processes to be an integer "
+              * "multiple of the number of\n"
+              * "nblocks($nblocks) = (r_nelement_global($r_nelement_global)/"
+              * "r_nelement_local($r_nelement_local))*"
+              * "(z_nelement_global($z_nelement_global)/"
+              * "z_nelement_local($z_nelement_local))")
     end
     
     # assign information regarding shared-memory blocks

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -37,7 +37,7 @@ assign to this and not just copy a pointer into the `.val` member because otherw
 `MPI.Comm` object created by `MPI.Comm_split()` would be deleted, which probably makes
 MPI.jl delete the communicator.
 """
-const comm_block = Ref(MPI.Comm())
+const comm_block = Ref(MPI.COMM_NULL)
 
 """
 Communicator connecting the root processes of each shared memory block
@@ -47,7 +47,7 @@ assign to this and not just copy a pointer into the `.val` member because otherw
 `MPI.Comm` object created by `MPI.Comm_split()` would be deleted, which probably makes
 MPI.jl delete the communicator.
 """
-const comm_inter_block = Ref(MPI.Comm())
+const comm_inter_block = Ref(MPI.COMM_NULL)
 
 # Use Ref for these variables so that they can be made `const` (so have a definite
 # type), but contain a value assigned at run-time.

--- a/src/continuity.jl
+++ b/src/continuity.jl
@@ -12,7 +12,7 @@ use the continuity equation dn/dt + d(n*upar)/dz to update the density n for all
 species
 """
 function continuity_equation!(dens_out, fvec_in, moments, composition, dt, spectral,
-                              ionization, num_diss_params)
+                              ionization, ion_source_settings, num_diss_params)
     begin_s_r_z_region()
 
     @loop_s_r_z is ir iz begin
@@ -30,6 +30,14 @@ function continuity_equation!(dens_out, fvec_in, moments, composition, dt, spect
         end
     end
 
+    if ion_source_settings.active
+        source_amplitude = moments.charged.external_source_amplitude
+        @loop_s_r_z is ir iz begin
+            dens_out[iz,ir,is] +=
+                dt * source_amplitude[iz,ir]
+        end
+    end
+
     # Ad-hoc diffusion to stabilise numerics...
     diffusion_coefficient = num_diss_params.moment_dissipation_coefficient
     if diffusion_coefficient > 0.0
@@ -44,7 +52,8 @@ use the continuity equation dn/dt + d(n*upar)/dz to update the density n for all
 species
 """
 function neutral_continuity_equation!(dens_out, fvec_in, moments, composition, dt,
-                                      spectral, ionization, num_diss_params)
+                                      spectral, ionization, neutral_source_settings,
+                                      num_diss_params)
     begin_sn_r_z_region()
 
     @loop_sn_r_z isn ir iz begin
@@ -59,6 +68,14 @@ function neutral_continuity_equation!(dens_out, fvec_in, moments, composition, d
     if composition.n_neutral_species > 0 && ionization > 0.0
         @loop_sn_r_z isn ir iz begin
             dens_out[iz,ir,isn] -= dt*ionization*fvec_in.density[iz,ir,isn]*fvec_in.density_neutral[iz,ir,isn]
+        end
+    end
+
+    if neutral_source_settings.active
+        source_amplitude = moments.neutral.external_source_amplitude
+        @loop_s_r_z is ir iz begin
+            dens_out[iz,ir,is] +=
+                dt * source_amplitude[iz,ir]
         end
     end
 

--- a/src/energy_equation.jl
+++ b/src/energy_equation.jl
@@ -12,7 +12,7 @@ using ..looping
 evolve the parallel pressure by solving the energy equation
 """
 function energy_equation!(ppar, fvec, moments, collisions, dt, spectral, composition,
-                          num_diss_params)
+                          ion_source_settings, num_diss_params)
 
     begin_s_r_z_region()
 
@@ -20,6 +20,15 @@ function energy_equation!(ppar, fvec, moments, collisions, dt, spectral, composi
         ppar[iz,ir,is] += dt*(-fvec.upar[iz,ir,is]*moments.charged.dppar_dz_upwind[iz,ir,is]
                               - moments.charged.dqpar_dz[iz,ir,is]
                               - 3.0*fvec.ppar[iz,ir,is]*moments.charged.dupar_dz[iz,ir,is])
+    end
+
+    if ion_source_settings.active
+        source_amplitude = moments.charged.external_source_amplitude
+        source_T = ion_source_settings.source_T
+        @loop_s_r_z is ir iz begin
+            ppar[iz,ir,is] += dt * source_amplitude[iz,ir] *
+                              (0.5*source_T + fvec.upar[iz,ir,is]^2)
+        end
     end
 
     diffusion_coefficient = num_diss_params.moment_dissipation_coefficient
@@ -57,39 +66,48 @@ end
 evolve the neutral parallel pressure by solving the energy equation
 """
 function neutral_energy_equation!(pz, fvec, moments, collisions, dt, spectral,
-                                  composition, num_diss_params)
+                                  composition, neutral_source_settings, num_diss_params)
 
     begin_sn_r_z_region()
 
-    @loop_sn_r_z is ir iz begin
-        pz[iz,ir,is] += dt*(-fvec.uz_neutral[iz,ir,is]*moments.neutral.dpz_dz_upwind[iz,ir,is]
-                            - moments.neutral.dqz_dz[iz,ir,is]
-                            - 3.0*fvec.pz_neutral[iz,ir,is]*moments.neutral.duz_dz[iz,ir,is])
+    @loop_sn_r_z isn ir iz begin
+        pz[iz,ir,isn] += dt*(-fvec.uz_neutral[iz,ir,isn]*moments.neutral.dpz_dz_upwind[iz,ir,isn]
+                             - moments.neutral.dqz_dz[iz,ir,isn]
+                             - 3.0*fvec.pz_neutral[iz,ir,isn]*moments.neutral.duz_dz[iz,ir,isn])
+    end
+
+    if neutral_source_settings.active
+        source_amplitude = moments.neutral.external_source_amplitude
+        source_T = neutral_source_settings.source_T
+        @loop_s_r_z isn ir iz begin
+            pz[iz,ir,isn] += dt * source_amplitude[iz,ir] *
+                             (0.5*source_T + fvec.uz_neutral[iz,ir,isn]^2)
+        end
     end
 
     diffusion_coefficient = num_diss_params.moment_dissipation_coefficient
     if diffusion_coefficient > 0.0
-        @loop_sn_r_z is ir iz begin
-            pz[iz,ir,is] += dt*diffusion_coefficient*moments.neutral.d2pz_dz2[iz,ir,is]
+        @loop_sn_r_z isn ir iz begin
+            pz[iz,ir,isn] += dt*diffusion_coefficient*moments.neutral.d2pz_dz2[iz,ir,isn]
         end
     end
 
     # add in contributions due to charge exchange/ionization collisions
     if composition.n_neutral_species > 0
         if abs(collisions.charge_exchange) > 0.0
-            @loop_sn_r_z is ir iz begin
-                pz[iz,ir,is] -=
+            @loop_sn_r_z isn ir iz begin
+                pz[iz,ir,isn] -=
                     dt*collisions.charge_exchange*(
-                        fvec.density[iz,ir,is]*fvec.pz_neutral[iz,ir,is] -
-                        fvec.density_neutral[iz,ir,is]*fvec.ppar[iz,ir,is] -
-                        fvec.density_neutral[iz,ir,is]*fvec.density[iz,ir,is] *
-                            (fvec.uz_neutral[iz,ir,is] - fvec.upar[iz,ir,is])^2)
+                        fvec.density[iz,ir,isn]*fvec.pz_neutral[iz,ir,isn] -
+                        fvec.density_neutral[iz,ir,isn]*fvec.ppar[iz,ir,isn] -
+                        fvec.density_neutral[iz,ir,isn]*fvec.density[iz,ir,isn] *
+                            (fvec.uz_neutral[iz,ir,isn] - fvec.upar[iz,ir,isn])^2)
             end
         end
         if abs(collisions.ionization) > 0.0
-            @loop_sn_r_z is ir iz begin
-                pz[iz,ir,is] -=
-                    dt*collisions.ionization*fvec.density[iz,ir,is]*fvec.pz_neutral[iz,ir,is]
+            @loop_sn_r_z isn ir iz begin
+                pz[iz,ir,isn] -=
+                    dt*collisions.ionization*fvec.density[iz,ir,isn]*fvec.pz_neutral[iz,ir,isn]
             end
         end
     end

--- a/src/external_sources.jl
+++ b/src/external_sources.jl
@@ -1,0 +1,551 @@
+"""
+Maxwellian source terms with spatially varying parameters representing external sources of
+particles and energy.
+
+Note there is no parallel momentum input from the external sources.
+
+The sources can be controlled by a PI controller to set density to a target value or
+profile. Note that the PI controller should not be used with operator splitting -
+implementing it in a way that would be compatible with splitting is complicated because
+the source contributes to several terms.
+"""
+module external_sources
+
+export setup_external_sources!, external_ion_source!, external_neutral_source!,
+       external_ion_source_controller!, external_neutral_source_controller!,
+       initialize_external_source_amplitude!,
+       initialize_external_source_controller_integral!
+
+using ..array_allocation: allocate_float, allocate_shared_float
+using ..communication
+using ..coordinates
+using ..input_structs: set_defaults_and_check_section!, Dict_to_NamedTuple
+using ..looping
+
+using MPI
+
+"""
+    setup_external_sources!(input_dict, r, z)
+
+Set up parameters for the external sources using settings in `input_dict`.
+
+Updates `input_dict` with defaults for unset parameters.
+
+`r` and `z` are the [`coordinates.coordinate`](@ref) objects for the r-
+and z-coordinates.
+
+Returns a NamedTuple `(ion=ion_source_settings, neutral=neutral_source_settings)`
+containing two NamedTuples of settings.
+"""
+function setup_external_sources!(input_dict, r, z)
+    external_ion_sources, external_neutral_sources = (
+        set_defaults_and_check_section!(
+             input_dict, section_name;
+             active=false,
+             source_strength=1.0,
+             source_T=1.0,
+             r_profile="constant",
+             r_width=1.0,
+             r_relative_minimum=0.0,
+             z_profile="constant",
+             z_width=1.0,
+             z_relative_minimum=0.0,
+             controller_type="",
+             PI_density_controller_P=0.0,
+             PI_density_controller_I=0.0,
+             PI_density_target_amplitude=1.0,
+             PI_density_target_r_profile="constant",
+             PI_density_target_r_width=1.0,
+             PI_density_target_r_relative_minimum=0.0,
+             PI_density_target_z_profile="constant",
+             PI_density_target_z_width=1.0,
+             PI_density_target_z_relative_minimum=0.0,
+            )
+        for section_name ∈ ("ion_source", "neutral_source"))
+
+    function get_settings(input)
+        r_amplitude = get_source_profile(input["r_profile"], input["r_width"],
+                                         input["r_relative_minimum"], r)
+        z_amplitude = get_source_profile(input["z_profile"], input["z_width"],
+                                         input["z_relative_minimum"], z)
+        if input["controller_type"] == "density_profile"
+            PI_density_target_amplitude = input["PI_density_target_amplitude"]
+            PI_density_target_r_factor =
+                get_source_profile(input["PI_density_target_r_profile"],
+                    input["PI_density_target_r_width"],
+                    input["PI_density_target_r_relative_minimum"], r)
+            PI_density_target_z_factor =
+                get_source_profile(input["PI_density_target_z_profile"],
+                    input["PI_density_target_z_width"],
+                    input["PI_density_target_z_relative_minimum"], z)
+            PI_density_target = allocate_shared_float(z.n,r.n)
+            for ir ∈ 1:r.n, iz ∈ 1:z.n
+                PI_density_target[iz,ir] =
+                    PI_density_target_amplitude * PI_density_target_r_factor[ir] *
+                    PI_density_target_z_factor[iz]
+            end
+            PI_controller_amplitude = nothing
+            controller_source_profile = nothing
+            PI_density_target_ir = nothing
+            PI_density_target_iz = nothing
+            PI_density_target_rank = nothing
+        elseif input["controller_type"] == "density_midpoint"
+            PI_density_target = input["PI_density_target_amplitude"]
+
+            if comm_block[] != MPI.COMM_NULL
+                PI_controller_amplitude = allocate_shared_float(1)
+                controller_source_profile = allocate_shared_float(z.n, r.n)
+            else
+                PI_controller_amplitude = allocate_float(1)
+                controller_source_profile = allocate_float(z.n, r.n)
+            end
+            for ir ∈ 1:r.n, iz ∈ 1:z.n
+                controller_source_profile[iz,ir] = r_amplitude[ir] * z_amplitude[iz]
+            end
+
+            # Find the indices, and process rank of the point at r=0, z=0.
+            # The result of findfirst() will be `nothing` if the point was not found.
+            PI_density_target_ir = findfirst(x->abs(x)<1.e-14, r.grid)
+            PI_density_target_iz = findfirst(x->abs(x)<1.e-14, z.grid)
+            if block_rank[] == 0
+                # Only need to do communications from the root process of each
+                # shared-memory block
+                if PI_density_target_ir !== nothing && PI_density_target_iz !== nothing
+                    PI_density_target_rank = iblock_index[]
+                else
+                    PI_density_target_rank = 0
+                end
+                if comm_inter_block[] != MPI.COMM_NULL
+                    PI_density_target_rank = MPI.Allreduce(PI_density_target_rank, +,
+                                                           comm_inter_block[])
+                end
+            else
+                PI_density_target_rank = nothing
+            end
+        elseif input["controller_type"] == ""
+            PI_density_target = nothing
+            PI_controller_amplitude = nothing
+            controller_source_profile = nothing
+            PI_density_target_ir = nothing
+            PI_density_target_iz = nothing
+            PI_density_target_rank = nothing
+        else
+            error("Unrecognised controller_type=$(input["controller_type"])."
+                  * "Possible values are: \"\", density_profile, density_midpoint")
+        end
+
+        return (; (Symbol(k)=>v for (k,v) ∈ input)..., r_amplitude=r_amplitude,
+                z_amplitude=z_amplitude, PI_density_target=PI_density_target,
+                PI_controller_amplitude=PI_controller_amplitude,
+                controller_source_profile=controller_source_profile,
+                PI_density_target_ir=PI_density_target_ir,
+                PI_density_target_iz=PI_density_target_iz,
+                PI_density_target_rank=PI_density_target_rank)
+    end
+
+    return (ion=get_settings(external_ion_sources),
+            neutral=get_settings(external_neutral_sources))
+end
+
+"""
+    get_source_profile(profile_type, width, min_val, coord)
+
+Create a profile of type `profile_type` with width `width` for coordinate `coord`.
+"""
+function get_source_profile(profile_type, width, relative_minimum, coord)
+    if width < 0.0
+        error("width must be ≥0, got $width")
+    end
+    if relative_minimum < 0.0
+        error("relative_minimum must be ≥0, got $relative_minimum")
+    end
+    if profile_type == "constant"
+        return ones(coord.n)
+    elseif profile_type == "gaussian"
+        x = coord.grid
+        return @. (1.0 - relative_minimum) * exp(-(x / width)^2) + relative_minimum
+    elseif profile_type == "parabolic"
+        x = coord.grid
+        L = coord.L
+        return @. (1.0 - relative_minimum) * (1.0 - (2.0 * x / L)^2) + relative_minimum
+    else
+        error("Unrecognised source profile type '$profile_type'.")
+    end
+end
+
+"""
+    initialize_external_source_amplitude!(moments, external_source_settings, vperp,
+                                          vzeta, vr, n_neutral_species)
+
+Initialize the arrays `moments.charged.external_source_amplitude` and
+`moments.neutral.external_source_amplitude`, using the settings in
+`external_source_settings`
+"""
+function initialize_external_source_amplitude!(moments, external_source_settings, vperp,
+                                               vzeta, vr, n_neutral_species)
+    ion_source_settings = external_source_settings.ion
+    if ion_source_settings.active
+        @loop_r_z ir iz begin
+            moments.charged.external_source_amplitude[iz,ir] =
+                ion_source_settings.source_strength *
+                ion_source_settings.r_amplitude[ir] * ion_source_settings.z_amplitude[iz]
+        end
+    end
+
+    if n_neutral_species > 0
+        neutral_source_settings = external_source_settings.neutral
+        if neutral_source_settings.active
+            @loop_r_z ir iz begin
+                moments.neutral.external_source_amplitude[iz,ir] =
+                    neutral_source_settings.source_strength *
+                    neutral_source_settings.r_amplitude[ir] *
+                    neutral_source_settings.z_amplitude[iz]
+            end
+        end
+    end
+
+    return nothing
+end
+
+"""
+function initialize_external_source_controller_integral!(
+             moments, external_source_settings, n_neutral_species)
+
+Initialize the arrays `moments.charged.external_source_controller_integral` and
+`moments.neutral.external_source_controller_integral`, using the settings in
+`external_source_settings`
+"""
+function initialize_external_source_controller_integral!(
+             moments, external_source_settings, n_neutral_species)
+    ion_source_settings = external_source_settings.ion
+    if ion_source_settings.active
+        if ion_source_settings.PI_density_controller_I != 0.0 &&
+            ion_source_settings.controller_type != ""
+            moments.charged.external_source_controller_integral .= 0.0
+        end
+    end
+
+    if n_neutral_species > 0
+        neutral_source_settings = external_source_settings.neutral
+        if neutral_source_settings.active
+            if neutral_source_settings.PI_density_controller_I != 0.0 &&
+                neutral_source_settings.controller_type != ""
+                moments.neutral.external_source_controller_integral .= 0.0
+            end
+        end
+    end
+
+    return nothing
+end
+
+"""
+    external_ion_source!(pdf, fvec, moments, ion_source_settings, vperp, vpa, dt)
+
+Add external source term to the ion kinetic equation.
+"""
+function external_ion_source!(pdf, fvec, moments, ion_source_settings, vperp, vpa, dt)
+    begin_s_r_z_vperp_region()
+
+    source_amplitude = moments.charged.external_source_amplitude
+    source_T = ion_source_settings.source_T
+    if vperp.n == 1
+        vth_factor = 1.0 / sqrt(source_T)
+    else
+        vth_factor = 1.0 / source_T^1.5
+    end
+    vpa_grid = vpa.grid
+    vperp_grid = vperp.grid
+
+    if moments.evolve_ppar && moments.evolve_upar && moments.evolve_density
+        vth = moments.charged.vth
+        density = fvec.density
+        upar = fvec.upar
+        @loop_s_r_z is ir iz begin
+            this_vth = vth[iz,ir,is]
+            this_upar = upar[iz,ir,is]
+            this_prefactor = dt * this_vth / density[iz,ir,is] * vth_factor *
+                             source_amplitude[iz,ir]
+            @loop_vperp_vpa ivperp ivpa begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                vperp_unnorm = vperp_grid[ivperp] * this_vth
+                vpa_unnorm = vpa_grid[ivpa] * this_vth + this_upar
+                pdf[ivpa,ivperp,iz,ir,is] +=
+                    this_prefactor *
+                    exp(-(vperp_unnorm^2 + vpa_unnorm^2) / source_T)
+            end
+        end
+    elseif moments.evolve_upar && moments.evolve_density
+        density = fvec.density
+        upar = fvec.upar
+        @loop_s_r_z is ir iz begin
+            this_upar = upar[iz,ir,is]
+            this_prefactor = dt / density[iz,ir,is] * vth_factor * source_amplitude[iz,ir]
+            @loop_vperp_vpa ivperp ivpa begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                vpa_unnorm = vpa_grid[ivpa] + this_upar
+                pdf[ivpa,ivperp,iz,ir,is] +=
+                    this_prefactor *
+                    exp(-(vperp_grid[ivperp]^2 + vpa_unnorm^2) / source_T)
+            end
+        end
+    elseif moments.evolve_density
+        density = fvec.density
+        @loop_s_r_z is ir iz begin
+            this_prefactor = dt / density[iz,ir,is] * vth_factor * source_amplitude[iz,ir]
+            @loop_vperp_vpa ivperp ivpa begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                pdf[ivpa,ivperp,iz,ir,is] +=
+                    this_prefactor *
+                    exp(-(vperp_grid[ivperp]^2 + vpa_grid[ivpa]^2) / source_T)
+            end
+        end
+    elseif !moments.evolve_ppar && !moments.evolve_upar && !moments.evolve_density
+        @loop_s_r_z is ir iz begin
+            this_prefactor = dt * vth_factor * source_amplitude[iz,ir]
+            @loop_vperp_vpa ivperp ivpa begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                pdf[ivpa,ivperp,iz,ir,is] +=
+                    this_prefactor *
+                    exp(-(vperp_grid[ivperp]^2 + vpa_grid[ivpa]^2) / source_T)
+            end
+        end
+    else
+        error("Unsupported combination evolve_density=$(moments.evolve_density), "
+              * "evolve_upar=$(moments.evolve_upar), evolve_ppar=$(moments.evolve_ppar)")
+    end
+end
+
+"""
+    external_neutral_source!(pdf, fvec, moments, neutral_source_settings, vzeta, vr,
+                            vz, dt)
+
+Add external source term to the neutral kinetic equation.
+"""
+function external_neutral_source!(pdf, fvec, moments, neutral_source_settings, vzeta, vr,
+                                 vz, dt)
+    begin_sn_r_z_vzeta_vr_region()
+
+    source_amplitude = moments.neutral.external_source_amplitude
+    source_T = neutral_source_settings.source_T
+    if vzeta.n == 1 && vr.n == 1
+        vth_factor = 1.0 / sqrt(source_T)
+    else
+        vth_factor = 1.0 / source_T^1.5
+    end
+    vzeta_grid = vzeta.grid
+    vr_grid = vr.grid
+    vz_grid = vz.grid
+
+    if moments.evolve_ppar && moments.evolve_upar && moments.evolve_density
+        vth = moments.neutral.vth
+        density = fvec.density_neutral
+        uz = fvec.uz_neutral
+        @loop_sn_r_z isn ir iz begin
+            this_vth = vth[iz,ir,isn]
+            this_uz = uz[iz,ir,isn]
+            this_prefactor = dt * this_vth / density[iz,ir,isn] * vth_factor *
+                             source_amplitude[iz,ir]
+            @loop_vzeta_vr_vz ivzeta ivr ivz begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                vzeta_unnorm = vzeta_grid[ivzeta] * this_vth
+                vr_unnorm = vr_grid[ivr] * this_vth
+                vz_unnorm = vz_grid[ivz] * this_vth + this_uz
+                pdf[ivz,ivr,ivzeta,iz,ir,isn] +=
+                    this_prefactor *
+                    exp(-(vzeta_unnorm^2 + vr_unnorm^2 + vz_unnorm^2) / source_T)
+            end
+        end
+    elseif moments.evolve_upar && moments.evolve_density
+        density = fvec.density_neutral
+        uz = fvec.uz_neutral
+        @loop_sn_r_z isn ir iz begin
+            this_uz = uz[iz,ir,isn]
+            this_prefactor = dt / density[iz,ir,isn] * vth_factor * source_amplitude[iz,ir]
+            @loop_vzeta_vr_vz ivzeta ivr ivz begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                vz_unnorm = vz_grid[ivz] + this_uz
+                pdf[ivz,ivr,ivzeta,iz,ir,isn] +=
+                    this_prefactor *
+                    exp(-(vzeta_grid[ivzeta]^2 + vr_grid[ivr]^2 + vz_unnorm^2) / source_T)
+            end
+        end
+    elseif moments.evolve_density
+        density = fvec.density_neutral
+        @loop_sn_r_z isn ir iz begin
+            this_prefactor = dt / density[iz,ir,isn] * vth_factor * source_amplitude[iz,ir]
+            @loop_vzeta_vr_vz ivzeta ivr ivz begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                pdf[ivz,ivr,ivzeta,iz,ir,isn] +=
+                    this_prefactor *
+                    exp(-(vzeta_grid[ivzeta]^2 + vr_grid[ivr]^2 + vz_grid[ivz]^2) / source_T)
+            end
+        end
+    elseif !moments.evolve_ppar && !moments.evolve_upar && !moments.evolve_density
+        @loop_sn_r_z isn ir iz begin
+            this_prefactor = dt * vth_factor * source_amplitude[iz,ir]
+            @loop_vzeta_vr_vz ivzeta ivr ivz begin
+                # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
+                # normalisation of F
+                pdf[ivz,ivr,ivzeta,iz,ir,isn] +=
+                    this_prefactor *
+                    exp(-(vzeta_grid[ivzeta]^2 + vr_grid[ivr]^2 + vz_grid[ivz]^2) / source_T)
+            end
+        end
+    else
+        error("Unsupported combination evolve_density=$(moments.evolve_density), "
+              * "evolve_upar=$(moments.evolve_upar), evolve_ppar=$(moments.evolve_ppar)")
+    end
+end
+
+"""
+    external_ion_source_controller!(fvec_in, ion_moments, ion_source_settings, dt)
+
+Calculate the amplitude when using a PI controller for the density to set the external
+source amplitude.
+"""
+function external_ion_source_controller!(fvec_in, ion_moments, ion_source_settings, dt)
+
+    is = 1
+
+    if ion_source_settings.controller_type == ""
+        return nothing
+    elseif ion_source_settings.controller_type == "density_midpoint"
+        begin_serial_region()
+
+        # controller_amplitude error is a shared memory Vector of length 1
+        controller_amplitude = ion_source_settings.PI_controller_amplitude
+        @serial_region begin
+            if ion_source_settings.PI_density_target_ir !== nothing &&
+                    ion_source_settings.PI_density_target_iz !== nothing
+                # This process has the target point
+
+                n_mid = fvec_in.density[ion_source_settings.PI_density_target_iz,
+                                        ion_source_settings.PI_density_target_ir, is]
+                n_error = ion_source_settings.PI_density_target - n_mid
+
+                ion_moments.external_source_controller_integral[1,1] +=
+                    dt * ion_source_settings.PI_density_controller_I * n_error
+
+                # Only want a source, so never allow amplitude to be negative
+                amplitude = max(
+                    ion_source_settings.PI_density_controller_P * n_error +
+                    ion_moments.external_source_controller_integral[1,1],
+                    0)
+            else
+                amplitude = nothing
+            end
+            controller_amplitude[1] =
+                MPI.Bcast(amplitude, ion_source_settings.PI_density_target_rank,
+                          comm_inter_block[])
+        end
+
+        begin_r_z_region()
+
+        amplitude = controller_amplitude[1]
+        @loop_r_z ir iz begin
+            ion_moments.external_source_amplitude[iz,ir] =
+                amplitude * ion_source_settings.controller_source_profile[iz,ir]
+        end
+    elseif ion_source_settings.controller_type == "density_profile"
+        begin_r_z_region()
+
+        density = fvec_in.density
+        target = ion_source_settings.PI_density_target
+        P = ion_source_settings.PI_density_controller_P
+        I = ion_source_settings.PI_density_controller_I
+        integral = ion_moments.external_source_controller_integral
+        amplitude = ion_moments.external_source_amplitude
+        @loop_r_z ir iz begin
+            n_error = target[iz,ir] - density[iz,ir,is]
+            integral[iz,ir] += dt * I * n_error
+            # Only want a source, so never allow amplitude to be negative
+            amplitude[iz,ir] = max(P * n_error + integral[iz,ir], 0)
+        end
+    else
+        error("Unrecognised controller_type=$(ion_source_settings.controller_type)")
+    end
+
+    return nothing
+end
+
+"""
+    external_neutral_source_controller!(fvec_in, neutral_moments,
+                                        neutral_source_settings, dt)
+
+Calculate the amplitude when using a PI controller for the density to set the external
+source amplitude.
+"""
+function external_neutral_source_controller!(fvec_in, neutral_moments,
+                                             neutral_source_settings, dt)
+
+    is = 1
+
+    if neutral_source_settings.controller_type == ""
+        return nothing
+    elseif neutral_source_settings.controller_type == "density_midpoint"
+        begin_serial_region()
+
+        # controller_amplitude error is a shared memory Vector of length 1
+        controller_amplitude = neutral_source_settings.PI_controller_amplitude
+        @serial_region begin
+            if neutral_source_settings.PI_density_target_ir !== nothing &&
+                    neutral_source_settings.PI_density_target_iz !== nothing
+                # This process has the target point
+
+                n_mid = fvec_in.density_neutral[neutral_source_settings.PI_density_target_iz,
+                                                neutral_source_settings.PI_density_target_ir,
+                                                is]
+                n_error = neutral_source_settings.PI_density_target - n_mid
+
+                neutral_moments.external_source_controller_integral[1,1] +=
+                    dt * neutral_source_settings.PI_density_controller_I * n_error
+
+                # Only want a source, so never allow amplitude to be negative
+                amplitude = max(
+                    neutral_source_settings.PI_density_controller_P * n_error +
+                    neutral_moments.external_source_controller_integral[1,1],
+                    0)
+            else
+                amplitude = nothing
+            end
+            controller_amplitude[1] =
+                MPI.Bcast(amplitude, neutral_source_settings.PI_density_target_rank,
+                          comm_inter_block[])
+        end
+
+        begin_r_z_region()
+
+        amplitude = controller_amplitude[1]
+        @loop_r_z ir iz begin
+            neutral_moments.external_source_amplitude[iz,ir] =
+                amplitude * neutral_source_settings.controller_source_profile[iz,ir]
+        end
+    elseif neutral_source_settings.controller_type == "density_profile"
+        begin_r_z_region()
+
+        density = fvec_in.density_neutral
+        target = neutral_source_settings.PI_density_target
+        P = neutral_source_settings.PI_density_controller_P
+        I = neutral_source_settings.PI_density_controller_I
+        integral = neutral_moments.external_source_controller_integral
+        amplitude = neutral_moments.external_source_amplitude
+        @loop_r_z ir iz begin
+            n_error = target[iz,ir] - density[iz,ir,is]
+            integral[iz,ir] += dt * I * n_error
+            amplitude[iz,ir] = P * n_error + integral[iz,ir]
+        end
+    else
+        error("Unrecognised controller_type=$(neutral_source_settings.controller_type)")
+    end
+
+    return nothing
+end
+
+end

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -44,8 +44,8 @@ end
 structure containing the data/metadata needed for binary file i/o
 moments & fields only
 """
-struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn}
-     # file identifier for the binary file to which data is written
+struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn, Texti1, Texti2, Textn1, Textn2}
+    # file identifier for the binary file to which data is written
     fid::Tfile
     # handle for the time variable
     time::Ttime
@@ -72,6 +72,12 @@ struct io_moments_info{Tfile, Ttime, Tphi, Tmomi, Tmomn}
     pz_neutral::Tmomn
     qz_neutral::Tmomn
     thermal_speed_neutral::Tmomn
+
+    # handles for external source variables
+    external_source_amplitude::Texti1
+    external_source_controller_integral::Texti2
+    external_source_neutral_amplitude::Textn1
+    external_source_neutral_controller_integral::Textn2
 
     # Use parallel I/O?
     parallel_io::Bool
@@ -110,7 +116,8 @@ open the necessary output files
 """
 function setup_file_io(io_input, boundary_distributions, vz, vr, vzeta, vpa, vperp, z, r,
                        composition, collisions, evolve_density, evolve_upar, evolve_ppar,
-                       input_dict, restart_time_index, previous_runs_info)
+                       external_source_settings, input_dict, restart_time_index,
+                       previous_runs_info)
     begin_serial_region()
     @serial_region begin
         # Only read/write from first process in each 'block'
@@ -134,15 +141,16 @@ function setup_file_io(io_input, boundary_distributions, vz, vr, vzeta, vpa, vpe
 
         io_moments = setup_moments_io(out_prefix, io_input.binary_format, r, z,
                                       composition, collisions, evolve_density,
-                                      evolve_upar, evolve_ppar, input_dict,
-                                      io_input.parallel_io, comm_inter_block[], run_id,
-                                      restart_time_index, previous_runs_info)
+                                      evolve_upar, evolve_ppar, external_source_settings,
+                                      input_dict, io_input.parallel_io,
+                                      comm_inter_block[], run_id, restart_time_index,
+                                      previous_runs_info)
         io_dfns = setup_dfns_io(out_prefix, io_input.binary_format,
                                 boundary_distributions, r, z, vperp, vpa, vzeta, vr, vz,
                                 composition, collisions, evolve_density, evolve_upar,
-                                evolve_ppar, input_dict, io_input.parallel_io,
-                                comm_inter_block[], run_id, restart_time_index,
-                                previous_runs_info)
+                                evolve_ppar, external_source_settings, input_dict,
+                                io_input.parallel_io, comm_inter_block[], run_id,
+                                restart_time_index, previous_runs_info)
 
         return ascii, io_moments, io_dfns
     end
@@ -544,7 +552,8 @@ function create_dynamic_variable!() end
 define dynamic (time-evolving) moment variables for writing to the hdf5 file
 """
 function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
-                                          r::coordinate, z::coordinate, parallel_io)
+                                          r::coordinate, z::coordinate, parallel_io,
+                                          external_source_settings)
     @serial_region begin
         dynamic = create_io_group(fid, "dynamic_data", description="time evolving variables")
 
@@ -637,10 +646,67 @@ function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
             parallel_io=parallel_io, description="neutral species thermal speed",
             units="c_ref")
 
+        ion_source_settings = external_source_settings.ion
+        if ion_source_settings.active
+            external_source_amplitude = create_dynamic_variable!(
+                dynamic, "external_source_amplitude", mk_float, z, r;
+                parallel_io=parallel_io, description="Amplitude of the external source for ions",
+                units="n_ref/c_ref^3*c_ref/L_ref")
+            if ion_source_settings.PI_density_controller_I != 0.0 &&
+                    ion_source_settings.PI_density_controller_type != ""
+                if ion_source_settings.PI_density_controller_type == "profile"
+                    external_source_controller_integral = create_dynamic_variable!(
+                        dynamic, "external_source_controller_integral", mk_float, z, r;
+                        parallel_io=parallel_io,
+                        description="Integral term for the PID controller of the external source for ions")
+                else
+                    external_source_controller_integral = create_dynamic_variable!(
+                        dynamic, "external_source_controller_integral", mk_float;
+                        parallel_io=parallel_io,
+                        description="Integral term for the PID controller of the external source for ions")
+                end
+            else
+                external_source_controller_integral = nothing
+            end
+        else
+            external_source_amplitude = nothing
+            external_source_controller_integral = nothing
+        end
+
+        neutral_source_settings = external_source_settings.neutral
+        if n_neutral_species > 0 && neutral_source_settings.active
+            external_source_neutral_amplitude = create_dynamic_variable!(
+                dynamic, "external_source_neutral_amplitude", mk_float, z, r;
+                parallel_io=parallel_io, description="Amplitude of the external source for neutrals",
+                units="n_ref/c_ref^3*c_ref/L_ref")
+            if neutral_source_settings.PI_density_controller_I != 0.0 &&
+                    neutral_source_settings.PI_density_controller_type != ""
+                if neutral_source_settings.PI_density_controller_type == "profile"
+                    external_source_neutral_controller_integral = create_dynamic_variable!(
+                        dynamic, "external_source_neutral_controller_integral", mk_float, z, r;
+                        parallel_io=parallel_io,
+                        description="Integral term for the PID controller of the external source for neutrals")
+                else
+                    external_source_neutral_controller_integral = create_dynamic_variable!(
+                        dynamic, "external_source_neutral_controller_integral", mk_float;
+                        parallel_io=parallel_io,
+                        description="Integral term for the PID controller of the external source for neutrals")
+                end
+            else
+                external_source_neutral_controller_integral = nothing
+            end
+        else
+            external_source_neutral_amplitude = nothing
+            external_source_neutral_controller_integral = nothing
+        end
+
         return io_moments_info(fid, io_time, io_phi, io_Er, io_Ez, io_density, io_upar,
                                io_ppar, io_qpar, io_vth, io_density_neutral, io_uz_neutral,
                                io_pz_neutral, io_qz_neutral, io_thermal_speed_neutral,
-                               parallel_io)
+                               external_source_amplitude,
+                               external_source_controller_integral,
+                               external_source_neutral_amplitude,
+                               external_source_neutral_controller_integral, parallel_io)
     end
 
     # For processes other than the root process of each shared-memory group...
@@ -652,12 +718,14 @@ define dynamic (time-evolving) distribution function variables for writing to th
 file
 """
 function define_dynamic_dfn_variables!(fid, r, z, vperp, vpa, vzeta, vr, vz,
-                                       n_ion_species, n_neutral_species, parallel_io)
+                                       n_ion_species, n_neutral_species, parallel_io,
+                                       external_source_settings)
 
     @serial_region begin
         io_moments = define_dynamic_moment_variables!(fid, n_ion_species,
                                                       n_neutral_species, r, z,
-                                                      parallel_io)
+                                                      parallel_io,
+                                                      external_source_settings)
 
         dynamic = get_group(fid, "dynamic_data")
 
@@ -716,9 +784,9 @@ end
 setup file i/o for moment variables
 """
 function setup_moments_io(prefix, binary_format, r, z, composition, collisions,
-                          evolve_density, evolve_upar, evolve_ppar, input_dict,
-                          parallel_io, io_comm, run_id, restart_time_index,
-                          previous_runs_info)
+                          evolve_density, evolve_upar, evolve_ppar,
+                          external_source_settings, input_dict, parallel_io, io_comm,
+                          run_id, restart_time_index, previous_runs_info)
     @serial_region begin
         moments_prefix = string(prefix, ".moments")
         if !parallel_io
@@ -746,7 +814,8 @@ function setup_moments_io(prefix, binary_format, r, z, composition, collisions,
         ### create variables for time-dependent quantities and store them ###
         ### in a struct for later access ###
         io_moments = define_dynamic_moment_variables!(
-            fid, composition.n_ion_species, composition.n_neutral_species, r, z, parallel_io)
+            fid, composition.n_ion_species, composition.n_neutral_species, r, z,
+            parallel_io, external_source_settings)
 
         close(fid)
 
@@ -780,6 +849,10 @@ function reopen_moments_io(file_info)
                                getvar("thermal_speed"), getvar("density_neutral"),
                                getvar("uz_neutral"), getvar("pz_neutral"),
                                getvar("qz_neutral"), getvar("thermal_speed_neutral"),
+                               getvar("external_source_amplitude"),
+                               getvar("external_source_controller_integral"),
+                               getvar("external_source_neutral_amplitude"),
+                               getvar("external_source_neutral_controller_integral"),
                                parallel_io)
     end
 
@@ -792,8 +865,9 @@ setup file i/o for distribution function variables
 """
 function setup_dfns_io(prefix, binary_format, boundary_distributions, r, z, vperp, vpa,
                        vzeta, vr, vz, composition, collisions, evolve_density,
-                       evolve_upar, evolve_ppar, input_dict, parallel_io, io_comm, run_id,
-                       restart_time_index, previous_runs_info)
+                       evolve_upar, evolve_ppar, external_source_settings, input_dict,
+                       parallel_io, io_comm, run_id, restart_time_index,
+                       previous_runs_info)
 
     @serial_region begin
         dfns_prefix = string(prefix, ".dfns")
@@ -830,7 +904,7 @@ function setup_dfns_io(prefix, binary_format, boundary_distributions, r, z, vper
         ### in a struct for later access ###
         io_dfns = define_dynamic_dfn_variables!(
             fid, r, z, vperp, vpa, vzeta, vr, vz, composition.n_ion_species,
-            composition.n_neutral_species, parallel_io)
+            composition.n_neutral_species, parallel_io, external_source_settings)
 
         close(fid)
 
@@ -865,7 +939,12 @@ function reopen_dfns_io(file_info)
                                      getvar("thermal_speed"), getvar("density_neutral"),
                                      getvar("uz_neutral"), getvar("pz_neutral"),
                                      getvar("qz_neutral"),
-                                     getvar("thermal_speed_neutral"), parallel_io)
+                                     getvar("thermal_speed_neutral"),
+                                     getvar("external_source_amplitude"),
+                                     getvar("external_source_controller_integral"),
+                                     getvar("external_source_neutral_amplitude"),
+                                     getvar("external_source_neutral_controller_integral"),
+                                     parallel_io)
 
         return io_dfns_info(fid, getvar("f"), getvar("f_neutral"), parallel_io,
                             io_moments)
@@ -920,6 +999,21 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
                               z, r, n_ion_species)
         append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth, t_idx, z, r,
                               n_ion_species)
+        if io_moments.external_source_amplitude !== nothing
+            append_to_dynamic_var(io_moments.external_source_amplitude,
+                                  moments.charged.external_source_amplitude, t_idx, z, r)
+        end
+        if io_moments.external_source_controller_integral !== nothing
+            if size(moments.charged.external_source_controller_integral) == (1,1)
+                append_to_dynamic_var(io_moments.external_source_controller_integral,
+                                      moments.charged.external_source_controller_integral[1,1],
+                                      t_idx)
+            else
+                append_to_dynamic_var(io_moments.external_source_controller_integral,
+                                      moments.charged.external_source_controller_integral,
+                                      t_idx, z, r)
+            end
+        end
         if n_neutral_species > 0
             append_to_dynamic_var(io_moments.density_neutral, moments.neutral.dens, t_idx,
                                   z, r, n_neutral_species)
@@ -931,6 +1025,22 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
                                   n_neutral_species)
             append_to_dynamic_var(io_moments.thermal_speed_neutral, moments.neutral.vth,
                                   t_idx, z, r, n_neutral_species)
+
+            if io_moments.external_source_neutral_amplitude !== nothing
+                append_to_dynamic_var(io_moments.external_source_neutral_amplitude,
+                                      moments.neutral.external_source_amplitude, t_idx, z, r)
+            end
+            if io_moments.external_source_neutral_controller_integral !== nothing
+                if size(moments.neutral.external_source_neutral_controller_integral) == (1,1)
+                    append_to_dynamic_var(io_moments.external_source_neutral_controller_integral,
+                                          moments.neutral.external_source_controller_integral[1,1],
+                                          t_idx)
+                else
+                    append_to_dynamic_var(io_moments.external_source_neutral_controller_integral,
+                                          moments.neutral.external_source_controller_integral,
+                                          t_idx, z, r)
+                end
+            end
         end
 
         closefile && close(io_moments.fid)
@@ -1008,6 +1118,22 @@ end
                                   moments.charged.qpar.data, t_idx, z, r, n_ion_species)
             append_to_dynamic_var(io_moments.thermal_speed, moments.charged.vth.data,
                                   t_idx, z, r, n_ion_species)
+            if io_moments.external_source_amplitude !== nothing
+                append_to_dynamic_var(io_moments.external_source_amplitude,
+                                      moments.charged.external_source_amplitude.data,
+                                      t_idx, z, r)
+            end
+            if io_moments.external_source_controller_integral !== nothing
+                if size(moments.charged.external_source_controller_integral) == (1,1)
+                    append_to_dynamic_var(io_moments.external_source_controller_integral,
+                                          moments.charged.external_source_controller_integral[1,1],
+                                          t_idx)
+                else
+                    append_to_dynamic_var(io_moments.external_source_controller_integral,
+                                          moments.charged.external_source_controller_integral,data,
+                                          t_idx, z, r)
+                end
+            end
             if n_neutral_species > 0
                 append_to_dynamic_var(io_moments.density_neutral,
                                       moments.neutral.dens.data, t_idx, z, r,
@@ -1021,6 +1147,23 @@ end
                 append_to_dynamic_var(io_moments.thermal_speed_neutral,
                                       moments.neutral.vth.data, t_idx, z, r,
                                       n_neutral_species)
+
+                if io_moments.external_source_neutral_amplitude !== nothing
+                    append_to_dynamic_var(io_moments.external_source_neutral_amplitude,
+                                          moments.neutral.external_source_amplitude,
+                                          t_idx, z, r)
+                end
+                if io_moments.external_source_neutral_controller_integral !== nothing
+                    if size(moments.neutral.external_source_neutral_controller_integral) == (1,1)
+                        append_to_dynamic_var(io_moments.external_source_neutral_controller_integral,
+                                              moments.neutral.external_source_controller_integral[1,1],
+                                              t_idx)
+                    else
+                        append_to_dynamic_var(io_moments.external_source_neutral_controller_integral,
+                                              moments.neutral.external_source_controller_integral,
+                                              t_idx, z, r)
+                    end
+                end
             end
 
             closefile && close(io_moments.fid)
@@ -1307,10 +1450,11 @@ function debug_dump(vz::coordinate, vr::coordinate, vzeta::coordinate, vpa::coor
             ### in a struct for later access ###
             io_moments = define_dynamic_moment_variables!(fid, composition.n_ion_species,
                                                           composition.n_neutral_species,
-                                                          r, z, false)
+                                                          r, z, false,
+                                                          external_source_settings)
             io_dfns = define_dynamic_dfn_variables!(
                 fid, r, z, vperp, vpa, vzeta, vr, vz, composition.n_ion_species,
-                composition.n_neutral_species, false)
+                composition.n_neutral_species, false, external_source_settings)
 
             # create the "istage" variable, used to identify the rk stage where
             # `debug_dump()` was called

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -684,6 +684,11 @@ function init_neutral_pdf_over_density!(pdf, boundary_distributions, spec, compo
         vz, vr, vzeta, z, vz_spectral, density, uz, pz, vth, v_norm_fac, evolve_density,
         evolve_upar, evolve_ppar, wall_flux_0, wall_flux_L)
 
+    # Reduce the ion flux by `recycling_fraction` to account for ions absorbed by the
+    # wall.
+    wall_flux_0 *= composition.recycling_fraction
+    wall_flux_L *= composition.recycling_fraction
+
     #if spec.vz_IC.initialization_option == "gaussian"
     # For now, continue to use 'vpa' initialization options for neutral species
     if spec.vpa_IC.initialization_option == "gaussian"
@@ -1428,8 +1433,8 @@ function enforce_neutral_z_boundary_condition!(pdf, density, uz, pz, moments, de
                 @views enforce_neutral_wall_bc!(
                     pdf[:,:,:,:,ir,isn], z, vzeta, vr, vz, pz[:,ir,isn], uz[:,ir,isn],
                     density[:,ir,isn], ion_flux_0, ion_flux_L, boundary_distributions,
-                    vtfac, moments.evolve_ppar, moments.evolve_upar,
-                    moments.evolve_density, zero)
+                    vtfac, composition.recycling_fraction, moments.evolve_ppar,
+                    moments.evolve_upar, moments.evolve_density, zero)
             end
         end
     end
@@ -1602,8 +1607,15 @@ enforce the wall boundary condition on neutrals;
 i.e., the incoming flux of neutrals equals the sum of the ion/neutral outgoing fluxes
 """
 function enforce_neutral_wall_bc!(pdf, z, vzeta, vr, vz, pz, uz, density, wall_flux_0,
-                                  wall_flux_L, boundary_distributions, vtfac, evolve_ppar,
-                                  evolve_upar, evolve_density, zero)
+                                  wall_flux_L, boundary_distributions, vtfac,
+                                  recycling_fraction, evolve_ppar, evolve_upar,
+                                  evolve_density, zero)
+
+    # Reduce the ion flux by `recycling_fraction` to account for ions absorbed by the
+    # wall.
+    wall_flux_0 *= recycling_fraction
+    wall_flux_L *= recycling_fraction
+
     if !evolve_density && !evolve_upar
         knudsen_cosine = boundary_distributions.knudsen
 
@@ -1654,8 +1666,9 @@ function enforce_neutral_wall_bc!(pdf, z, vzeta, vr, vz, pz, uz, density, wall_f
 
             # Calculate normalisation factors N_in for the incoming and N_out for the
             # Knudsen parts of the distirbution so that ∫dvpa F = 1 and ∫dvpa vpa F = uz
-            # Note wall_flux_0 is the ion flux into the wall, and the neutral flux should
-            # be out of the wall (i.e. uz>0) so n*uz = |n*uz| = wall_flux_0
+            # Note wall_flux_0 is the ion flux into the wall (reduced by the recycling
+            # fraction), and the neutral flux should be out of the wall (i.e. uz>0) so
+            # n*uz = |n*uz| = wall_flux_0
             # ⇒ N_in*pdf_integral_0 + N_out*knudsen_integral_0 = 1
             #   N_in*pdf_integral_1 + N_out*knudsen_integral_1 = uz
             uz = wall_flux_0 / density[1]
@@ -1685,8 +1698,9 @@ function enforce_neutral_wall_bc!(pdf, z, vzeta, vr, vz, pz, uz, density, wall_f
 
             # Calculate normalisation factors N_in for the incoming and N_out for the
             # Knudsen parts of the distirbution so that ∫dvpa F = 1 and ∫dvpa vpa F = uz
-            # Note wall_flux_L is the ion flux into the wall, and the neutral flux should
-            # be out of the wall (i.e. uz<0) so -n*uz = |n*uz| = wall_flux_L
+            # Note wall_flux_L is the ion flux into the wall (reduced by the recycling
+            # fraction), and the neutral flux should be out of the wall (i.e. uz<0) so
+            # -n*uz = |n*uz| = wall_flux_L
             # ⇒ N_in*pdf_integral_0 + N_out*knudsen_integral_0 = 1
             #   N_in*pdf_integral_1 + N_out*knudsen_integral_1 = uz
             uz = -wall_flux_L / density[end]

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -2114,6 +2114,15 @@ function enforce_v_boundary_condition_local!(f, bc, speed, v_diffusion)
             # 'upwind' boundary
             f[end] = 0.0
         end
+    elseif bc == "incoming_zero"
+        if speed[1] > 0.0
+            # 'upwind' boundary
+            f[1] = 0.0
+        end
+        if speed[end] < 0.0
+            # 'upwind' boundary
+            f[end] = 0.0
+        end
     elseif bc == "both_zero"
         f[1] = 0.0
         f[end] = 0.0

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -608,7 +608,7 @@ function init_charged_pdf_over_density!(pdf, spec, composition, vpa, vperp, z,
                     #
                     # Implemented by multiplying by a smooth 'notch' function
                     # notch(v,u0,width) = 1 - exp(-(v-u0)^2/width)
-                    width = 0.1
+                    width = 0.1 * vth[iz]
                     inverse_width = 1.0 / width
 
                     @. pdf[:,ivperp,iz] *= 1.0 - exp(-vpa.grid^2*inverse_width)

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -269,6 +269,9 @@ mutable struct species_composition
     mn_over_mi::mk_float
     # ratio of the electron particle mass to the ion mass
     me_over_mi::mk_float
+    # The ion flux reaching the wall that is recycled as neutrals is reduced by
+    # `recycling_fraction` to account for ions absorbed by the wall.
+    recycling_fraction::mk_float
     # scratch buffer whose size is n_species
     scratch::Vector{mk_float}
 end

--- a/src/input_structs.jl
+++ b/src/input_structs.jl
@@ -62,11 +62,13 @@ mutable struct advance_info
     ionization_collisions_1V::Bool
     ionization_source::Bool
     krook_collisions::Bool
+    external_source::Bool
     numerical_dissipation::Bool
     source_terms::Bool
     continuity::Bool
     force_balance::Bool
     energy::Bool
+    neutral_external_source::Bool
     neutral_source_terms::Bool
     neutral_continuity::Bool
     neutral_force_balance::Bool

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -620,6 +620,15 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
             moments.charged.qpar_updated .= true
             moments.charged.vth .= load_moment("thermal_speed")
 
+            if "external_source_controller_integral" ∈ get_variable_keys(dynamic) &&
+                    length(moments.charged.external_source_controller_integral) == 1
+                moments.charged.external_source_controller_integral .=
+                    load_slice(dynamic, "external_source_controller_integral", time_index)
+            elseif length(moments.charged.external_source_controller_integral) > 1
+                moments.charged.external_source_controller_integral .=
+                    load_moment("external_source_controller_integral")
+            end
+
             function load_charged_pdf()
                 this_pdf = load_slice(dynamic, "f", vpa_range, vperp_range, z_range,
                                       r_range, :, time_index)
@@ -1142,6 +1151,17 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
                 moments.neutral.qz .= load_moment("qz_neutral")
                 moments.neutral.qz_updated .= true
                 moments.neutral.vth .= load_moment("thermal_speed_neutral")
+
+                if "external_source_neutral_controller_integral" ∈ get_variable_keys(dynamic) &&
+                        length(moments.neutral.external_source_controller_integral) == 1
+                    moments.neutral.external_source_controller_integral .=
+                        load_slice(dynamic,
+                                   "external_source_neutral_controller_integral",
+                                   time_index)
+                elseif length(moments.neutral.external_source_controller_integral) > 1
+                    moments.neutral.external_source_controller_integral .=
+                        load_moment("external_source_neutral_controller_integral")
+                end
 
                 function load_neutral_pdf()
                     this_pdf = load_slice(dynamic, "f_neutral", vz_range, vr_range,

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -192,6 +192,9 @@ function load_coordinate_data(fid, name; printout=false, irank=nothing, nrank=no
         println("Loading $name coordinate data...")
     end
 
+    overview = get_group(fid, "overview")
+    parallel_io = load_variable(overview, "parallel_io")
+
     coord_group = get_group(get_group(fid, "coords"), name)
 
     ngrid = load_variable(coord_group, "ngrid")
@@ -262,7 +265,7 @@ function load_coordinate_data(fid, name; printout=false, irank=nothing, nrank=no
                        discretization, fd_option, bc, advection_input("", 0.0, 0.0, 0.0),
                        MPI.COMM_NULL)
 
-    coord, spectral = define_coordinate(input)
+    coord, spectral = define_coordinate(input, parallel_io)
 
     return coord, spectral, chunk_size
 end

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -18,6 +18,7 @@ using ..array_allocation: allocate_float
 using ..coordinates: coordinate, define_coordinate
 using ..file_io: get_group, get_subgroup_keys, get_variable_keys
 using ..input_structs: advection_input, grid_input
+using ..interpolation: interpolate_to_grid_1d!
 using ..looping
 using ..type_definitions: mk_int
 
@@ -523,39 +524,34 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
             if time_index < 0
                 time_index, _, _ = load_time_data(fid)
             end
+            restart_evolve_density, restart_evolve_upar, restart_evolve_ppar =
+                load_mk_options(fid)
 
             previous_runs_info = load_run_info_history(fid)
 
             restart_n_ion_species, restart_n_neutral_species = load_species_data(fid)
-            restart_z, _, _ = load_coordinate_data(fid, "z"; irank=z.irank, nrank=z.nrank)
-            restart_r, _, _ = load_coordinate_data(fid, "r"; irank=r.irank, nrank=r.nrank)
-            restart_vperp, _, _ = load_coordinate_data(fid, "vperp"; irank=vperp.irank,
-                                                       nrank=vperp.nrank)
-            restart_vpa, _, _ = load_coordinate_data(fid, "vpa"; irank=vpa.irank,
-                                                     nrank=vpa.nrank)
-            restart_vzeta, _, _ = load_coordinate_data(fid, "vzeta"; irank=vzeta.irank,
-                                                       nrank=vzeta.nrank)
-            restart_vr, _, _ = load_coordinate_data(fid, "vr"; irank=vr.irank,
-                                                    nrank=vr.nrank)
-            restart_vz, _, _ = load_coordinate_data(fid, "vz"; irank=vz.irank,
-                                                    nrank=vz.nrank)
-            if (restart_n_ion_species != composition.n_ion_species ||
-                restart_n_neutral_species != composition.n_neutral_species ||
-                restart_z.n != z.n_global || restart_r.n != r.n_global ||
-                restart_vperp.n_global != vperp.n_global ||
-                restart_vpa.n != vpa.n_global || restart_vzeta.n != vzeta.n_global ||
-                restart_vr.n != vr.n_global || restart_vz.n != vz.n_global)
+            restart_z, restart_z_spectral, _ =
+                load_coordinate_data(fid, "z"; irank=z.irank, nrank=z.nrank)
+            restart_r, restart_r_spectral, _ =
+                load_coordinate_data(fid, "r"; irank=r.irank, nrank=r.nrank)
+            restart_vperp, restart_vperp_spectral, _ =
+                load_coordinate_data(fid, "vperp"; irank=vperp.irank, nrank=vperp.nrank)
+            restart_vpa, restart_vpa_spectral, _ =
+                load_coordinate_data(fid, "vpa"; irank=vpa.irank, nrank=vpa.nrank)
+            restart_vzeta, restart_vzeta_spectral, _ =
+                load_coordinate_data(fid, "vzeta"; irank=vzeta.irank, nrank=vzeta.nrank)
+            restart_vr, restart_vr_spectral, _ =
+                load_coordinate_data(fid, "vr"; irank=vr.irank, nrank=vr.nrank)
+            restart_vz, restart_vz_spectral, _ =
+                load_coordinate_data(fid, "vz"; irank=vz.irank, nrank=vz.nrank)
 
-                error("Dimensions of restart file and input do not match.\n" *
-                      "Restart file was n_ion_species=$restart_n_ion_species, " *
-                      "n_neutral_species=$restart_n_neutral_species, nr=$(restart_r.n), " *
-                      "nz=$(restart_z.n), nvperp=$(restart_vperp.n), nvpa=$(restart_vpa.n).\n" *
-                      "nvzeta=$(restart_vzeta.n), nvr=$(restart_vr.n), nvz=$(restart_vz.n)." *
-                      "Input file gave n_ion_species=$(composition.n_ion_species), " *
-                      "n_neutral_species=$(composition.n_neutral_species), nr=$(r.n), " *
-                      "nz=$(z.n), nvperp=$(vperp.n), nvpa=$(vpa.n), nvzeta=$(vzeta.n), " *
-                      "nvr=$(vr.n), nvz=$(vz.n).")
-            end
+            # Test whether any interpolation is needed
+            interpolation_needed = Dict(
+                x.name => x.n != restart_x.n || !all(isapprox.(x.grid, restart_x.grid))
+                for (x, restart_x) ∈ ((z, restart_z), (r, restart_r),
+                                      (vperp, restart_vperp), (vpa, restart_vpa),
+                                      (vzeta, restart_vzeta), (vr, restart_vr),
+                                      (vz, restart_vz)))
 
             code_time = load_slice(dynamic, "time", time_index)
 
@@ -566,17 +562,17 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
                     else
                         # Need to modify the range to load the end-point that is duplicated on
                         # the next process
-                        r = coord.global_io_range
-                        return r.start:(r.stop+1)
+                        this_range = coord.global_io_range
+                        return this_range.start:(this_range.stop+1)
                     end
                 end
-                r_range = get_range(r)
-                z_range = get_range(z)
-                vperp_range = get_range(vperp)
-                vpa_range = get_range(vpa)
-                vzeta_range = get_range(vzeta)
-                vr_range = get_range(vr)
-                vz_range = get_range(vz)
+                r_range = get_range(restart_r)
+                z_range = get_range(restart_z)
+                vperp_range = get_range(restart_vperp)
+                vpa_range = get_range(restart_vpa)
+                vzeta_range = get_range(restart_vzeta)
+                vr_range = get_range(restart_vr)
+                vz_range = get_range(restart_vz)
             else
                 r_range = (:)
                 z_range = (:)
@@ -587,56 +583,1133 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
                 vz_range = (:)
             end
 
-            pdf.charged.norm .= load_slice(dynamic, "f", vpa_range, vperp_range,
-                                           z_range, r_range, :, time_index)
-            moments.charged.dens .= load_slice(dynamic, "density", z_range, r_range,
-                                               :, time_index)
+            function load_moment(var_name)
+                moment = load_slice(dynamic, var_name, z_range, r_range, :, time_index)
+                orig_nz, orig_nr, nspecies = size(moment)
+                if interpolation_needed["r"]
+                    new_moment = allocate_float(orig_nz, r.n, nspecies)
+                    for is ∈ 1:nspecies, iz ∈ 1:orig_nz
+                        @views interpolate_to_grid_1d!(new_moment[iz,:,is], r.grid,
+                                                       moment[iz,:,is], restart_r,
+                                                       restart_r_spectral)
+                    end
+                    moment = new_moment
+                end
+                if interpolation_needed["z"]
+                    new_moment = allocate_float(z.n, r.n, nspecies)
+                    for is ∈ 1:nspecies, ir ∈ 1:r.n
+                        @views interpolate_to_grid_1d!(new_moment[:,ir,is], z.grid,
+                                                       moment[:,ir,is], restart_z,
+                                                       restart_z_spectral)
+                    end
+                    moment = new_moment
+                end
+                return moment
+            end
+
+            moments.charged.dens .= load_moment("density")
             moments.charged.dens_updated .= true
-            moments.charged.upar .= load_slice(dynamic, "parallel_flow", z_range,
-                                               r_range, :, time_index)
+            moments.charged.upar .= load_moment("parallel_flow")
             moments.charged.upar_updated .= true
-            moments.charged.ppar .= load_slice(dynamic, "parallel_pressure", z_range,
-                                               r_range, :, time_index)
+            moments.charged.ppar .= load_moment("parallel_pressure")
             moments.charged.ppar_updated .= true
-            moments.charged.qpar .= load_slice(dynamic, "parallel_heat_flux", z_range,
-                                               r_range, :, time_index)
+            moments.charged.qpar .= load_moment("parallel_heat_flux")
             moments.charged.qpar_updated .= true
-            moments.charged.vth .= load_slice(dynamic, "thermal_speed", z_range,
-                                              r_range, :, time_index)
+            moments.charged.vth .= load_moment("thermal_speed")
+
+            function load_charged_pdf()
+                this_pdf = load_slice(dynamic, "f", vpa_range, vperp_range, z_range,
+                                      r_range, :, time_index)
+                orig_nvpa, orig_nvperp, orig_nz, orig_nr, nspecies = size(this_pdf)
+                if interpolation_needed["r"]
+                    new_pdf = allocate_float(orig_nvpa, orig_nvperp, orig_nz, r.n, nspecies)
+                    for is ∈ 1:nspecies, iz ∈ 1:orig_nz, ivperp ∈ 1:orig_nvperp,
+                            ivpa ∈ 1:orig_nvpa
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[ivpa,ivperp,iz,:,is], r.grid,
+                            this_pdf[ivpa,ivperp,iz,:,is], restart_r,
+                            restart_r_spectral)
+                    end
+                    this_pdf = new_pdf
+                end
+                if interpolation_needed["z"]
+                    new_pdf = allocate_float(orig_nvpa, orig_nvperp, z.n, r.n, nspecies)
+                    for is ∈ 1:nspecies, ir ∈ 1:r.n, ivperp ∈ 1:orig_nvperp,
+                            ivpa ∈ 1:orig_nvpa
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[ivpa,ivperp,:,ir,is], z.grid,
+                            this_pdf[ivpa,ivperp,:,ir,is], restart_z,
+                            restart_z_spectral)
+                    end
+                    this_pdf = new_pdf
+                end
+
+                # Current moment-kinetic implementation is only 1V, so no need to handle a
+                # normalised vperp coordinate. This will need to change when 2V
+                # moment-kinetics is implemented.
+                if interpolation_needed["vperp"]
+                    new_pdf = allocate_float(orig_nvpa, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ 1:nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivpa ∈ 1:orig_nvpa
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[ivpa,:,iz,ir,is], vperp.grid,
+                            this_pdf[ivpa,:,iz,ir,is], restart_vperp,
+                            restart_vperp_spectral)
+                    end
+                    this_pdf = new_pdf
+                end
+
+                if (
+                    (moments.evolve_density == restart_evolve_density &&
+                     moments.evolve_upar == restart_evolve_upar && moments.evolve_ppar ==
+                     restart_evolve_ppar)
+                    || (!moments.evolve_upar && !restart_evolve_upar &&
+                        !moments.evolve_ppar && !restart_evolve_ppar)
+                   )
+                    # No chages to velocity-space coordinates, so just interpolate from
+                    # one grid to the other
+                    if interpolation_needed["vpa"]
+                        new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                        for is ∈ 1:nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivperp,iz,ir,is], vpa.grid,
+                                this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                                restart_vpa_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+                elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                        restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa = old_wpa + upar
+                    # => old_wpa = new_wpa - upar
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .- moments.charged.upar[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                        !restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa = old_wpa*vth
+                    # => old_wpa = new_wpa/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid ./ moments.charged.vth[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                        restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa = old_wpa*vth + upar
+                    # => old_wpa = (new_wpa - upar)/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. (vpa.grid - moments.charged.upar[iz,ir,is]) /
+                               moments.charged.vth[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                        !restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa + upar = old_wpa
+                    # => old_wpa = new_wpa + upar
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .+ moments.charged.upar[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                        !restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa + upar = old_wpa*vth
+                    # => old_wpa = (new_wpa + upar)/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. (vpa.grid + moments.charged.upar[iz,ir,is]) /
+                               moments.charged.vth
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                        restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa + upar = old_wpa*vth + upar
+                    # => old_wpa = new_wpa/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid ./ moments.charged.vth
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                        !restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth = old_wpa
+                    # => old_wpa = new_wpa*vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .* moments.charged.vth[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                        restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth = old_wpa + upar
+                    # => old_wpa = new_wpa*vth - upar/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = @. vpa.grid * moments.charged.vth[iz,ir,is] -
+                                              moments.charged.upar[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                        restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa*vth = old_wpa*vth + upar
+                    # => old_wpa = new_wpa - upar/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. vpa.grid -
+                               moments.charged.upar[iz,ir,is]/moments.charged.vth[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && moments.evolve_ppar &&
+                        !restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth + upar = old_wpa
+                    # => old_wpa = new_wpa*vth + upar
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = @. vpa.grid * moments.charged.vth[iz,ir,is] +
+                                              moments.charged.upar[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && moments.evolve_ppar &&
+                        restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth + upar = old_wpa + upar
+                    # => old_wpa = new_wpa*vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .* moments.charged.vth[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && moments.evolve_ppar &&
+                        !restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa*vth + upar = old_wpa*vth
+                    # => old_wpa = new_wpa + upar/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, r.n, nspecies)
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. vpa.grid +
+                               moments.charged.upar[iz,ir,is] / moments.charged.vth[iz,ir,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,ir,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,ir,is], restart_vpa,
+                            restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                else
+                    # This should never happen, as all combinations of evolve_* options
+                    # should be handled above.
+                    error("Unsupported combination of moment-kinetic options:"
+                          * " evolve_density=", moments.evolve_density
+                          * " evolve_upar=", moments.evolve_upar
+                          * " evolve_ppar=", moments.evolve_ppar
+                          * " restart_evolve_density=", restart_evolve_density
+                          * " restart_evolve_upar=", restart_evolve_upar
+                          * " restart_evolve_ppar=", restart_evolve_ppar)
+                end
+                if moments.evolve_density && !restart_evolve_density
+                    # Need to normalise by density
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,ir,is] ./= moments.charged.dens[iz,ir,is]
+                    end
+                elseif !moments.evolve_density && restart_evolve_density
+                    # Need to unnormalise by density
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,ir,is] .*= moments.charged.dens[iz,ir,is]
+                    end
+                end
+                if moments.evolve_ppar && !restart_evolve_ppar
+                    # Need to normalise by vth
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,ir,is] .*= moments.charged.vth[iz,ir,is]
+                    end
+                elseif !moments.evolve_ppar && restart_evolve_ppar
+                    # Need to unnormalise by vth
+                    for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,ir,is] ./= moments.charged.vth[iz,ir,is]
+                    end
+                end
+
+                return this_pdf
+            end
+
+            pdf.charged.norm .= load_charged_pdf()
 
             boundary_distributions_io = get_group(fid, "boundary_distributions")
+
+            function load_charged_boundary_pdf(var_name)
+                this_pdf = load_slice(boundary_distributions_io, var_name, vpa_range,
+                                      vperp_range, z_range, :)
+                orig_nvpa, orig_nvperp, orig_nz, nspecies = size(this_pdf)
+                if interpolation_needed["z"]
+                    new_pdf = allocate_float(orig_nvpa, orig_nvperp, z.n, nspecies)
+                    for is ∈ 1:nspecies, ivperp ∈ 1:orig_nvperp,
+                            ivpa ∈ 1:orig_nvpa
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[ivpa,ivperp,:,is], z.grid,
+                            this_pdf[ivpa,ivperp,:,is], restart_z,
+                            restart_z_spectral)
+                    end
+                    this_pdf = new_pdf
+                end
+
+                # Current moment-kinetic implementation is only 1V, so no need to handle a
+                # normalised vperp coordinate. This will need to change when 2V
+                # moment-kinetics is implemented.
+                if interpolation_needed["vperp"]
+                    new_pdf = allocate_float(orig_nvpa, vperp.n, z.n, nspecies)
+                    for is ∈ 1:nspecies, iz ∈ 1:z.n, ivpa ∈ 1:orig_nvpa
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[ivpa,:,iz,is], vperp.grid,
+                            this_pdf[ivpa,:,iz,is], restart_vperp,
+                            restart_vperp_spectral)
+                    end
+                    this_pdf = new_pdf
+                end
+
+                if (
+                    (moments.evolve_density == restart_evolve_density &&
+                     moments.evolve_upar == restart_evolve_upar && moments.evolve_ppar ==
+                     restart_evolve_ppar)
+                    || (!moments.evolve_upar && !restart_evolve_upar &&
+                        !moments.evolve_ppar && !restart_evolve_ppar)
+                   )
+                    # No chages to velocity-space coordinates, so just interpolate from
+                    # one grid to the other
+                    if interpolation_needed["vpa"]
+                        new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                        for is ∈ 1:nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivperp,iz,is], vpa.grid,
+                                this_pdf[:,ivperp,iz,is], restart_vpa,
+                                restart_vpa_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+                elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                        restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa = old_wpa + upar
+                    # => old_wpa = new_wpa - upar
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .- moments.charged.upar[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                        !restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa = old_wpa*vth
+                    # => old_wpa = new_wpa/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid ./ moments.charged.vth[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                        restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa = old_wpa*vth + upar
+                    # => old_wpa = (new_wpa - upar)/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. (vpa.grid - moments.charged.upar[iz,is]) /
+                               moments.charged.vth[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                        !restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa + upar = old_wpa
+                    # => old_wpa = new_wpa + upar
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .+ moments.charged.upar[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                        !restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa + upar = old_wpa*vth
+                    # => old_wpa = (new_wpa + upar)/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. (vpa.grid + moments.charged.upar[iz,is]) /
+                               moments.charged.vth
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                        restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa + upar = old_wpa*vth + upar
+                    # => old_wpa = new_wpa/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid ./ moments.charged.vth
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                        !restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth = old_wpa
+                    # => old_wpa = new_wpa*vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .* moments.charged.vth[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                        restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth = old_wpa + upar
+                    # => old_wpa = new_wpa*vth - upar/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = @. vpa.grid * moments.charged.vth[iz,is] -
+                                              moments.charged.upar[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                        restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa*vth = old_wpa*vth + upar
+                    # => old_wpa = new_wpa - upar/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. vpa.grid -
+                               moments.charged.upar[iz,is]/moments.charged.vth[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && moments.evolve_ppar &&
+                        !restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth + upar = old_wpa
+                    # => old_wpa = new_wpa*vth + upar
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = @. vpa.grid * moments.charged.vth[iz,is] +
+                                              moments.charged.upar[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && moments.evolve_ppar &&
+                        restart_evolve_upar && !restart_evolve_ppar)
+                    # vpa = new_wpa*vth + upar = old_wpa + upar
+                    # => old_wpa = new_wpa*vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals = vpa.grid .* moments.charged.vth[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                elseif (moments.evolve_upar && moments.evolve_ppar &&
+                        !restart_evolve_upar && restart_evolve_ppar)
+                    # vpa = new_wpa*vth + upar = old_wpa*vth
+                    # => old_wpa = new_wpa + upar/vth
+                    new_pdf = allocate_float(vpa.n, vperp.n, z.n, nspecies)
+                    for is ∈ nspecies, iz ∈ 1:z.n, ivperp ∈ 1:vperp.n
+                        restart_vpa_vals =
+                            @. vpa.grid +
+                               moments.charged.upar[iz,is] / moments.charged.vth[iz,is]
+                        @views interpolate_to_grid_1d!(
+                            new_pdf[:,ivperp,iz,is], restart_vpa_vals,
+                            this_pdf[:,ivperp,iz,is], restart_vpa, restart_vpa_spectral)
+                    end
+                    this_pdf = new_pdf
+                else
+                    # This should never happen, as all combinations of evolve_* options
+                    # should be handled above.
+                    error("Unsupported combination of moment-kinetic options:"
+                          * " evolve_density=", moments.evolve_density
+                          * " evolve_upar=", moments.evolve_upar
+                          * " evolve_ppar=", moments.evolve_ppar
+                          * " restart_evolve_density=", restart_evolve_density
+                          * " restart_evolve_upar=", restart_evolve_upar
+                          * " restart_evolve_ppar=", restart_evolve_ppar)
+                end
+                if moments.evolve_density && !restart_evolve_density
+                    # Need to normalise by density
+                    for is ∈ nspecies, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,is] ./= moments.charged.dens[iz,is]
+                    end
+                elseif !moments.evolve_density && restart_evolve_density
+                    # Need to unnormalise by density
+                    for is ∈ nspecies, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,is] .*= moments.charged.dens[iz,is]
+                    end
+                end
+                if moments.evolve_ppar && !restart_evolve_ppar
+                    # Need to normalise by vth
+                    for is ∈ nspecies, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,is] .*= moments.charged.vth[iz,is]
+                    end
+                elseif !moments.evolve_ppar && restart_evolve_ppar
+                    # Need to unnormalise by vth
+                    for is ∈ nspecies, iz ∈ 1:z.n
+                        this_pdf[:,:,iz,is] ./= moments.charged.vth[iz,is]
+                    end
+                end
+
+                return this_pdf
+            end
+
             boundary_distributions.pdf_rboundary_charged[:,:,:,1,:] .=
-            load_slice(boundary_distributions_io, "pdf_rboundary_charged_left",
-                       vpa_range, vperp_range, z_range, :)
+                load_charged_boundary_pdf("pdf_rboundary_charged_left")
             boundary_distributions.pdf_rboundary_charged[:,:,:,2,:] .=
-            load_slice(boundary_distributions_io, "pdf_rboundary_charged_right",
-                       vpa_range, vperp_range, z_range, :)
+                load_charged_boundary_pdf("pdf_rboundary_charged_right")
 
             if composition.n_neutral_species > 0
-                pdf.neutral.norm .= load_slice(dynamic, "f_neutral", vz_range,
-                                               vr_range, vzeta_range, z_range,
-                                               r_range, :, time_index)
-                moments.neutral.dens .= load_slice(dynamic, "density_neutral",
-                                                   z_range, r_range, :, time_index)
+                moments.neutral.dens .= load_moment("density_neutral")
                 moments.neutral.dens_updated .= true
-                moments.neutral.uz .= load_slice(dynamic, "uz_neutral", z_range,
-                                                 r_range, :, time_index)
+                moments.neutral.uz .= load_moment("uz_neutral")
                 moments.neutral.uz_updated .= true
-                moments.neutral.pz .= load_slice(dynamic, "pz_neutral", z_range,
-                                                 r_range, :, time_index)
+                moments.neutral.pz .= load_moment("pz_neutral")
                 moments.neutral.pz_updated .= true
-                moments.neutral.qz .= load_slice(dynamic, "qz_neutral", z_range,
-                                                 r_range, :, time_index)
+                moments.neutral.qz .= load_moment("qz_neutral")
                 moments.neutral.qz_updated .= true
-                moments.neutral.vth .= load_slice(dynamic, "thermal_speed_neutral", z_range,
-                                                  r_range, :, time_index)
+                moments.neutral.vth .= load_moment("thermal_speed_neutral")
+
+                function load_neutral_pdf()
+                    this_pdf = load_slice(dynamic, "f_neutral", vz_range, vr_range,
+                                          vzeta_range, z_range, r_range, :, time_index)
+                    orig_nvz, orig_nvr, orig_nvzeta, orig_nz, orig_nr, nspecies =
+                        size(this_pdf)
+                    if interpolation_needed["r"]
+                        new_pdf = allocate_float(orig_nvz, orig_nvr, orig_nvzeta, orig_nz,
+                                                 r.n, nspecies)
+                        for is ∈ 1:nspecies, iz ∈ 1:orig_nz, ivzeta ∈ 1:orig_nnzeta,
+                                ivr ∈ 1:orig_nvr, ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,ivr,ivzeta,iz,:,is], r.grid,
+                                this_pdf[ivz,ivr,ivzeta,iz,:,is], restart_r,
+                                restart_r_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+                    if interpolation_needed["z"]
+                        new_pdf = allocate_float(orig_nvz, orig_nvr, orig_nvzeta, z.n,
+                                                 r.n, nspecies)
+                        for is ∈ 1:nspecies, ir ∈ 1:r.n, ivzeta ∈ 1:orig_nvzeta,
+                                ivr ∈ 1:orig_nvr, ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,ivr,ivzeta,:,ir,is], z.grid,
+                                this_pdf[ivz,ivr,ivzeta,:,ir,is], restart_z,
+                                restart_z_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+
+                    # Current moment-kinetic implementation is only 1V, so no need
+                    # to handle normalised vzeta or vr coordinates. This will need
+                    # to change when/if 3V moment-kinetics is implemented.
+                    if interpolation_needed["vzeta"]
+                        new_pdf = allocate_float(orig_nvz, orig_nvr, vzeta.n, z.n, r.n,
+                                                 nspecies)
+                        for is ∈ 1:nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:orig_ivr,
+                                ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,ivr,:,iz,ir,is], vzeta.grid,
+                                this_pdf[ivz,ivr,:,iz,ir,is], restart_vzeta,
+                                restart_vzeta_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+                    if interpolation_needed["vr"]
+                        new_pdf = allocate_float(orig_nvz, vr.n, vzeta.n, z.n, r.n,
+                                                 nspecies)
+                        for is ∈ 1:nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n,
+                                ivzeta ∈ 1:orig_ivzeta, ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,:,ivzeta,iz,ir,is], vr.grid,
+                                this_pdf[ivz,:,ivzeta,iz,ir,is], restart_vr,
+                                restart_vr_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+
+                    if (
+                        (moments.evolve_density == restart_evolve_density &&
+                         moments.evolve_upar == restart_evolve_upar &&
+                         moments.evolve_ppar == restart_evolve_ppar)
+                        || (!moments.evolve_upar && !restart_evolve_upar &&
+                            !moments.evolve_ppar && !restart_evolve_ppar)
+                       )
+                        # No chages to velocity-space coordinates, so just interpolate from
+                        # one grid to the other
+                        if interpolation_needed["vz"]
+                            new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                            for is ∈ 1:nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                    ivzeta ∈ 1:vzeta.n
+                                @views interpolate_to_grid_1d!(
+                                    new_pdf[:,ivr,ivzeta,iz,ir,is], vz.grid,
+                                    this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                    restart_vz_spectral)
+                            end
+                            this_pdf = new_pdf
+                        end
+                    elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                            restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa = old_wpa + upar
+                        # => old_wpa = new_wpa - upar
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivzeta ∈ 1:vzeta.n,
+                                ivr ∈ 1:vr.n
+                            restart_vz_vals = vz.grid .- moments.neutral.uz[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                            !restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa = old_wpa*vth
+                        # => old_wpa = new_wpa/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid ./ moments.neutral.vth[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                            restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa = old_wpa*vth + upar
+                        # => old_wpa = (new_wpa - upar)/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. (vz.grid - moments.neutral.uz[iz,ir,is]) /
+                                   moments.neutral.vth[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                            !restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa + upar = old_wpa
+                        # => old_wpa = new_wpa + upar
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid .+ moments.neutral.uz[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz, restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                            !restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa + upar = old_wpa*vth
+                        # => old_wpa = (new_wpa + upar)/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. (vz.grid + moments.neutral.uz[iz,ir,is]) /
+                                   moments.neutral.vth
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                            restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa + upar = old_wpa*vth + upar
+                        # => old_wpa = new_wpa/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid ./ moments.neutral.vth
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                            !restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth = old_wpa
+                        # => old_wpa = new_wpa*vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid .* moments.neutral.vth[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                            restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth = old_wpa + upar
+                        # => old_wpa = new_wpa*vth - upar/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid * moments.neutral.vth[iz,ir,is] -
+                                   moments.neutral.upar[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                            restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa*vth = old_wpa*vth + upar
+                        # => old_wpa = new_wpa - upar/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid -
+                                   moments.neutral.uz[iz,ir,is]/moments.neutral.vth[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && moments.evolve_ppar &&
+                            !restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth + upar = old_wpa
+                        # => old_wpa = new_wpa*vth + upar
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid * moments.neutral.vth[iz,ir,is] +
+                                   moments.neutral.uz[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && moments.evolve_ppar &&
+                            restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth + upar = old_wpa + upar
+                        # => old_wpa = new_wpa*vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid .* moments.neutral.vth[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && moments.evolve_ppar &&
+                            !restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa*vth + upar = old_wpa*vth
+                        # => old_wpa = new_wpa + upar/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, r.n, nspecies)
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid +
+                                   moments.neutral.uz[iz,ir,is]/moments.neutral.vth[iz,ir,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,ir,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    else
+                        # This should never happen, as all combinations of evolve_* options
+                        # should be handled above.
+                        error("Unsupported combination of moment-kinetic options:"
+                              * " evolve_density=", moments.evolve_density
+                              * " evolve_upar=", moments.evolve_upar
+                              * " evolve_ppar=", moments.evolve_ppar
+                              * " restart_evolve_density=", restart_evolve_density
+                              * " restart_evolve_upar=", restart_evolve_upar
+                              * " restart_evolve_ppar=", restart_evolve_ppar)
+                    end
+                    if moments.evolve_density && !restart_evolve_density
+                        # Need to normalise by density
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,ir,is] ./= moments.neutral.dens[iz,ir,is]
+                        end
+                    elseif !moments.evolve_density && restart_evolve_density
+                        # Need to unnormalise by density
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,ir,is] .*= moments.neutral.dens[iz,ir,is]
+                        end
+                    end
+                    if moments.evolve_ppar && !restart_evolve_ppar
+                        # Need to normalise by vth
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,ir,is] .*= moments.neutral.vth[iz,ir,is]
+                        end
+                    elseif !moments.evolve_ppar && restart_evolve_ppar
+                        # Need to unnormalise by vth
+                        for is ∈ nspecies, ir ∈ 1:r.n, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,ir,is] ./= moments.neutral.vth[iz,ir,is]
+                        end
+                    end
+
+                    return this_pdf
+                end
+
+                pdf.neutral.norm .= load_neutral_pdf()
+
+                function load_neutral_boundary_pdf(var_name)
+                    this_pdf = load_slice(boundary_distributions_io, var_name, vz_range,
+                                          vr_range, vzeta_range, z_range, :)
+                    orig_nvz, orig_nvr, orig_nvzeta, orig_nz, nspecies = size(this_pdf)
+                    if interpolation_needed["z"]
+                        new_pdf = allocate_float(orig_nvz, orig_nvr, orig_nvzeta, z.n,
+                                                 nspecies)
+                        for is ∈ 1:nspecies, ivzeta ∈ 1:orig_nvzeta, ivr ∈ 1:orig_nvr,
+                                ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,ivr,ivzeta,:,is], z.grid,
+                                this_pdf[ivz,ivr,ivzeta,:,is], restart_z,
+                                restart_z_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+
+                    # Current moment-kinetic implementation is only 1V, so no need
+                    # to handle normalised vzeta or vr coordinates. This will need
+                    # to change when/if 3V moment-kinetics is implemented.
+                    if interpolation_needed["vzeta"]
+                        new_pdf = allocate_float(orig_nvz, orig_nvr, vzeta.n, z.n,
+                                                 nspecies)
+                        for is ∈ 1:nspecies, iz ∈ 1:z.n, ivr ∈ 1:orig_ivr,
+                                ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,ivr,:,iz,is], vzeta.grid,
+                                this_pdf[ivz,ivr,:,iz,is], restart_vzeta,
+                                restart_vzeta_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+                    if interpolation_needed["vr"]
+                        new_pdf = allocate_float(orig_nvz, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ 1:nspecies, iz ∈ 1:z.n, ivzeta ∈ 1:orig_ivzeta,
+                                ivz ∈ 1:orig_nvz
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[ivz,:,ivzeta,iz,is], vr.grid,
+                                this_pdf[ivz,:,ivzeta,iz,is], restart_vr,
+                                restart_vr_spectral)
+                        end
+                        this_pdf = new_pdf
+                    end
+
+                    if (
+                        (moments.evolve_density == restart_evolve_density &&
+                         moments.evolve_upar == restart_evolve_upar && moments.evolve_ppar ==
+                         restart_evolve_ppar)
+                        || (!moments.evolve_upar && !restart_evolve_upar &&
+                            !moments.evolve_ppar && !restart_evolve_ppar)
+                       )
+                        # No chages to velocity-space coordinates, so just interpolate from
+                        # one grid to the other
+                        if interpolation_needed["vz"]
+                            new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                            for is ∈ 1:nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n,
+                                    ivzeta ∈ 1:vzeta.n
+                                @views interpolate_to_grid_1d!(
+                                    new_pdf[:,ivr,ivzeta,iz,is], vz.grid,
+                                    this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                    restart_vz_spectral)
+                            end
+                            this_pdf = new_pdf
+                        end
+                    elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                            restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa = old_wpa + upar
+                        # => old_wpa = new_wpa - upar
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivzeta ∈ 1:vzeta.n, ivr ∈ 1:vr.n
+                            restart_vz_vals = vz.grid .- moments.neutral.uz[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                            !restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa = old_wpa*vth
+                        # => old_wpa = new_wpa/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid ./ moments.neutral.vth[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && !moments.evolve_ppar &&
+                            restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa = old_wpa*vth + upar
+                        # => old_wpa = (new_wpa - upar)/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. (vz.grid - moments.neutral.uz[iz,is]) /
+                                   moments.neutral.vth[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                            !restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa + upar = old_wpa
+                        # => old_wpa = new_wpa + upar
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid .+
+                                              moments.neutral.uz[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                            !restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa + upar = old_wpa*vth
+                        # => old_wpa = (new_wpa + upar)/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. (vz.grid + moments.neutral.uz[iz,is]) /
+                                   moments.neutral.vth
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && !moments.evolve_ppar &&
+                            restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa + upar = old_wpa*vth + upar
+                        # => old_wpa = new_wpa/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid ./ moments.neutral.vth
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                            !restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth = old_wpa
+                        # => old_wpa = new_wpa*vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid .*
+                                              moments.neutral.vth[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                            restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth = old_wpa + upar
+                        # => old_wpa = new_wpa*vth - upar/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid * moments.neutral.vth[iz,is] -
+                                   moments.neutral.upar[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (!moments.evolve_upar && moments.evolve_ppar &&
+                            restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa*vth = old_wpa*vth + upar
+                        # => old_wpa = new_wpa - upar/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid -
+                                   moments.neutral.uz[iz,is]/moments.neutral.vth[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && moments.evolve_ppar &&
+                            !restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth + upar = old_wpa
+                        # => old_wpa = new_wpa*vth + upar
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid * moments.neutral.vth[iz,is] +
+                                   moments.neutral.uz[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && moments.evolve_ppar &&
+                            restart_evolve_upar && !restart_evolve_ppar)
+                        # vpa = new_wpa*vth + upar = old_wpa + upar
+                        # => old_wpa = new_wpa*vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals = vz.grid .* moments.neutral.vth[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                        this_pdf = new_pdf
+                    elseif (moments.evolve_upar && moments.evolve_ppar &&
+                            !restart_evolve_upar && restart_evolve_ppar)
+                        # vpa = new_wpa*vth + upar = old_wpa*vth
+                        # => old_wpa = new_wpa + upar/vth
+                        new_pdf = allocate_float(vz.n, vr.n, vzeta.n, z.n, nspecies)
+                        for is ∈ nspecies, iz ∈ 1:z.n, ivr ∈ 1:vr.n, ivzeta ∈ 1:vzeta.n
+                            restart_vz_vals =
+                                @. vz.grid +
+                                   moments.neutral.uz[iz,is]/moments.neutral.vth[iz,is]
+                            @views interpolate_to_grid_1d!(
+                                new_pdf[:,ivr,ivzeta,iz,is], restart_vz_vals,
+                                this_pdf[:,ivr,ivzeta,iz,is], restart_vz,
+                                restart_vz_spectral)
+                        end
+                    else
+                        # This should never happen, as all combinations of evolve_* options
+                        # should be handled above.
+                        error("Unsupported combination of moment-kinetic options:"
+                              * " evolve_density=", moments.evolve_density
+                              * " evolve_upar=", moments.evolve_upar
+                              * " evolve_ppar=", moments.evolve_ppar
+                              * " restart_evolve_density=", restart_evolve_density
+                              * " restart_evolve_upar=", restart_evolve_upar
+                              * " restart_evolve_ppar=", restart_evolve_ppar)
+                    end
+                    if moments.evolve_density && !restart_evolve_density
+                        # Need to normalise by density
+                        for is ∈ nspecies, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,is] ./= moments.neutral.dens[iz,is]
+                        end
+                    elseif !moments.evolve_density && restart_evolve_density
+                        # Need to unnormalise by density
+                        for is ∈ nspecies, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,is] .*= moments.neutral.dens[iz,is]
+                        end
+                    end
+                    if moments.evolve_ppar && !restart_evolve_ppar
+                        # Need to normalise by vth
+                        for is ∈ nspecies, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,is] .*= moments.neutral.vth[iz,is]
+                        end
+                    elseif !moments.evolve_ppar && restart_evolve_ppar
+                        # Need to unnormalise by vth
+                        for is ∈ nspecies, iz ∈ 1:z.n
+                            this_pdf[:,:,:,iz,is] ./= moments.neutral.vth[iz,is]
+                        end
+                    end
+
+                    return this_pdf
+                end
 
                 boundary_distributions.pdf_rboundary_neutral[:,:,:,:,1,:] .=
-                load_slice(boundary_distributions_io, "pdf_rboundary_neutral_left",
-                           vz_range, vr_range, vzeta_range, z_range, :)
+                    load_neutral_boundary_pdf("pdf_rboundary_neutral_left")
                 boundary_distributions.pdf_rboundary_neutral[:,:,:,:,2,:] .=
-                load_slice(boundary_distributions_io, "pdf_rboundary_neutral_right",
-                           vz_range, vr_range, vzeta_range, z_range, :)
+                    load_neutral_boundary_pdf("pdf_rboundary_neutral_right")
             end
         finally
             close(fid)

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -779,8 +779,8 @@ function get_run_info(run_dir, restart_index=nothing; itime_min=1, itime_max=-1,
     # obtain input options from moment_kinetics_input.jl
     # and check input to catch errors
     io_input, evolve_moments, t_input, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-        composition, species, collisions, geometry, drive_input, num_diss_params,
-        manufactured_solns_input, reference_parameters = mk_input(input)
+        composition, species, collisions, geometry, drive_input, external_source_settings,
+        num_diss_params, manufactured_solns_input, reference_parameters = mk_input(input)
 
     n_ion_species, n_neutral_species = load_species_data(file_final_restart)
     evolve_density, evolve_upar, evolve_ppar = load_mk_options(file_final_restart)

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -330,8 +330,11 @@ function restart_moment_kinetics(input_dict::Dict,
         # Stop code from hanging when running on multiple processes if only one of them
         # throws an error
         if global_size[] > 1
-            println("Abort called on rank $(block_rank[]) due to error. Error message "
-                    * "was:\n", e)
+            println("$(typeof(e)) on process $(global_rank[]):")
+            showerror(stdout, e)
+            display(stacktrace(catch_backtrace()))
+            flush(stdout)
+            flush(stderr)
             MPI.Abort(comm_world, 1)
         end
 

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -287,7 +287,13 @@ function restart_moment_kinetics(input_dict::Dict,
         else
             error("Unrecognized binary_format '$binary_format'")
         end
-        restart_filename = glob(joinpath(output_dir, run_name * ".dfns*." * ext))[1]
+        restart_filename_pattern = joinpath(output_dir, run_name * ".dfns*." * ext)
+        restart_filename_glob = glob(restart_filename_pattern)
+        if length(restart_filename_glob) == 0
+            error("No output file to restart from found matching the pattern "
+                  * "$restart_filename_pattern")
+        end
+        restart_filename = restart_filename_glob[1]
     end
 
     mk_state = nothing

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -90,6 +90,12 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     composition.use_test_neutral_wall_pdf = get(scan_input, "use_test_neutral_wall_pdf", false)
     # constant to be used to test nonzero Er in wall boundary condition
     composition.Er_constant = get(scan_input, "Er_constant", 0.0)
+    # The ion flux reaching the wall that is recycled as neutrals is reduced by
+    # `recycling_fraction` to account for ions absorbed by the wall.
+    composition.recycling_fraction = get(scan_input, "recycling_fraction", 1.0)
+    if !(0.0 <= composition.recycling_fraction <= 1.0)
+        error("recycling_fraction must be between 0 and 1. Got $recycling_fraction.")
+    end
 
     # Get reference parameters for normalizations
     reference_parameter_section = copy(set_defaults_and_check_section!(
@@ -854,10 +860,13 @@ function load_defaults(n_ion_species, n_neutral_species, electron_physics)
     mn_over_mi = 1.0
     # ratio of the electron particle mass to the ion particle mass
     me_over_mi = 1.0/1836.0
+    # The ion flux reaching the wall that is recycled as neutrals is reduced by
+    # `recycling_fraction` to account for ions absorbed by the wall.
+    recycling_fraction = 1.0
     composition = species_composition(n_species, n_ion_species, n_neutral_species,
         electron_physics, use_test_neutral_wall_pdf, T_e, T_wall, phi_wall, Er_constant,
         epsilon_offset, use_vpabar_in_mms_dfni, alpha_switch, mn_over_mi, me_over_mi,
-        allocate_float(n_species))
+        recycling_fraction, allocate_float(n_species))
     
     species_charged = Array{species_parameters_mutable,1}(undef,n_ion_species)
     species_neutral = Array{species_parameters_mutable,1}(undef,n_neutral_species)

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -1043,6 +1043,8 @@ function check_coordinate_input(coord, coord_name, io)
         println(io,">$coord_name.bc = 'constant'.  enforcing constant incoming BC in $coord_name.")
     elseif coord.bc == "zero"
         println(io,">$coord_name.bc = 'zero'.  enforcing zero incoming BC in $coord_name.")
+    elseif coord.bc == "incoming_zero"
+        println(io,">$coord_name.bc = 'incoming_zero'.  enforcing zero incoming BC in $coord_name (even when there is diffusion).")
     elseif coord.bc == "both_zero"
         println(io,">$coord_name.bc = 'both_zero'.  enforcing zero BC in $coord_name.")
     elseif coord.bc == "periodic"

--- a/src/moment_kinetics_input.jl
+++ b/src/moment_kinetics_input.jl
@@ -11,6 +11,7 @@ using ..type_definitions: mk_float, mk_int
 using ..array_allocation: allocate_float
 using ..communication
 using ..coordinates: define_coordinate
+using ..external_sources
 using ..file_io: io_has_parallel, input_option_error, open_ascii_output_file
 using ..constants
 using ..krook_collisions: setup_krook_collisions
@@ -511,6 +512,8 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     # initialize vr grid and write grid point locations to file
     vzeta, vzeta_spectral = define_coordinate(vzeta_immutable, io_immutable.parallel_io)
 
+    external_source_settings = setup_external_sources!(scan_input, r, z)
+
     if global_rank[] == 0 && save_inputs_to_txt
         # Make file to log some information about inputs into.
         # check to see if output_dir exists in the current directory
@@ -531,7 +534,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
                   vpa, vpa_spectral, vperp, vperp_spectral, gyrophase, gyrophase_spectral,
                   vz, vz_spectral, vr, vr_spectral, vzeta, vzeta_spectral, composition,
                   species_immutable, collisions, geometry, drive_immutable,
-                  num_diss_params, manufactured_solns_input,
+                  external_source_settings, num_diss_params, manufactured_solns_input,
                   reference_parameters)
     println(io, "\nAll inputs returned from mk_input():")
     println(io, all_inputs)

--- a/src/neutral_vz_advection.jl
+++ b/src/neutral_vz_advection.jl
@@ -12,7 +12,7 @@ using ..looping
 """
 """
 function neutral_advection_vz!(f_out, fvec_in, fields, moments, advect, vz, vr, vzeta, z,
-        r, dt, vz_spectral, composition, collisions)
+        r, dt, vz_spectral, composition, collisions, neutral_source_settings)
 
     # only have a parallel acceleration term for neutrals if using the peculiar velocity
     # wpar = vpar - upar as a variable; i.e., d(wpar)/dt /=0 for neutrals even though d(vpar)/dt = 0.
@@ -23,7 +23,8 @@ function neutral_advection_vz!(f_out, fvec_in, fields, moments, advect, vz, vr, 
     begin_sn_r_z_vzeta_vr_region()
 
     # calculate the advection speed corresponding to current f
-    update_speed_neutral_vz!(advect, fields, fvec_in, moments, vz, vr, vzeta, z, r, composition, collisions)
+    update_speed_neutral_vz!(advect, fields, fvec_in, moments, vz, vr, vzeta, z, r,
+                             composition, collisions, neutral_source_settings)
     @loop_sn isn begin
         @loop_r_z_vzeta_vr ir iz ivzeta ivr begin
             @views advance_f_local!(f_out[:,ivr,ivzeta,iz,ir,isn], fvec_in.pdf_neutral[:,ivr,ivzeta,iz,ir,isn],
@@ -36,7 +37,7 @@ end
 calculate the advection speed in the vz-direction at each grid point
 """
 function update_speed_neutral_vz!(advect, fields, fvec, moments, vz, vr, vzeta, z, r,
-                                  composition, collisions)
+                                  composition, collisions, neutral_source_settings)
     @boundscheck r.n == size(advect[1].speed,5) || throw(BoundsError(advect[1].speed))
     @boundscheck z.n == size(advect[1].speed,4) || throw(BoundsError(advect[1].speed))
     @boundscheck vzeta.n == size(advect[1].speed,3) || throw(BoundsError(advect[1].speed))
@@ -45,7 +46,8 @@ function update_speed_neutral_vz!(advect, fields, fvec, moments, vz, vr, vzeta, 
     @boundscheck vz.n == size(advect[1].speed,1) || throw(BoundsError(advect[1].speed))
     if vz.advection.option == "default"
         # dvpa/dt = Ze/m ⋅ E_parallel
-        update_speed_default_neutral!(advect, fields, fvec, moments, vz, z, r, composition, collisions)
+        update_speed_default_neutral!(advect, fields, fvec, moments, vz, z, r,
+                                      composition, collisions, neutral_source_settings)
     elseif vz.advection.option == "constant"
         begin_serial_region()
         @serial_region begin
@@ -70,13 +72,19 @@ end
 
 """
 """
-function update_speed_default_neutral!(advect, fields, fvec, moments, vz, z, r, composition, collisions)
+function update_speed_default_neutral!(advect, fields, fvec, moments, vz, z, r,
+                                       composition, collisions, neutral_source_settings)
     if moments.evolve_ppar && moments.evolve_upar
-        update_speed_n_u_p_evolution_neutral!(advect, fvec, moments, vz, z, r, composition, collisions)
+        update_speed_n_u_p_evolution_neutral!(advect, fvec, moments, vz, z, r,
+                                              composition, collisions,
+                                              neutral_source_settings)
     elseif moments.evolve_ppar
-        update_speed_n_p_evolution_neutral!(advect, fields, fvec, moments, vz, z, r, composition, collisions)
+        update_speed_n_p_evolution_neutral!(advect, fields, fvec, moments, vz, z, r,
+                                            composition, collisions,
+                                            neutral_source_settings)
     elseif moments.evolve_upar
-        update_speed_n_u_evolution_neutral!(advect, fvec, moments, vz, z, r, composition, collisions)
+        update_speed_n_u_evolution_neutral!(advect, fvec, moments, vz, z, r, composition,
+                                            collisions, neutral_source_settings)
     end
 end
 
@@ -86,7 +94,9 @@ coordinate for the case where density, flow and pressure are evolved independent
 the pdf; in this case, the parallel velocity coordinate is the normalized peculiar
 velocity wpahat = (vpa - upar)/vth
 """
-function update_speed_n_u_p_evolution_neutral!(advect, fvec, moments, vz, z, r, composition, collisions)
+function update_speed_n_u_p_evolution_neutral!(advect, fvec, moments, vz, z, r,
+                                               composition, collisions,
+                                               neutral_source_settings)
     @loop_sn isn begin
         @loop_r ir begin
             # update parallel acceleration to account for:
@@ -116,6 +126,26 @@ function update_speed_n_u_p_evolution_neutral!(advect, fvec, moments, vz, z, r, 
             end
         end
     end
+    if neutral_source_settings.active
+        source_amplitude = moments.neutral.external_source_amplitude
+        source_T = neutral_source_settings.source_T
+        density = fvec.density_neutral
+        uz = fvec.uz_neutral
+        pz = fvec.pz_neutral
+        vth = moments.neutral.vth
+        vz_grid = vz.grid
+        @loop_s_r_z is ir iz begin
+            prefactor = source_amplitude[iz,ir]
+            term1 = prefactor * uz[iz,ir,is]/(density[iz,ir,is]*vth[iz,ir,is])
+            term2_over_vpa =
+                0.5 * prefactor * (-(0.5*source_T + uz[iz,ir,is]^2) / pz[iz,ir,is]
+                                   + 1.0/density[iz,ir,is])
+            @loop_vzeta_vr_vz ivzeta ivr ivz begin
+                advect[is].speed[ivz,ivr,ivzeta,iz,ir] += term1 +
+                                                          vz_grid[ivz] * term2_over_vpa
+            end
+        end
+    end
 end
 
 """
@@ -124,7 +154,9 @@ where density and pressure are evolved independently from the pdf;
 in this case, the parallel velocity coordinate is the normalized velocity
 vpahat = vpa/vth
 """
-function update_speed_n_p_evolution_neutral!(advect, fields, fvec, moments, vz, z, r, composition, collisions)
+function update_speed_n_p_evolution_neutral!(advect, fields, fvec, moments, vz, z, r,
+                                             composition, collisions,
+                                             neutral_source_settings)
     @loop_sn isn begin
         # include contributions common to both ion and neutral species
         @loop_r ir begin
@@ -150,6 +182,9 @@ function update_speed_n_p_evolution_neutral!(advect, fields, fvec, moments, vz, 
             end
         end
     end
+    if ion_source_settings.active
+        error("External source not implemented for evolving n and ppar case")
+    end
 end
 
 """
@@ -158,7 +193,8 @@ where density and flow are evolved independently from the pdf;
 in this case, the parallel velocity coordinate is the peculiar velocity
 wpa = vpa-upar
 """
-function update_speed_n_u_evolution_neutral!(advect, fvec, moments, vz, z, r, composition, collisions)
+function update_speed_n_u_evolution_neutral!(advect, fvec, moments, vz, z, r, composition,
+                                             collisions, neutral_source_settings)
     @loop_sn isn begin
         @loop_r ir begin
             # update parallel acceleration to account for:
@@ -178,6 +214,19 @@ function update_speed_n_u_evolution_neutral!(advect, fvec, moments, vz, z, r, co
             # include contribution to neutral acceleration due to collisional friction with ions
             @loop_r_z_vzeta_vr ir iz ivzeta ivr begin
                 @views @. advect[isn].speed[:,ivr,ivzeta,iz,ir] -= collisions.charge_exchange*fvec.density[iz,ir,isn]*(fvec.upar[iz,ir,isn]-fvec.uz_neutral[iz,ir,isn])
+            end
+        end
+    end
+    if neutral_source_settings.active
+        source_amplitude = moments.neutral.external_source_amplitude
+        source_T = neutral_source_settings.source_T
+        density = fvec.density_neutral
+        uz = fvec.uz_neutral
+        vth = moments.neutral.vth
+        @loop_s_r_z is ir iz begin
+            term = source_amplitude[iz,ir] * uz[iz,ir,is] / density[iz,ir,is]
+            @loop_vperp_vpa ivperp ivpa begin
+                advect[is].speed[ivpa,ivperp,iz,ir] += term
             end
         end
     end

--- a/src/plot_MMS_sequence.jl
+++ b/src/plot_MMS_sequence.jl
@@ -66,8 +66,8 @@ function get_MMS_error_data(path_list,scan_type,scan_name)
         #io_input, evolve_moments, t_input, z, z_spectral, r, r_spectral, vpa, vpa_spectral,
         #    vperp, vperp_spectral, gyrophase, gyrophase_spectral, vz, vz_spectral, vr,
         #    vr_spectral, vzeta, vzeta_spectral, composition, species, collisions, geometry,
-        #    drive_input, num_diss_params, manufactured_solns_input,
-        #    reference_parameters = mk_input(scan_input)
+        #    drive_input, external_source_settings, num_diss_params,
+        #    manufactured_solns_input, reference_parameters = mk_input(scan_input)
         z_nelement, r_nelement, vpa_nelement, vperp_nelement, 
           vz_nelement, vr_nelement, vzeta_nelement = get_coords_nelement(scan_input)
         if scan_type == "vpa_nelement"

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -1048,8 +1048,8 @@ function analyze_and_plot_data(prefix...; run_index=nothing)
     # obtain input options from moment_kinetics_input.jl
     # and check input to catch errors
     io_input, evolve_moments, t_input, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-        composition, species, collisions, geometry, drive_input, num_diss_params,
-        manufactured_solns_input = input
+        composition, species, collisions, geometry, drive_input, external_source_settings,
+        num_diss_params, manufactured_solns_input = input
 
     if !is_1D1V
         # make plots and animations of the phi, Ez and Er

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -1613,7 +1613,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     end
     if advance.neutral_external_source
         external_neutral_source_controller!(fvec_in, moments.neutral,
-                                            external_source_settings.neutral, dt)
+                                            external_source_settings.neutral, r, z, dt)
     end
 
     if advance.vpa_advection

--- a/src/time_advance.jl
+++ b/src/time_advance.jl
@@ -41,6 +41,7 @@ using ..vpa_advection: update_speed_vpa!, vpa_advection!
 using ..charge_exchange: charge_exchange_collisions_1V!, charge_exchange_collisions_3V!
 using ..ionization: ionization_collisions_1V!, ionization_collisions_3V!, constant_ionization_source!
 using ..krook_collisions: krook_collisions!
+using ..external_sources
 using ..numerical_dissipation: vpa_boundary_buffer_decay!,
                                vpa_boundary_buffer_diffusion!, vpa_dissipation!,
                                z_dissipation!, r_dissipation!,
@@ -164,8 +165,8 @@ function setup_time_advance!(pdf, vz, vr, vzeta, vpa, vperp, z, r, vz_spectral,
                              vr_spectral, vzeta_spectral, vpa_spectral, vperp_spectral,
                              z_spectral, r_spectral, composition, drive_input, moments,
                              t_input, collisions, species, geometry,
-                             boundary_distributions, num_diss_params,
-                             manufactured_solns_input, restarting)
+                             boundary_distributions, external_source_settings,
+                             num_diss_params, manufactured_solns_input, restarting)
     # define some local variables for convenience/tidiness
     n_species = composition.n_species
     n_ion_species = composition.n_ion_species
@@ -177,8 +178,9 @@ function setup_time_advance!(pdf, vz, vr, vzeta, vpa, vperp, z, r, vz_spectral,
     # if no splitting of operators, all terms advanced concurrently;
     # else, will advance one term at a time.
     advance = setup_advance_flags(moments, composition, t_input, collisions,
-                                  num_diss_params, manufactured_solns_input, rk_coefs, r,
-                                  vperp, vpa, vzeta, vr, vz)
+                                  external_source_settings, num_diss_params,
+                                  manufactured_solns_input, rk_coefs, r, vperp, vpa,
+                                  vzeta, vr, vz)
 
     begin_serial_region()
 
@@ -231,7 +233,8 @@ function setup_time_advance!(pdf, vz, vr, vzeta, vpa, vperp, z, r, vz_spectral,
     # initialise the vpa advection speed
     begin_s_r_z_vperp_region()
     update_speed_vpa!(vpa_advect, fields, scratch[1], moments, vpa, vperp, z, r,
-                      composition, collisions, 0.0, geometry)
+                      composition, collisions, external_source_settings.ion, 0.0,
+                      geometry)
 
     # create structure vperp_advect whose members are the arrays needed to compute
     # the advection term(s) appearing in the split part of the GK equation dealing
@@ -291,7 +294,8 @@ function setup_time_advance!(pdf, vz, vr, vzeta, vpa, vperp, z, r, vz_spectral,
         end
         begin_sn_r_z_vzeta_vr_region()
         @views update_speed_neutral_vz!(neutral_vz_advect, fields, scratch[1], moments,
-                                        vz, vr, vzeta, z, r, composition, collisions)
+                                        vz, vr, vzeta, z, r, composition, collisions,
+                                        external_source_settings.neutral)
     end
 
     ##
@@ -393,7 +397,8 @@ indicate which parts of the equations are to be advanced concurrently.
 if no splitting of operators, all terms advanced concurrently;
 else, will advance one term at a time.
 """
-function setup_advance_flags(moments, composition, t_input, collisions, num_diss_params,
+function setup_advance_flags(moments, composition, t_input, collisions,
+                             external_source_settings, num_diss_params,
                              manufactured_solns_input, rk_coefs, r, vperp, vpa, vzeta, vr,
                              vz)
     # default is not to concurrently advance different operators
@@ -406,6 +411,7 @@ function setup_advance_flags(moments, composition, t_input, collisions, num_diss
     advance_ionization_1V = false
     advance_ionization_source = false
     advance_krook_collisions = false
+    advance_external_source = false
     advance_numerical_dissipation = false
     advance_sources = false
     advance_continuity = false
@@ -414,6 +420,7 @@ function setup_advance_flags(moments, composition, t_input, collisions, num_diss
     advance_neutral_z_advection = false
     advance_neutral_r_advection = false
     advance_neutral_vz_advection = false
+    advance_neutral_external_source = false
     advance_neutral_sources = false
     advance_neutral_continuity = false
     advance_neutral_force_balance = false
@@ -478,6 +485,8 @@ function setup_advance_flags(moments, composition, t_input, collisions, num_diss
         if collisions.krook_collision_frequency_prefactor > 0.0
             advance_krook_collisions = true
         end
+        advance_external_source = external_source_settings.ion.active
+        advance_neutral_external_source = external_source_settings.neutral.active
         advance_numerical_dissipation = true
         # if evolving the density, must advance the continuity equation,
         # in addition to including sources arising from the use of a modified distribution
@@ -527,8 +536,9 @@ function setup_advance_flags(moments, composition, t_input, collisions, num_diss
                         advance_neutral_vz_advection, advance_cx, advance_cx_1V,
                         advance_ionization, advance_ionization_1V,
                         advance_ionization_source, advance_krook_collisions,
-                        advance_numerical_dissipation, advance_sources,
-                        advance_continuity, advance_force_balance, advance_energy,
+                        advance_external_source, advance_numerical_dissipation,
+                        advance_sources, advance_continuity, advance_force_balance,
+                        advance_energy, advance_neutral_external_source,
                         advance_neutral_sources, advance_neutral_continuity,
                         advance_neutral_force_balance, advance_neutral_energy, rk_coefs,
                         manufactured_solns_test, r_diffusion, vpa_diffusion, vz_diffusion)
@@ -729,7 +739,7 @@ time integrator can be used without severe CFL condition
 function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyrophase, z, r,
            moments, fields, spectral_objects, advect_objects,
            composition, collisions, geometry, boundary_distributions,
-           num_diss_params, advance, scratch_dummy,
+           external_source_settings, num_diss_params, advance, scratch_dummy,
            manufactured_source_list, ascii_io, io_moments, io_dfns)
 
     @debug_detect_redundant_block_synchronize begin
@@ -763,12 +773,14 @@ function time_advance!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyro
             # MRH NOT SUPPORTED
             time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, i)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, i)
         else
             time_advance_no_splitting!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyrophase, z, r,
                 moments, fields, spectral_objects, advect_objects,
                 composition, collisions, geometry, boundary_distributions,
-                num_diss_params, advance,  scratch_dummy, manufactured_source_list, i)
+                external_source_settings, num_diss_params, advance, scratch_dummy,
+                manufactured_source_list, i)
         end
         # update the time
         t += t_input.dt
@@ -1000,7 +1012,7 @@ end
 """
 function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
     vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-    composition, collisions, num_diss_params, advance, istep)
+    composition, collisions, external_source_settings, num_diss_params, advance, istep)
 
     # define some abbreviated variables for tidiness
     n_ion_species = composition.n_ion_species
@@ -1016,14 +1028,16 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
         advance.vpa_advection = true
         time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
             vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-            composition, collisions, num_diss_params, advance, istep)
+            composition, collisions, external_source_settings, num_diss_params, advance,
+            istep)
         advance.vpa_advection = false
         # z_advection! advances the operator-split 1D advection equation in z
         # apply z-advection operation to all species (charged and neutral)
         advance.z_advection = true
         time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
             vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-            composition, collisions, num_diss_params, advance, istep)
+            composition, collisions, external_source_settings, num_diss_params, advance,
+            istep)
         advance.z_advection = false
         # account for charge exchange collisions between ions and neutrals
         if composition.n_neutral_species > 0
@@ -1031,16 +1045,16 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
                 advance.cx_collisions = true
                 time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                     vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                    composition, collisions, num_diss_params, advance,
-                    istep)
+                    composition, collisions, external_source_settings, num_diss_params,
+                    advance, istep)
                 advance.cx_collisions = false
             end
             if collisions.ionization > 0.0
                 advance.ionization_collisions = true
                 time_advance_no_splitting!(pdf, scratch, t, t_input, z, vpa,
                     z_spectral, vpa_spectral, moments, fields, z_advect, vpa_advect,
-                    composition, collisions, num_diss_params, advance,
-                    istep)
+                    composition, collisions, external_source_settings, num_diss_params,
+                    advance, istep)
                 advance.ionization_collisions = false
             end
         end
@@ -1058,7 +1072,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.source_terms = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.source_terms = false
         end
         # use the continuity equation to update the density
@@ -1066,7 +1081,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.continuity = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.continuity = false
         end
         # use force balance to update the parallel flow
@@ -1074,7 +1090,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.force_balance = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.force_balance = false
         end
         # use the energy equation to update the parallel pressure
@@ -1082,7 +1099,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.energy = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.energy = false
         end
     else
@@ -1091,7 +1109,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.energy = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.energy = false
         end
         # use force balance to update the parallel flow
@@ -1099,7 +1118,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.force_balance = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.force_balance = false
         end
         # use the continuity equation to update the density
@@ -1107,7 +1127,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.continuity = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.continuity = false
         end
         # and add the source terms associated with redefining g = pdf/density or pdf*vth/density
@@ -1116,7 +1137,8 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
             advance.source_terms = true
             time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                 vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                composition, collisions, num_diss_params, advance, istep)
+                composition, collisions, external_source_settings, num_diss_params,
+                advance, istep)
             advance.source_terms = false
         end
         # account for charge exchange collisions between ions and neutrals
@@ -1125,16 +1147,16 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
                 advance.ionization = true
                 time_advance_no_splitting!(pdf, scratch, t, t_input, z, vpa,
                     z_spectral, vpa_spectral, moments, fields, z_advect, vpa_advect,
-                    composition, collisions, num_diss_params, advance,
-                    istep)
+                    composition, collisions, external_source_settings, num_diss_params,
+                    advance, istep)
                 advance.ionization = false
             end
             if collisions.charge_exchange > 0.0
                 advance.cx_collisions = true
                 time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
                     vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-                    composition, collisions, num_diss_params, advance,
-                    istep)
+                    composition, collisions, external_source_settings, num_diss_params,
+                    advance, istep)
                 advance.cx_collisions = false
             end
         end
@@ -1143,14 +1165,16 @@ function time_advance_split_operators!(pdf, scratch, t, t_input, vpa, z,
         advance.z_advection = true
         time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
             vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-            composition, collisions, num_diss_params, advance, istep)
+            composition, collisions, external_source_settings, num_diss_params, advance,
+            istep)
         advance.z_advection = false
         # advance the operator-split 1D advection equation in vpa
         # vpa-advection only applies for charged species
         advance.vpa_advection = true
         time_advance_no_splitting!(pdf, scratch, t, t_input, vpa, z,
             vpa_spectral, z_spectral, moments, fields, vpa_advect, z_advect,
-            composition, collisions, num_diss_params, advance, istep)
+            composition, collisions, external_source_settings, num_diss_params, advance,
+            istep)
         advance.vpa_advection = false
     end
     return nothing
@@ -1161,13 +1185,14 @@ end
 function time_advance_no_splitting!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyrophase, z, r,
            moments, fields, spectral_objects, advect_objects,
            composition, collisions, geometry, boundary_distributions,
-           num_diss_params, advance, scratch_dummy, manufactured_source_list, istep)
+           external_source_settings, num_diss_params, advance, scratch_dummy,
+           manufactured_source_list, istep)
 
     if t_input.n_rk_stages > 1
         ssp_rk!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyrophase, z, r,
-            moments, fields, spectral_objects, advect_objects,
-            composition, collisions, geometry, boundary_distributions, num_diss_params,
-            advance,  scratch_dummy, manufactured_source_list, istep)
+            moments, fields, spectral_objects, advect_objects, composition, collisions,
+            geometry, boundary_distributions, external_source_settings, num_diss_params,
+            advance, scratch_dummy, manufactured_source_list, istep)
     else
         euler_time_advance!(scratch, scratch, pdf, fields, moments,
             advect_objects, vz, vr, vzeta, vpa, vperp, gyrophase, z, r, t,
@@ -1435,8 +1460,8 @@ end
 """
 """
 function ssp_rk!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyrophase, z, r,
-           moments, fields, spectral_objects, advect_objects,
-           composition, collisions, geometry, boundary_distributions, num_diss_params,
+           moments, fields, spectral_objects, advect_objects, composition, collisions,
+           geometry, boundary_distributions, external_source_settings, num_diss_params,
            advance, scratch_dummy, manufactured_source_list, istep)
 
     begin_s_r_z_region()
@@ -1480,8 +1505,8 @@ function ssp_rk!(pdf, scratch, t, t_input, vz, vr, vzeta, vpa, vperp, gyrophase,
             pdf, fields, moments,
             advect_objects, vz, vr, vzeta, vpa, vperp, gyrophase, z, r, t,
             t_input, spectral_objects, composition,
-            collisions, geometry, scratch_dummy, manufactured_source_list, 
-            num_diss_params, advance, istage)
+            collisions, geometry, scratch_dummy, manufactured_source_list,
+            external_source_settings, num_diss_params, advance, istage)
         @views rk_update!(scratch, pdf, moments, fields, boundary_distributions, vz, vr,
                           vzeta, vpa, vperp, z, r, advect_objects,
                           advance.rk_coefs[:,istage], istage, composition, geometry,
@@ -1567,7 +1592,8 @@ with fvec_in an input and fvec_out the output
 function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     advect_objects, vz, vr, vzeta, vpa, vperp, gyrophase, z, r, t, t_input,
     spectral_objects, composition, collisions, geometry, scratch_dummy,
-    manufactured_source_list, num_diss_params, advance, istage)
+    manufactured_source_list, external_source_settings, num_diss_params, advance, istage)
+
     # define some abbreviated variables for tidiness
     n_ion_species = composition.n_ion_species
     n_neutral_species = composition.n_neutral_species
@@ -1581,9 +1607,18 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     vpa_advect, r_advect, z_advect = advect_objects.vpa_advect, advect_objects.r_advect, advect_objects.z_advect
     neutral_z_advect, neutral_r_advect, neutral_vz_advect = advect_objects.neutral_z_advect, advect_objects.neutral_r_advect, advect_objects.neutral_vz_advect
 
+    if advance.external_source
+        external_ion_source_controller!(fvec_in, moments.charged,
+                                    external_source_settings.ion, dt)
+    end
+    if advance.neutral_external_source
+        external_neutral_source_controller!(fvec_in, moments.neutral,
+                                            external_source_settings.neutral, dt)
+    end
+
     if advance.vpa_advection
         vpa_advection!(fvec_out.pdf, fvec_in, fields, moments, vpa_advect, vpa, vperp, z, r, dt, t,
-            vpa_spectral, composition, collisions, geometry)
+            vpa_spectral, composition, collisions, external_source_settings.ion, geometry)
     end
 
     # z_advection! advances 1D advection equation in z
@@ -1606,7 +1641,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
 
     if advance.source_terms
         source_terms!(fvec_out.pdf, fvec_in, moments, vpa, z, r, dt, z_spectral,
-                      composition, collisions)
+                      composition, collisions, external_source_settings.ion)
     end
 
     if advance.neutral_z_advection
@@ -1622,12 +1657,12 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     if advance.neutral_vz_advection
         neutral_advection_vz!(fvec_out.pdf_neutral, fvec_in, fields, moments,
                               neutral_vz_advect, vz, vr, vzeta, z, r, dt, vz_spectral,
-                              composition, collisions)
+                              composition, collisions, external_source_settings.neutral)
     end
 
     if advance.neutral_source_terms
         source_terms_neutral!(fvec_out.pdf_neutral, fvec_in, moments, vpa, z, r, dt, z_spectral,
-                      composition, collisions)
+                      composition, collisions, external_source_settings.neutral)
     end
 
     if advance.manufactured_solns_test
@@ -1664,11 +1699,20 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
         constant_ionization_source!(fvec_out.pdf, vpa, vperp, z, r, moments, composition,
                                     collisions, dt)
     end
-    
+
     # Add a for Krook collision operoator for ions
     if advance.krook_collisions
         krook_collisions!(fvec_out.pdf, fvec_in, moments, composition, collisions,
                           vperp, vpa, dt)
+    end
+
+    if advance.external_source
+        external_ion_source!(fvec_out.pdf, fvec_in, moments, external_source_settings.ion,
+                            vperp, vpa, dt)
+    end
+    if advance.neutral_external_source
+        external_neutral_source!(fvec_out.pdf_neutral, fvec_in, moments,
+                                external_source_settings.neutral, vzeta, vr, vz, dt)
     end
 
     # add numerical dissipation
@@ -1698,7 +1742,8 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     end
     if advance.continuity
         continuity_equation!(fvec_out.density, fvec_in, moments, composition, dt,
-                             z_spectral, collisions.ionization, num_diss_params)
+                             z_spectral, collisions.ionization,
+                             external_source_settings.ion, num_diss_params)
     end
     if advance.force_balance
         # fvec_out.upar is over-written in force_balance! and contains the particle flux
@@ -1707,7 +1752,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     end
     if advance.energy
         energy_equation!(fvec_out.ppar, fvec_in, moments, collisions, dt, z_spectral,
-                         composition, num_diss_params)
+                         composition, external_source_settings.ion, num_diss_params)
     end
     if moments.evolve_density || moments.evolve_upar || moments.evolve_ppar
         # Only need to change region type if moment evolution equations will be used.
@@ -1719,7 +1764,7 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     if advance.neutral_continuity
         neutral_continuity_equation!(fvec_out.density_neutral, fvec_in, moments,
                                      composition, dt, z_spectral, collisions.ionization,
-                                     num_diss_params)
+                                     external_source_settings.neutral, num_diss_params)
     end
     if advance.neutral_force_balance
         # fvec_out.upar is over-written in force_balance! and contains the particle flux
@@ -1729,7 +1774,8 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     end
     if advance.neutral_energy
         neutral_energy_equation!(fvec_out.pz_neutral, fvec_in, moments, collisions, dt,
-                                 z_spectral, composition, num_diss_params)
+                                 z_spectral, composition,
+                                 external_source_settings.neutral, num_diss_params)
     end
     # reset "xx.updated" flags to false since ff has been updated
     # and the corresponding moments have not

--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -92,6 +92,10 @@ struct moments_charged_substruct
     dqpar_dz::Union{MPISharedArray{mk_float,3},Nothing}
     # this is the z-derivative of the thermal speed based on the parallel temperature Tpar = ppar/dens: vth = sqrt(2*Tpar/m)
     dvth_dz::Union{MPISharedArray{mk_float,3},Nothing}
+    # Spatially varying amplitude of the external source term
+    external_source_amplitude::MPISharedArray{mk_float,2}
+    # Integral term for the PID controller of the external source term
+    external_source_controller_integral::MPISharedArray{mk_float,2}
 end
 
 """
@@ -161,12 +165,16 @@ struct moments_neutral_substruct
     dvth_dz::Union{MPISharedArray{mk_float,3},Nothing}
     # this is the z-derivative of the heat flux along z
     dqz_dz::Union{MPISharedArray{mk_float,3},Nothing}
+    # Spatially varying amplitude of the external source term
+    external_source_amplitude::MPISharedArray{mk_float,2}
+    # Integral term for the PID controller of the external source term
+    external_source_controller_integral::MPISharedArray{mk_float,2}
 end
 
 """
 """
 function create_moments_charged(nz, nr, n_species, evolve_density, evolve_upar,
-                                evolve_ppar, numerical_dissipation)
+                                evolve_ppar, ion_source_settings, numerical_dissipation)
     # allocate array used for the particle density
     density = allocate_shared_float(nz, nr, n_species)
     # allocate array of Bools that indicate if the density is updated for each species
@@ -244,13 +252,31 @@ function create_moments_charged(nz, nr, n_species, evolve_density, evolve_upar,
         dqpar_dz = nothing
         dvth_dz = nothing
     end
-    
+
+    if ion_source_settings.active
+        external_source_amplitude = allocate_shared_float(nz, nr)
+        if ion_source_settings.PI_density_controller_I != 0.0 &&
+                ion_source_settings.PI_density_controller_type != ""
+            if ion_source_settings.PI_density_controller_type == "profile"
+                external_source_controller_integral = allocate_shared_float(nz, nr)
+            else
+                external_source_controller_integral = allocate_shared_float(1, 1)
+            end
+        else
+            external_source_controller_integral = allocate_shared_float(1, 1)
+        end
+    else
+        external_source_amplitude = allocate_shared_float(1, 1)
+        external_source_controller_integral = allocate_shared_float(1, 1)
+    end
+
     # return struct containing arrays needed to update moments
     return moments_charged_substruct(density, density_updated, parallel_flow,
         parallel_flow_updated, parallel_pressure, parallel_pressure_updated,
         parallel_heat_flux, parallel_heat_flux_updated, thermal_speed, v_norm_fac,
         ddens_dz_upwind, d2dens_dz2, dupar_dz, dupar_dz_upwind, d2upar_dz2, dppar_dz,
-        dppar_dz_upwind, d2ppar_dz2, dqpar_dz, dvth_dz)
+        dppar_dz_upwind, d2ppar_dz2, dqpar_dz, dvth_dz, external_source_amplitude,
+        external_source_controller_integral)
 end
 
 # neutral particles have natural mean velocities 
@@ -259,7 +285,8 @@ end
 # therefore separate moments object for neutrals 
     
 function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
-                                evolve_ppar, numerical_dissipation)
+                                evolve_ppar, neutral_source_settings,
+                                numerical_dissipation)
     density = allocate_shared_float(nz, nr, n_species)
     density_updated = allocate_bool(n_species)
     density_updated .= false
@@ -341,11 +368,29 @@ function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
         dvth_dz = nothing
     end
 
+    if neutral_source_settings.active
+        external_source_amplitude = allocate_shared_float(nz, nr)
+        if neutral_source_settings.PI_density_controller_I != 0.0 &&
+                neutral_source_settings.PI_density_controller_type != ""
+            if neutral_source_settings.PI_density_controller_type == "profile"
+                external_source_controller_integral = allocate_shared_float(nz, nr)
+            else
+                external_source_controller_integral = allocate_shared_float(1, 1)
+            end
+        else
+            external_source_controller_integral = allocate_shared_float(1, 1)
+        end
+    else
+        external_source_amplitude = allocate_shared_float(1, 1)
+        external_source_controller_integral = allocate_shared_float(1, 1)
+    end
+
     # return struct containing arrays needed to update moments
     return moments_neutral_substruct(density, density_updated, uz, uz_updated, ur,
         ur_updated, uzeta, uzeta_updated, pz, pz_updated, pr, pr_updated, pzeta,
         pzeta_updated, ptot, qz, qz_updated, vth, v_norm_fac, ddens_dz_upwind, d2dens_dz2,
-        duz_dz, duz_dz_upwind, d2uz_dz2, dpz_dz, dpz_dz_upwind, d2pz_dz2, dqz_dz, dvth_dz)
+        duz_dz, duz_dz_upwind, d2uz_dz2, dpz_dz, dpz_dz_upwind, d2pz_dz2, dqz_dz, dvth_dz,
+        external_source_amplitude, external_source_controller_integral)
 end
 
 """

--- a/src/vpa_advection.jl
+++ b/src/vpa_advection.jl
@@ -12,7 +12,7 @@ using ..looping
 """
 """
 function vpa_advection!(f_out, fvec_in, fields, moments, advect, vpa, vperp, z, r, dt, t,
-                        vpa_spectral, composition, collisions, geometry)
+                        vpa_spectral, composition, collisions, ion_source_settings, geometry)
 
     begin_s_r_z_vperp_region()
 
@@ -20,7 +20,8 @@ function vpa_advection!(f_out, fvec_in, fields, moments, advect, vpa, vperp, z, 
     # wpar = vpar - upar as a variable; i.e., d(wpar)/dt /=0 for neutrals even though d(vpar)/dt = 0.
 
     # calculate the advection speed corresponding to current f
-    update_speed_vpa!(advect, fields, fvec_in, moments, vpa, vperp, z, r, composition, collisions, t, geometry)
+    update_speed_vpa!(advect, fields, fvec_in, moments, vpa, vperp, z, r, composition,
+                      collisions, ion_source_settings, t, geometry)
     @loop_s is begin
         @loop_r_z_vperp ir iz ivperp begin
             @views advance_f_local!(f_out[:,ivperp,iz,ir,is], fvec_in.pdf[:,ivperp,iz,ir,is],
@@ -32,7 +33,8 @@ end
 """
 calculate the advection speed in the vpa-direction at each grid point
 """
-function update_speed_vpa!(advect, fields, fvec, moments, vpa, vperp, z, r, composition, collisions, t, geometry)
+function update_speed_vpa!(advect, fields, fvec, moments, vpa, vperp, z, r, composition,
+                           collisions, ion_source_settings, t, geometry)
     @boundscheck r.n == size(advect[1].speed,4) || throw(BoundsError(advect))
     @boundscheck z.n == size(advect[1].speed,3) || throw(BoundsError(advect))
     @boundscheck vperp.n == size(advect[1].speed,2) || throw(BoundsError(advect))
@@ -41,7 +43,8 @@ function update_speed_vpa!(advect, fields, fvec, moments, vpa, vperp, z, r, comp
     @boundscheck vpa.n == size(advect[1].speed,1) || throw(BoundsError(speed))
     if vpa.advection.option == "default"
         # dvpa/dt = Ze/m ⋅ E_parallel
-        update_speed_default!(advect, fields, fvec, moments, vpa, z, r, composition, collisions, t, geometry)
+        update_speed_default!(advect, fields, fvec, moments, vpa, z, r, composition,
+                              collisions, ion_source_settings, t, geometry)
     elseif vpa.advection.option == "constant"
         begin_serial_region()
         @serial_region begin
@@ -66,13 +69,17 @@ end
 
 """
 """
-function update_speed_default!(advect, fields, fvec, moments, vpa, z, r, composition, collisions, t, geometry)
+function update_speed_default!(advect, fields, fvec, moments, vpa, z, r, composition,
+                               collisions, ion_source_settings, t, geometry)
     if moments.evolve_ppar && moments.evolve_upar
-        update_speed_n_u_p_evolution!(advect, fvec, moments, vpa, z, r, composition, collisions)
+        update_speed_n_u_p_evolution!(advect, fvec, moments, vpa, z, r, composition,
+                                      collisions, ion_source_settings)
     elseif moments.evolve_ppar
-        update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r, composition, collisions)
+        update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r, composition,
+                                    collisions, ion_source_settings)
     elseif moments.evolve_upar
-        update_speed_n_u_evolution!(advect, fvec, moments, vpa, z, r, composition, collisions)
+        update_speed_n_u_evolution!(advect, fvec, moments, vpa, z, r, composition,
+                                    collisions, ion_source_settings)
     else
         bzed = geometry.bzed
         @inbounds @fastmath begin
@@ -90,7 +97,8 @@ where density, flow and pressure are evolved independently from the pdf;
 in this case, the parallel velocity coordinate is the normalized peculiar velocity
 wpahat = (vpa - upar)/vth
 """
-function update_speed_n_u_p_evolution!(advect, fvec, moments, vpa, z, r, composition, collisions)
+function update_speed_n_u_p_evolution!(advect, fvec, moments, vpa, z, r, composition,
+                                       collisions, ion_source_settings)
     @loop_s is begin
         @loop_r ir begin
             # update parallel acceleration to account for:
@@ -135,6 +143,25 @@ function update_speed_n_u_p_evolution!(advect, fvec, moments, vpa, z, r, composi
             end
         end
     end
+    if ion_source_settings.active
+        source_amplitude = moments.charged.external_source_amplitude
+        source_T = ion_source_settings.source_T
+        density = fvec.density
+        upar = fvec.upar
+        ppar = fvec.ppar
+        vth = moments.charged.vth
+        vpa_grid = vpa.grid
+        @loop_s_r_z is ir iz begin
+            prefactor = source_amplitude[iz,ir]
+            term1 = prefactor * upar[iz,ir,is]/(density[iz,ir,is]*vth[iz,ir,is])
+            term2_over_vpa =
+                0.5 * prefactor * (-(0.5*source_T + upar[iz,ir,is]^2) / ppar[iz,ir,is]
+                                   + 1.0/density[iz,ir,is])
+            @loop_vperp_vpa ivperp ivpa begin
+                advect[is].speed[ivpa,ivperp,iz,ir] += term1 + vpa_grid[ivpa] * term2_over_vpa
+            end
+        end
+    end
 end
 
 """
@@ -143,7 +170,8 @@ where density and pressure are evolved independently from the pdf;
 in this case, the parallel velocity coordinate is the normalized velocity
 vpahat = vpa/vth
 """
-function update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r, composition, collisions)
+function update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r,
+                                     composition, collisions, ion_source_settings)
     @loop_s is begin
         # include contributions common to both ion and neutral species
         @loop_r ir begin
@@ -174,6 +202,9 @@ function update_speed_n_p_evolution!(advect, fields, fvec, moments, vpa, z, r, c
             end
         end
     end
+    if ion_source_settings.active
+        error("External source not implemented for evolving n and ppar case")
+    end
 end
 
 """
@@ -182,7 +213,8 @@ where density and flow are evolved independently from the pdf;
 in this case, the parallel velocity coordinate is the peculiar velocity
 wpa = vpa-upar
 """
-function update_speed_n_u_evolution!(advect, fvec, moments, vpa, z, r, composition, collisions)
+function update_speed_n_u_evolution!(advect, fvec, moments, vpa, z, r, composition,
+                                     collisions, ion_source_settings)
     @loop_s is begin
         @loop_r ir begin
             # update parallel acceleration to account for:
@@ -211,6 +243,22 @@ function update_speed_n_u_evolution!(advect, fvec, moments, vpa, z, r, compositi
                 @loop_r_z_vperp ir iz ivperp begin
                     @views @. advect[is].speed[:,ivperp,iz,ir] -= collisions.ionization*fvec.density_neutral[iz,ir,is]*(fvec.uz_neutral[iz,ir,is]-fvec.upar[iz,ir,is])
                 end
+            end
+        end
+    end
+    if ion_source_settings.active
+        source_amplitude = moments.charged.external_source_amplitude
+        source_strength = ion_source_settings.source_strength
+        source_T = ion_source_settings.source_T
+        r_amplitude = ion_source_settings.r_amplitude
+        z_amplitude = ion_source_settings.z_amplitude
+        density = fvec.density
+        upar = fvec.upar
+        vth = moments.charged.vth
+        @loop_s_r_z is ir iz begin
+            term = source_amplitude[iz,ir] * upar[iz,ir,is] / density[iz,ir,is]
+            @loop_vperp_vpa ivperp ivpa begin
+                advect[is].speed[ivpa,ivperp,iz,ir] += term
             end
         end
     end


### PR DESCRIPTION
...even when diffusion is present. This is in contrast to "zero" which sets zero at the incoming boundary when no diffusion is present, but zero at both boundaries when some diffusion is present. This may be useful when numerical diffusion is present but is small compared to the advection speed near the boundary. Specify with, e.g. `vpa_bc = "incoming_zero"`.

Not sure whether this is really useful - I ended up not needing any numerical dissipation in my 1D1V runs for EFTC, so the existing `"zero"` bc was fine in the end. I guess we might as well add the option to force 'zero at the incoming boundary' in case it is useful in future.