### PR TITLE
Allow loading coordinates from files created before `element_spacing_option` was added

### DIFF
--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -259,7 +259,11 @@ function load_coordinate_data(fid, name; printout=false, irank=nothing, nrank=no
     discretization = load_variable(coord_group, "discretization")
     fd_option = load_variable(coord_group, "fd_option")
     bc = load_variable(coord_group, "bc")
-    element_spacing_option = load_variable(coord_group, "element_spacing_option")
+    if "element_spacing_option" ∈ keys(coord_group)
+        element_spacing_option = load_variable(coord_group, "element_spacing_option")
+    else
+        element_spacing_option = "uniform"
+    end
     # Define input to create coordinate struct
     input = grid_input(name, ngrid, nelement_global, nelement_local, nrank, irank, L,
                        discretization, fd_option, bc, advection_input("", 0.0, 0.0, 0.0),


### PR DESCRIPTION
For old files, can safely default to `element_spacing_option = "uniform"`.