### PR TITLE
source_terms!(), source_terms_neutral!() use distributed MPI derivatives

### DIFF
--- a/src/velocity_moments.jl
+++ b/src/velocity_moments.jl
@@ -88,6 +88,8 @@ struct moments_charged_substruct
     # v_norm_fac accounts for this: it is vth if using the above definition for the parallel velocity,
     # and it is one otherwise
     v_norm_fac::Union{MPISharedArray{mk_float,3},Nothing}
+    # this is the z-derivative of the particle density
+    ddens_dz::Union{MPISharedArray{mk_float,3},Nothing}
     # this is the upwinded z-derivative of the particle density
     ddens_dz_upwind::Union{MPISharedArray{mk_float,3},Nothing}
     # this is the second-z-derivative of the particle density
@@ -170,6 +172,8 @@ struct moments_neutral_substruct
     # and it is one otherwise
     v_norm_fac::MPISharedArray{mk_float,3}
     # this is the z-derivative of the particle density
+    ddens_dz::Union{MPISharedArray{mk_float,3},Nothing}
+    # this is the z-derivative of the particle density
     ddens_dz_upwind::Union{MPISharedArray{mk_float,3},Nothing}
     # this is the second-z-derivative of the particle density
     d2dens_dz2::Union{MPISharedArray{mk_float,3},Nothing}
@@ -244,8 +248,10 @@ function create_moments_charged(nz, nr, n_species, evolve_density, evolve_upar,
     end
 
     if evolve_density
+        ddens_dz = allocate_shared_float(nz, nr, n_species)
         ddens_dz_upwind = allocate_shared_float(nz, nr, n_species)
     else
+        ddens_dz = nothing
         ddens_dz_upwind = nothing
     end
     if evolve_density &&
@@ -329,10 +335,11 @@ function create_moments_charged(nz, nr, n_species, evolve_density, evolve_upar,
         parallel_flow_updated, parallel_pressure, parallel_pressure_updated,perpendicular_pressure,
         parallel_heat_flux, parallel_heat_flux_updated, thermal_speed, 
         chodura_integral_lower, chodura_integral_upper, v_norm_fac,
-        ddens_dz_upwind, d2dens_dz2, dupar_dz, dupar_dz_upwind, d2upar_dz2, dppar_dz,
-        dppar_dz_upwind, d2ppar_dz2, dqpar_dz, dvth_dz, external_source_amplitude,
-        external_source_density_amplitude, external_source_momentum_amplitude,
-        external_source_pressure_amplitude, external_source_controller_integral)
+        ddens_dz, ddens_dz_upwind, d2dens_dz2, dupar_dz, dupar_dz_upwind, d2upar_dz2,
+        dppar_dz, dppar_dz_upwind, d2ppar_dz2, dqpar_dz, dvth_dz,
+        external_source_amplitude, external_source_density_amplitude,
+        external_source_momentum_amplitude, external_source_pressure_amplitude,
+        external_source_controller_integral)
 end
 
 # neutral particles have natural mean velocities 
@@ -379,8 +386,10 @@ function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
     qz_updated .= false
 
     if evolve_density
+        ddens_dz = allocate_shared_float(nz, nr, n_species)
         ddens_dz_upwind = allocate_shared_float(nz, nr, n_species)
     else
+        ddens_dz = nothing
         ddens_dz_upwind = nothing
     end
     if evolve_density &&
@@ -462,9 +471,9 @@ function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
     # return struct containing arrays needed to update moments
     return moments_neutral_substruct(density, density_updated, uz, uz_updated, ur,
         ur_updated, uzeta, uzeta_updated, pz, pz_updated, pr, pr_updated, pzeta,
-        pzeta_updated, ptot, qz, qz_updated, vth, v_norm_fac, ddens_dz_upwind, d2dens_dz2,
-        duz_dz, duz_dz_upwind, d2uz_dz2, dpz_dz, dpz_dz_upwind, d2pz_dz2, dqz_dz, dvth_dz,
-        external_source_amplitude, external_source_density_amplitude,
+        pzeta_updated, ptot, qz, qz_updated, vth, v_norm_fac, ddens_dz, ddens_dz_upwind,
+        d2dens_dz2, duz_dz, duz_dz_upwind, d2uz_dz2, dpz_dz, dpz_dz_upwind, d2pz_dz2,
+        dqz_dz, dvth_dz, external_source_amplitude, external_source_density_amplitude,
         external_source_momentum_amplitude, external_source_pressure_amplitude,
         external_source_controller_integral)
 end
@@ -932,6 +941,8 @@ function calculate_moment_derivatives!(moments, scratch, scratch_dummy, z, z_spe
         buffer_r_5 = @view scratch_dummy.buffer_rs_5[:,is]
         buffer_r_6 = @view scratch_dummy.buffer_rs_6[:,is]
         if moments.evolve_density
+            @views derivative_z!(moments.charged.ddens_dz[:,:,is], density, buffer_r_1,
+                                 buffer_r_2, buffer_r_3, buffer_r_4, z_spectral, z)
             # Upwinded using upar as advection velocity, to be used in continuity equation
             @loop_r_z ir iz begin
                 dummy_zr[iz,ir] = -upar[iz,ir]
@@ -1465,6 +1476,8 @@ function calculate_moment_derivatives_neutral!(moments, scratch, scratch_dummy, 
         buffer_r_5 = @view scratch_dummy.buffer_rsn_5[:,isn]
         buffer_r_6 = @view scratch_dummy.buffer_rsn_6[:,isn]
         if moments.evolve_density
+            @views derivative_z!(moments.neutral.ddens_dz[:,:,isn], density, buffer_r_1,
+                                 buffer_r_2, buffer_r_3, buffer_r_4, z_spectral, z)
             # Upwinded using upar as advection velocity, to be used in continuity equation
             @loop_r_z ir iz begin
                 dummy_zr[iz,ir] = -uz[iz,ir]


### PR DESCRIPTION
Previously source_terms!() and source_terms_neutral!() were using the `derivative!()` function for z-derivatives. This is an error because `derivative!()` does not include communication between different shared-memory blocks. Mistake introduced in 1d-2d merge.

Instead, use the already-calculated moment derivatives. This slightly changes the way the derivatives are calculated, e.g. (n*du/dz + u*dn/dz) instead of d(n*u)/dz.