### PR TITLE
`makie_post_processing` update

### DIFF
--- a/docs/src/post_processing_notes.md
+++ b/docs/src/post_processing_notes.md
@@ -54,17 +54,15 @@ or to load from the distribution functions output file `.dfns.h5`
 ```julia
 julia> run_info_dfns = get_run_info("runs/example-run/"; dfns=true)
 ```
-You will usually want to set up the options (stored in
-[`moment_kinetics.makie_post_processing.input_dict`](@ref) and
-[`moment_kinetics.makie_post_processing.input_dict_dfns`](@ref)) with
-[`moment_kinetics.makie_post_processing.setup_makie_post_processing_input!()`](@ref)
-```
-julia> setup_makie_post_processing_input!("my_input.toml"; run_info_moments=run_info, run_info_dfns=run_info_dfns)
-```
-The `run_info_moments` and `run_info_dfns` arguments are used to set sensible
-defaults for various options - they are not required, and usually you will
-probably only pass one (`run_info_dfns` if you loaded distribution function
-output, and `run_info_moments` otherwise).
+Settings for post-processing are read from an input file, by default
+`post_processing_input.toml` (you can select a different one using the
+`setup_input_file` argument to `get_run_info()`). The relevant settings for
+interactive use are the default indices (`iz0`, `ivpa0`, etc.) that are used to
+select slices for 1D/2D plots and animations. The settings are read by
+`setup_makie_post_processing!()` which is called by default as part of
+`get_run_info()`. You might want to call it directly if you load both 'moments'
+and 'distribution functions' data, to get sensible settings for both at the
+same time.
 
 Then you can make 1d or 2d plots, e.g.
 ```julia

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -248,7 +248,9 @@ function makie_post_process(run_dir::Union{String,Tuple},
         if length(run_info) == 1
             plot_prefix = run_info[1].run_prefix * "_"
         else
-            plot_prefix = joinpath("comparison_plots", "compare_")
+            comparison_plot_dir = "comparison_plots"
+            mkpath(comparison_plot_dir)
+            plot_prefix = joinpath(comparison_plot_dir, "compare_")
         end
     end
 

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -1589,15 +1589,15 @@ for dim ∈ one_dimension_combinations
              """
              function $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, outfile=nothing, yscale=nothing,
-                      $($spaces)transform=identity, it=nothing, ir=nothing, iz=nothing,
-                      $($spaces)ivperp=nothing, ivpa=nothing, ivzeta=nothing, ivr=nothing,
-                      $($spaces)ivz=nothing, kwargs...)
+                      transform=identity, axis_args=Dict{Symbol,Any}(), it=nothing,
+                      $($spaces)ir=nothing, iz=nothing, ivperp=nothing, ivpa=nothing,
+                      $($spaces)ivzeta=nothing, ivr=nothing, ivz=nothing, kwargs...)
              function $($function_name_str)(run_info, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, ax=nothing, label=nothing,
                       $($spaces)outfile=nothing, yscale=nothing, transform=identity,
-                      $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
-                      $($spaces)ivpa=nothing, ivzeta=nothing, ivr=nothing, ivz=nothing,
-                      $($spaces)kwargs...)
+                      $($spaces)axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing,
+                      $($spaces)iz=nothing, ivperp=nothing, ivpa=nothing, ivzeta=nothing,
+                      $($spaces)ivr=nothing, ivz=nothing, kwargs...)
 
              Plot `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref)) vs $($dim_str).
@@ -1619,6 +1619,9 @@ for dim ∈ one_dimension_combinations
              using a log scale on data that may contain some negative values it might be
              useful to pass `transform=abs` (to plot the absolute value) or
              `transform=positive_or_nan` (to ignore any negative or zero values).
+
+             `axis_args` are passed as keyword arguments to `get_1d_ax()`, and from there
+             to the `Axis` constructor.
 
              Extra `kwargs` are passed to Makie's `lines!() function`.
 
@@ -1648,7 +1651,8 @@ for dim ∈ one_dimension_combinations
 
              function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, yscale=nothing,
-                                     transform=identity, kwargs...)
+                                     transform=identity, axis_args=Dict{Symbol,Any}(),
+                                     kwargs...)
 
                  try
                      if data === nothing
@@ -1661,9 +1665,9 @@ for dim ∈ one_dimension_combinations
 
                      n_runs = length(run_info)
 
-                     fig, ax = get_1d_ax(xlabel="$($dim_str)",
+                     fig, ax = get_1d_ax(; xlabel="$($dim_str)",
                                          ylabel=get_variable_symbol(var_name),
-                                         yscale=yscale)
+                                         yscale=yscale, axis_args...)
                      for (d, ri) ∈ zip(data, run_info)
                          $function_name(ri, var_name, is=is, data=d, input=input, ax=ax,
                                         transform=transform, label=ri.run_name, kwargs...)
@@ -1693,9 +1697,11 @@ for dim ∈ one_dimension_combinations
 
              function $function_name(run_info, var_name; is=1, data=nothing,
                                      input=nothing, fig=nothing, ax=nothing,
-                                     label=nothing, outfile=nothing, it=nothing,
-                                     ir=nothing, iz=nothing, ivperp=nothing, ivpa=nothing,
-                                     ivzeta=nothing, ivr=nothing, ivz=nothing, kwargs...)
+                                     label=nothing, outfile=nothing,
+                                     axis_args=Dict{Symbol,Any}(), it=nothing,
+                                     ir=nothing, iz=nothing, ivperp=nothing,
+                                     ivpa=nothing, ivzeta=nothing, ivr=nothing,
+                                     ivz=nothing, kwargs...)
                  if input === nothing
                      if run_info.dfns
                          input = input_dict_dfns[var_name]
@@ -1722,7 +1728,8 @@ for dim ∈ one_dimension_combinations
 
                  if ax === nothing
                      fig, ax = get_1d_ax(; xlabel="$($dim_str)",
-                                         ylabel=get_variable_symbol(var_name))
+                                         ylabel=get_variable_symbol(var_name),
+                                         axis_args...)
                      ax_was_nothing = true
                  else
                      ax_was_nothing = false
@@ -1773,16 +1780,17 @@ for (dim1, dim2) ∈ two_dimension_combinations
              """
              function $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, outfile=nothing, colorscale=identity,
-                      $($spaces)transform=identity, it=nothing, ir=nothing, iz=nothing,
-                      $($spaces)ivperp=nothing, ivpa=nothing, ivzeta=nothing, ivr=nothing,
-                      $($spaces)ivz=nothing, kwargs...)
+                      $($spaces)transform=identity, axis_args=Dict{Symbol,Any}(),
+                      $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
+                      $($spaces)ivpa=nothing, ivzeta=nothing, ivr=nothing, ivz=nothing,
+                      $($spaces)kwargs...)
              function $($function_name_str)(run_info, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, ax=nothing,
                       $($spaces)colorbar_place=nothing, title=nothing,
                       $($spaces)outfile=nothing, colorscale=identity, transform=identity,
-                      $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
-                      $($spaces)ivpa=nothing, ivzeta=nothing, ivr=nothing, ivz=nothing,
-                      $($spaces)kwargs...)
+                      $($spaces)axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing,
+                      $($spaces)iz=nothing, ivperp=nothing, ivpa=nothing, ivzeta=nothing,
+                      $($spaces)ivr=nothing, ivz=nothing, kwargs...)
 
              Plot `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref))vs $($dim1_str) and $($dim2_str).
@@ -1804,6 +1812,9 @@ for (dim1, dim2) ∈ two_dimension_combinations
              using a log scale on data that may contain some negative values it might be
              useful to pass `transform=abs` (to plot the absolute value) or
              `transform=positive_or_nan` (to ignore any negative or zero values).
+
+             `axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there
+             to the `Axis` constructor.
 
              Extra `kwargs` are passed to Makie's `heatmap!() function`.
 
@@ -1833,14 +1844,15 @@ for (dim1, dim2) ∈ two_dimension_combinations
 
              function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, transform=identity,
-                                     kwargs...)
+                                     axis_args=Dict{Symbol,Any}(), kwargs...)
 
                  try
                      if data === nothing
                          data = Tuple(nothing for _ in run_info)
                      end
-                     fig, ax, colorbar_places = get_2d_ax(length(run_info),
-                                                          title=get_variable_symbol(var_name))
+                     fig, ax, colorbar_places = get_2d_ax(length(run_info);
+                                                          title=get_variable_symbol(var_name),
+                                                          axis_args...)
                      for (d, ri, a, cp) ∈ zip(data, run_info, ax, colorbar_places)
                          $function_name(ri, var_name; is=is, data=d, input=input, ax=a,
                                         transform=transform, colorbar_place=cp,
@@ -1860,9 +1872,10 @@ for (dim1, dim2) ∈ two_dimension_combinations
              function $function_name(run_info, var_name; is=1, data=nothing,
                                      input=nothing, ax=nothing,
                                      colorbar_place=nothing, title=nothing,
-                                     outfile=nothing, it=nothing, ir=nothing, iz=nothing,
-                                     ivperp=nothing, ivpa=nothing, ivzeta=nothing,
-                                     ivr=nothing, ivz=nothing, kwargs...)
+                                     outfile=nothing, axis_args=Dict{Symbol,Any}(),
+                                     it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
+                                     ivpa=nothing, ivzeta=nothing, ivr=nothing,
+                                     ivz=nothing, kwargs...)
                  if input === nothing
                      if run_info.dfns
                          input = input_dict_dfns[var_name]
@@ -1898,7 +1911,7 @@ for (dim1, dim2) ∈ two_dimension_combinations
                  end
 
                  if ax === nothing
-                     fig, ax, colorbar_place = get_2d_ax(; title=title)
+                     fig, ax, colorbar_place = get_2d_ax(; title=title, axis_args...)
                      ax_was_nothing = true
                  else
                      fig = nothing
@@ -1953,15 +1966,17 @@ for dim ∈ one_dimension_combinations_no_t
              """
              function $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, outfile=nothing, yscale=nothing,
-                      $($spaces)transform=identity, ylims=nothing, it=nothing, ir=nothing,
-                      $($spaces)iz=nothing, ivperp=nothing, ivpa=nothing, ivzeta=nothing,
-                      $($spaces)ivr=nothing, ivz=nothing, kwargs...)
+                      $($spaces)transform=identity, ylims=nothing,
+                      $($spaces)axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing, iz=nothing,
+                      $($spaces)ivperp=nothing, ivpa=nothing, ivzeta=nothing, ivr=nothing,
+                      $($spaces)ivz=nothing, kwargs...)
              function $($function_name_str)(run_info, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, frame_index=nothing, ax=nothing,
                       $($spaces)fig=nothing, outfile=nothing, yscale=nothing,
-                      $($spaces)transform=identity, ylims=nothing, it=nothing, ir=nothing,
-                      $($spaces)iz=nothing, ivperp=nothing, ivpa=nothing, ivzeta=nothing,
-                      $($spaces)ivr=nothing, ivz=nothing, kwargs...)
+                      $($spaces)transform=identity, ylims=nothing,
+                      $($spaces)axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing, iz=nothing,
+                      $($spaces)ivperp=nothing, ivpa=nothing, ivzeta=nothing, ivr=nothing,
+                      $($spaces)ivz=nothing, kwargs...)
 
              Animate `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref))vs $($dim_str).
@@ -1984,6 +1999,9 @@ for dim ∈ one_dimension_combinations_no_t
              using a log scale on data that may contain some negative values it might be
              useful to pass `transform=abs` (to plot the absolute value) or
              `transform=positive_or_nan` (to ignore any negative or zero values).
+
+             `axis_args` are passed as keyword arguments to `get_1d_ax()`, and from there
+             to the `Axis` constructor.
 
              Extra `kwargs` are passed to Makie's `lines!() function`.
 
@@ -2013,7 +2031,8 @@ for dim ∈ one_dimension_combinations_no_t
 
              function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, yscale=nothing,
-                                     ylims=nothing, it=nothing, kwargs...)
+                                     ylims=nothing, axis_args=Dict{Symbol,Any}(),
+                                     it=nothing, kwargs...)
 
                  try
                      if data === nothing
@@ -2041,9 +2060,9 @@ for dim ∈ one_dimension_combinations_no_t
                                                for (irun,ri) ∈ enumerate(run_info)), "; "),
                                       frame_index)
                      end
-                     fig, ax = get_1d_ax(xlabel="$($dim_str)",
+                     fig, ax = get_1d_ax(; xlabel="$($dim_str)",
                                          ylabel=get_variable_symbol(var_name),
-                                         title=title, yscale=yscale)
+                                         title=title, yscale=yscale, axis_args...)
 
                      for (d, ri) ∈ zip(data, run_info)
                          $function_name(ri, var_name; is=is, data=d, input=input,
@@ -2080,9 +2099,10 @@ for dim ∈ one_dimension_combinations_no_t
              function $function_name(run_info, var_name; is=1, data=nothing,
                                      input=nothing, frame_index=nothing, ax=nothing,
                                      fig=nothing, outfile=nothing, yscale=nothing,
-                                     ylims=nothing, it=nothing, ir=nothing, iz=nothing,
-                                     ivperp=nothing, ivpa=nothing, ivzeta=nothing,
-                                     ivr=nothing, ivz=nothing, kwargs...)
+                                     ylims=nothing, axis_args=Dict{Symbol,Any}(),
+                                     it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
+                                     ivpa=nothing, ivzeta=nothing, ivr=nothing,
+                                     ivz=nothing, kwargs...)
                  if input === nothing
                      if run_info.dfns
                          input = input_dict_dfns[var_name]
@@ -2114,9 +2134,9 @@ for dim ∈ one_dimension_combinations_no_t
                  end
                  if ax === nothing
                      title = lift(i->string("t = ", run_info.time[i]), ind)
-                     fig, ax = get_1d_ax(xlabel="$($dim_str)",
+                     fig, ax = get_1d_ax(; xlabel="$($dim_str)",
                                          ylabel=get_variable_symbol(var_name),
-                                         yscale=yscale, title=title)
+                                         yscale=yscale, title=title, axis_args...)
                  else
                      fig = nothing
                  end
@@ -2173,16 +2193,18 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
              """
              function $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, outfile=nothing, colorscale=identity,
-                      $($spaces)transform=identity, it=nothing, ir=nothing, iz=nothing,
-                      $($spaces)ivperp=nothing, ivpa=nothing, ivzeta=nothing, ivr=nothing,
-                      $($spaces)ivz=nothing, kwargs...)
+                      $($spaces)transform=identity, axis_args=Dict{Symbol,Any}(),
+                      $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
+                      $($spaces)ivpa=nothing, ivzeta=nothing, ivr=nothing, ivz=nothing,
+                      $($spaces)kwargs...)
              function $($function_name_str)(run_info, var_name; is=1, data=nothing,
                       $($spaces)input=nothing, frame_index=nothing, ax=nothing,
                       $($spaces)fig=nothing, colorbar_place=colorbar_place,
                       $($spaces)title=nothing, outfile=nothing, colorscale=identity,
-                      $($spaces)transform=identity, it=nothing, ir=nothing, iz=nothing,
-                      $($spaces)ivperp=nothing, ivpa=nothing, ivzeta=nothing, ivr=nothing,
-                      $($spaces)ivz=nothing, kwargs...)
+                      $($spaces)transform=identity, axis_args=Dict{Symbol,Any}(),
+                      $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
+                      $($spaces)ivpa=nothing, ivzeta=nothing, ivr=nothing, ivz=nothing,
+                      $($spaces)kwargs...)
 
              Animate `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref))vs $($dim1_str) and $($dim2_str).
@@ -2202,6 +2224,9 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
              using a log scale on data that may contain some negative values it might be
              useful to pass `transform=abs` (to plot the absolute value) or
              `transform=positive_or_nan` (to ignore any negative or zero values).
+
+             `axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there
+             to the `Axis` constructor.
 
              Extra `kwargs` are passed to Makie's `heatmap!() function`.
 
@@ -2236,7 +2261,7 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
 
              function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, transform=identity,
-                                     it=nothing, kwargs...)
+                                     axis_args=Dict{Symbol,Any}(), it=nothing, kwargs...)
 
                  try
                      if data === nothing
@@ -2261,7 +2286,8 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                      end
                      fig, ax, colorbar_places = get_2d_ax(length(run_info),
                                                           title=title,
-                                                          subtitles=subtitles)
+                                                          subtitles=subtitles,
+                                                          axis_args...)
 
                      for (d, ri, a, cp) ∈ zip(data, run_info, ax, colorbar_places)
                          $function_name(ri, var_name; is=is, data=d, input=input,
@@ -2286,8 +2312,9 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
              function $function_name(run_info, var_name; is=1, data=nothing,
                                      input=nothing, frame_index=nothing, ax=nothing,
                                      fig=nothing, colorbar_place=colorbar_place,
-                                     title=nothing, outfile=nothing, it=nothing,
-                                     ir=nothing, iz=nothing, ivperp=nothing, ivpa=nothing,
+                                     title=nothing, outfile=nothing,
+                                     axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing,
+                                     iz=nothing, ivperp=nothing, ivpa=nothing,
                                      ivzeta=nothing, ivr=nothing, ivz=nothing, kwargs...)
                  if input === nothing
                      if run_info.dfns
@@ -2327,7 +2354,7 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                  end
 
                  if ax === nothing
-                     fig, ax = get_2d_ax(; title=title)
+                     fig, ax = get_2d_ax(; title=title, axis_args...)
                      ax_was_nothing = true
                  else
                      ax_was_nothing = false
@@ -2541,7 +2568,8 @@ end
 
 """
     plot_1d(xcoord, data; ax=nothing, xlabel=nothing, ylabel=nothing, title=nothing,
-            yscale=nothing, transform=identity, kwargs...)
+            yscale=nothing, transform=identity, axis_args=Dict{Symbol,Any}(),
+            kwargs...)
 
 Make a 1d plot of `data` vs `xcoord`.
 
@@ -2558,15 +2586,19 @@ it might be useful to pass `transform=abs` (to plot the absolute value) or
 If `ax` is passed, the plot will be added to that existing `Axis`, otherwise a new
 `Figure` and `Axis` will be created.
 
+`axis_args` are passed as keyword arguments to `get_1d_ax()`, and from there to the `Axis`
+constructor.
+
 Other `kwargs` are passed to Makie's `lines!()` function.
 
 If `ax` is not passed, returns the `Figure`, otherwise returns the object returned by
 `lines!()`.
 """
 function plot_1d(xcoord, data; ax=nothing, xlabel=nothing, ylabel=nothing, title=nothing,
-                 yscale=nothing, transform=identity, kwargs...)
+                 yscale=nothing, transform=identity, axis_args=Dict{Symbol,Any}(),
+                 kwargs...)
     if ax === nothing
-        fig, ax = get_1d_ax()
+        fig, ax = get_1d_ax(; axis_args...)
     else
         fig = nothing
     end
@@ -2604,7 +2636,8 @@ end
 """
     plot_2d(xcoord, ycoord, data; ax=nothing, colorbar_place=nothing, xlabel=nothing,
             ylabel=nothing, title=nothing, colormap="reverse_deep",
-            colorscale=nothing, transform=identity, kwargs...)
+            colorscale=nothing, transform=identity, axis_args=Dict{Symbol,Any}(),
+            kwargs...)
 
 Make a 2d plot of `data` vs `xcoord` and `ycoord`.
 
@@ -2631,6 +2664,9 @@ When `xcoord` and `ycoord` are both one-dimensional, uses Makie's `heatmap!()` f
 for the plot. If either or both of `xcoord` and `ycoord` are two-dimensional, instead uses
 [`irregular_heatmap!`](@ref).
 
+`axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there to the `Axis`
+constructor.
+
 Other `kwargs` are passed to Makie's `heatmap!()` function.
 
 If `ax` is not passed, returns the `Figure`, otherwise returns the object returned by
@@ -2638,9 +2674,10 @@ If `ax` is not passed, returns the `Figure`, otherwise returns the object return
 """
 function plot_2d(xcoord, ycoord, data; ax=nothing, colorbar_place=nothing, xlabel=nothing,
                  ylabel=nothing, title=nothing, colormap="reverse_deep",
-                 colorscale=nothing, transform=identity, kwargs...)
+                 colorscale=nothing, transform=identity, axis_args=Dict{Symbol,Any}(),
+                 kwargs...)
     if ax === nothing
-        fig, ax, colorbar_place = get_2d_ax()
+        fig, ax, colorbar_place = get_2d_ax(; axis_args...)
     else
         fig = nothing
     end
@@ -2711,7 +2748,8 @@ end
 """
     animate_1d(xcoord, data; frame_index=nothing, ax=nothing, fig=nothing,
                xlabel=nothing, ylabel=nothing, title=nothing, yscale=nothing,
-               transform=identity, outfile=nothing, ylims=nothing, kwargs...)
+               transform=identity, outfile=nothing, ylims=nothing,
+               axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Make a 1d animation of `data` vs `xcoord`.
 
@@ -2738,6 +2776,9 @@ determines the file type. If `ax` is passed at the same time as `outfile` then t
 `Figure` containing `ax` must also be passed (to the `fig` argument) so that the animation
 can be saved.
 
+`axis_args` are passed as keyword arguments to `get_1d_ax()`, and from there to the `Axis`
+constructor.
+
 Other `kwargs` are passed to Makie's `lines!()` function.
 
 If `ax` is not passed, returns the `Figure`, otherwise returns the object returned by
@@ -2745,7 +2786,8 @@ If `ax` is not passed, returns the `Figure`, otherwise returns the object return
 """
 function animate_1d(xcoord, data; frame_index=nothing, ax=nothing, fig=nothing,
                     xlabel=nothing, ylabel=nothing, title=nothing, yscale=nothing,
-                    transform=identity, ylims=nothing, outfile=nothing, kwargs...)
+                    transform=identity, ylims=nothing, outfile=nothing,
+                    axis_args=Dict{Symbol,Any}(), kwargs...)
 
     if frame_index === nothing
         ind = Observable(1)
@@ -2754,7 +2796,8 @@ function animate_1d(xcoord, data; frame_index=nothing, ax=nothing, fig=nothing,
     end
 
     if ax === nothing
-        fig, ax = get_1d_ax(title=title, xlabel=xlabel, ylabel=ylabel, yscale=yscale)
+        fig, ax = get_1d_ax(; title=title, xlabel=xlabel, ylabel=ylabel, yscale=yscale,
+                            axis_args...)
     end
 
     if !isa(data, VariableCache)
@@ -2806,7 +2849,7 @@ end
     animate_2d(xcoord, ycoord, data; frame_index=nothing, ax=nothing, fig=nothing,
                colorbar_place=nothing, xlabel=nothing, ylabel=nothing, title=nothing,
                outfile=nothing, colormap="reverse_deep", colorscale=nothing,
-               transform=identity, kwargs...)
+               transform=identity, axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Make a 2d animation of `data` vs `xcoord` and `ycoord`.
 
@@ -2840,6 +2883,9 @@ When `xcoord` and `ycoord` are both one-dimensional, uses Makie's `heatmap!()` f
 for the plot. If either or both of `xcoord` and `ycoord` are two-dimensional, instead uses
 [`irregular_heatmap!`](@ref).
 
+`axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there to the `Axis`
+constructor.
+
 Other `kwargs` are passed to Makie's `heatmap!()` function.
 
 If `ax` is not passed, returns the `Figure`, otherwise returns the object returned by
@@ -2848,11 +2894,11 @@ If `ax` is not passed, returns the `Figure`, otherwise returns the object return
 function animate_2d(xcoord, ycoord, data; frame_index=nothing, ax=nothing, fig=nothing,
                     colorbar_place=nothing, xlabel=nothing, ylabel=nothing, title=nothing,
                     outfile=nothing, colormap="reverse_deep", colorscale=nothing,
-                    transform=identity, kwargs...)
+                    transform=identity, axis_args=Dict{Symbol,Any}(), kwargs...)
     colormap = parse_colormap(colormap)
 
     if ax === nothing
-        fig, ax, colorbar_place = get_2d_ax(title=title)
+        fig, ax, colorbar_place = get_2d_ax(; title=title, axis_args...)
     end
     if frame_index === nothing
         ind = Observable(1)
@@ -3753,7 +3799,8 @@ end
 """
     plot_f_unnorm_vs_vpa(run_info; input=nothing, neutral=false, it=nothing, is=1,
                          iz=nothing, fig=nothing, ax=nothing, outfile=nothing,
-                         yscale=identity, transform=identity, kwargs...)
+                         yscale=identity, transform=identity,
+                         axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Plot an unnormalized distribution function against \$v_\\parallel\$ at a fixed z.
 
@@ -3790,16 +3837,20 @@ plotted. For example when using a log scale on data that may contain some negati
 it might be useful to pass `transform=abs` (to plot the absolute value) or
 `transform=positive_or_nan` (to ignore any negative or zero values).
 
+`axis_args` are passed as keyword arguments to `get_1d_ax()`, and from there to the `Axis`
+constructor.
+
 Any extra `kwargs` are passed to [`plot_1d`](@ref).
 """
 function plot_f_unnorm_vs_vpa end
 
-function plot_f_unnorm_vs_vpa(run_info::Tuple; neutral=false, outfile=nothing, kwargs...)
+function plot_f_unnorm_vs_vpa(run_info::Tuple; neutral=false, outfile=nothing,
+                              axis_args=Dict{Symbol,Any}(), kwargs...)
     try
         n_runs = length(run_info)
 
         ylabel = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
-        fig, ax = get_1d_ax(xlabel=L"v_\parallel", ylabel=ylabel)
+        fig, ax = get_1d_ax(; xlabel=L"v_\parallel", ylabel=ylabel, axis_args...)
 
         for ri ∈ run_info
             plot_f_unnorm_vs_vpa(ri; neutral=neutral, ax=ax, kwargs...)
@@ -3821,7 +3872,7 @@ end
 
 function plot_f_unnorm_vs_vpa(run_info; input=nothing, neutral=false, it=nothing, is=1,
                               iz=nothing, fig=nothing, ax=nothing, outfile=nothing,
-                              transform=identity, kwargs...)
+                              transform=identity, axis_args=Dict{Symbol,Any}(), kwargs...)
     if input === nothing
         if neutral
             input = Dict_to_NamedTuple(input_dict_dfns["f_neutral"])
@@ -3841,7 +3892,7 @@ function plot_f_unnorm_vs_vpa(run_info; input=nothing, neutral=false, it=nothing
 
     if ax === nothing
         ylabel = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
-        fig, ax = get_1d_ax(xlabel=L"v_\parallel", ylabel=ylabel)
+        fig, ax = get_1d_ax(; xlabel=L"v_\parallel", ylabel=ylabel, axis_args...)
     end
 
     if neutral
@@ -3890,7 +3941,8 @@ end
 """
     plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothing, is=1,
                            fig=nothing, ax=nothing, outfile=nothing, yscale=identity,
-                           transform=identity, rasterize=true, kwargs...)
+                           transform=identity, rasterize=true,
+                           axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Plot unnormalized distribution function against \$v_\\parallel\$ and z.
 
@@ -3931,17 +3983,21 @@ plots as vectorized plots from `mesh!()` have a very large file size. Pass `fals
 plots vectorized. Pass a number to increase the resolution of the rasterized plot by that
 factor.
 
+`axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there to the `Axis`
+constructor.
+
 Any extra `kwargs` are passed to [`plot_2d`](@ref).
 """
 function plot_f_unnorm_vs_vpa_z end
 
 function plot_f_unnorm_vs_vpa_z(run_info::Tuple; neutral=false, outfile=nothing,
-                                kwargs...)
+                                axis_args=Dict{Symbol,Any}(), kwargs...)
     try
         n_runs = length(run_info)
         title = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
         fig, axes, colorbar_places =
-            get_2d_ax(n_runs; title=title, xlabel=L"v_\parallel", ylabel=L"z")
+            get_2d_ax(n_runs; title=title, xlabel=L"v_\parallel", ylabel=L"z",
+                      axis_args...)
 
         for (ri, ax, colorbar_place) ∈ zip(run_info, axes, colorbar_places)
             plot_f_unnorm_vs_vpa_z(ri; neutral=neutral, ax=ax, colorbar_place=colorbar_place,
@@ -3961,7 +4017,7 @@ end
 function plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothing, is=1,
                                 fig=nothing, ax=nothing, colorbar_place=nothing, title=nothing,
                                 outfile=nothing, transform=identity, rasterize=true,
-                                kwargs...)
+                                axis_args=Dict{Symbol,Any}(), kwargs...)
     if input === nothing
         if neutral
             input = Dict_to_NamedTuple(input_dict_dfns["f_neutral"])
@@ -3980,7 +4036,8 @@ function plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothi
         if title === nothing
             title = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
         end
-        fig, ax, colorbar_place = get_2d_ax(title=title, xlabel=L"v_\parallel", ylabel=L"z")
+        fig, ax, colorbar_place = get_2d_ax(; title=title, xlabel=L"v_\parallel",
+                                            ylabel=L"z", axis_args...)
     else
         ax.title = run_info.run_name
     end
@@ -4035,7 +4092,7 @@ end
     animate_f_unnorm_vs_vpa(run_info; input=nothing, neutral=false, is=1, iz=nothing,
                             fig=nothing, ax=nothing, frame_index=nothing,
                             outfile=nothing, yscale=identity, transform=identity,
-                            kwargs...)
+                            axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Plot an unnormalized distribution function against \$v_\\parallel\$ at a fixed z.
 
@@ -4074,12 +4131,16 @@ plotted. For example when using a log scale on data that may contain some negati
 it might be useful to pass `transform=abs` (to plot the absolute value) or
 `transform=positive_or_nan` (to ignore any negative or zero values).
 
+`axis_args` are passed as keyword arguments to `get_1d_ax()`, and from there to the `Axis`
+constructor.
+
 Any extra `kwargs` are passed to [`plot_1d`](@ref) (which is used to create the plot, as
 we have to handle time-varying coordinates so cannot use [`animate_1d`](@ref)).
 """
 function animate_f_unnorm_vs_vpa end
 
-function animate_f_unnorm_vs_vpa(run_info::Tuple; neutral=false, outfile=nothing, kwargs...)
+function animate_f_unnorm_vs_vpa(run_info::Tuple; neutral=false, outfile=nothing,
+                                 axis_args=Dict{Symbol,Any}(), kwargs...)
     try
         n_runs = length(run_info)
 
@@ -4094,7 +4155,8 @@ function animate_f_unnorm_vs_vpa(run_info::Tuple; neutral=false, outfile=nothing
                                               for (irun,ri) ∈ enumerate(run_info)), "; ")),
                          frame_index)
         end
-        fig, ax = get_1d_ax(xlabel=L"v_\parallel", ylabel=ylabel, title=title)
+        fig, ax = get_1d_ax(; xlabel=L"v_\parallel", ylabel=ylabel, title=title,
+                            axis_args...)
 
         for ri ∈ run_info
             animate_f_unnorm_vs_vpa(ri; neutral=neutral, ax=ax, frame_index=frame_index,
@@ -4118,7 +4180,8 @@ end
 
 function animate_f_unnorm_vs_vpa(run_info; input=nothing, neutral=false, is=1, iz=nothing,
                                  fig=nothing, ax=nothing, frame_index=nothing,
-                                 outfile=nothing, transform=identity, kwargs...)
+                                 outfile=nothing, transform=identity,
+                                 axis_args=Dict{Symbol,Any}(), kwargs...)
     if input === nothing
         if neutral
             input = Dict_to_NamedTuple(input_dict_dfns["f_neutral"])
@@ -4137,7 +4200,8 @@ function animate_f_unnorm_vs_vpa(run_info; input=nothing, neutral=false, is=1, i
         frame_index = Observable(1)
         title = lift(i->LaTeXString(string("t = ", run_info.time[i])), frame_index)
         ylabel = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
-        fig, ax = get_1d_ax(xlabel=L"v_\parallel", ylabel=ylabel, title=title)
+        fig, ax = get_1d_ax(; xlabel=L"v_\parallel", ylabel=ylabel, title=title,
+                            axis_args...)
     end
     if frame_index === nothing
         error("Must pass an Observable to `frame_index` when passing `ax`.")
@@ -4213,7 +4277,7 @@ end
     animate_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, is=1,
                               fig=nothing, ax=nothing, frame_index=nothing,
                               outfile=nothing, yscale=identity, transform=identity,
-                              kwargs...)
+                              axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Animate an unnormalized distribution function against \$v_\\parallel\$ and z.
 
@@ -4249,13 +4313,16 @@ plotted. For example when using a log scale on data that may contain some negati
 it might be useful to pass `transform=abs` (to plot the absolute value) or
 `transform=positive_or_nan` (to ignore any negative or zero values).
 
+`axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there to the `Axis`
+constructor.
+
 Any extra `kwargs` are passed to [`plot_2d`](@ref) (which is used to create the plot, as
 we have to handle time-varying coordinates so cannot use [`animate_2d`](@ref)).
 """
 function animate_f_unnorm_vs_vpa_z end
 
 function animate_f_unnorm_vs_vpa_z(run_info::Tuple; neutral=false, outfile=nothing,
-                                   kwargs...)
+                                   axis_args=Dict{Symbol,Any}(), kwargs...)
     try
         n_runs = length(run_info)
 
@@ -4274,7 +4341,8 @@ function animate_f_unnorm_vs_vpa_z(run_info::Tuple; neutral=false, outfile=nothi
             subtitles = nothing
         end
         fig, axes, colorbar_places = get_2d_ax(n_runs; title=title, subtitles=subtitles,
-                                               xlabel=L"v_\parallel", ylabel=L"z")
+                                               xlabel=L"v_\parallel", ylabel=L"z",
+                                               axis_args...)
 
         for (ri, ax, colorbar_place) ∈ zip(run_info, axes, colorbar_places)
             animate_f_unnorm_vs_vpa_z(ri; neutral=neutral, ax=ax,
@@ -4296,7 +4364,8 @@ end
 function animate_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, is=1,
                                    fig=nothing, ax=nothing, colorbar_place=nothing,
                                    frame_index=nothing, outfile=nothing,
-                                   transform=identity, kwargs...)
+                                   transform=identity, axis_args=Dict{Symbol,Any}(),
+                                   kwargs...)
     if input === nothing
         if neutral
             input = Dict_to_NamedTuple(input_dict_dfns["f_neutral"])
@@ -4312,7 +4381,8 @@ function animate_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, is=1,
         var_name = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
         title = lift(i->LaTeXString(string(var_name, "\nt = ", run_info.time[i])),
                      frame_index)
-        fig, ax, colorbar_place = get_2d_ax(title=title, xlabel=L"v_\parallel", ylabel=L"z")
+        fig, ax, colorbar_place = get_2d_ax(; title=title, xlabel=L"v_\parallel",
+                                            ylabel=L"z", axis_args...)
     end
     if frame_index === nothing
         error("Must pass an Observable to `frame_index` when passing `ax`.")

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -1898,9 +1898,10 @@ for (dim1, dim2) ∈ two_dimension_combinations
                  end
 
                  if ax === nothing
-                     fig, ax = get_2d_ax(; title=title)
+                     fig, ax, colorbar_place = get_2d_ax(; title=title)
                      ax_was_nothing = true
                  else
+                     fig = nothing
                      ax_was_nothing = false
                  end
 
@@ -1912,9 +1913,9 @@ for (dim1, dim2) ∈ two_dimension_combinations
                  if $idim1 !== nothing
                      y = y[$idim1]
                  end
-                 fig = plot_2d(x, y, data; ax=ax, xlabel="$($dim2_str)",
-                               ylabel="$($dim1_str)",colorbar_place=colorbar_place,
-                               colormap=colormap, kwargs...)
+                 plot_2d(x, y, data; ax=ax, xlabel="$($dim2_str)",
+                         ylabel="$($dim1_str)", colorbar_place=colorbar_place,
+                         colormap=colormap, kwargs...)
 
                  if input.show_element_boundaries && Symbol($dim2_str) != :t
                      element_boundary_positions = run_info.$dim2.grid[begin:run_info.$dim2.ngrid-1:end]

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -5435,10 +5435,10 @@ function sound_wave_plots(run_info; outfile=nothing, ax=nothing, phi=nothing)
             fit_label = "fit"
         end
 
-        @views lines!(ax, time, abs.(delta_phi[input.iz0,:]), label=delta_phi_label)
+        @views lines!(ax, time, positive_or_nan.(abs.(delta_phi[input.iz0,:]), epsilon=1.e-20), label=delta_phi_label)
 
         if input.calculate_frequency
-            @views lines!(ax, time, abs.(fitted_delta_phi), label=fit_label)
+            @views lines!(ax, time, positive_or_nan.(abs.(fitted_delta_phi), epsilon=1.e-20), label=fit_label)
         end
 
         if outfile !== nothing

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -2460,10 +2460,13 @@ increased in proportion to `n`.
 When `n` is passed, `subtitles` can be passed a Tuple of length `n` which will be used to
 set a subtitle for each `Axis` in `ax`.
 
+`resolution` is passed through to the `Figure` constructor. Its default value is
+`(600, 400)` if `n` is not passed, or `(600*n, 400)` if `n` is passed.
+
 Extra `kwargs` are passed to the `Axis()` constructor.
 """
 function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
-                   get_legend_place=nothing, kwargs...)
+                   get_legend_place=nothing, resolution=(600, 400), kwargs...)
     valid_legend_places = (nothing, :left, :right, :above, :below)
     if get_legend_place ∉ valid_legend_places
         error("get_legend_place=$get_legend_place is not one of $valid_legend_places")
@@ -2472,7 +2475,10 @@ function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
         kwargs = tuple(kwargs..., :yscale=>yscale)
     end
     if n == nothing
-        fig = Figure(resolution=(600, 400))
+        if resolution == nothing
+            resolution = (600, 400)
+        end
+        fig = Figure(resolution=resolution)
         ax = Axis(fig[1,1]; kwargs...)
         if get_legend_place === :left
             legend_place = fig[1,0]
@@ -2488,7 +2494,10 @@ function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
             Label(title_layout[1,1:2], title)
         end
     else
-        fig = Figure(resolution=(600*n, 400))
+        if resolution == nothing
+            resolution = (600*n, 400)
+        end
+        fig = Figure(resolution=resolution)
         plot_layout = fig[1,1] = GridLayout()
 
         if title !== nothing
@@ -2562,11 +2571,18 @@ horizontal row, and the width of the figure is increased in proportion to `n`.
 When `n` is passed, `subtitles` can be passed a Tuple of length `n` which will be used to
 set a subtitle for each `Axis` in `ax`.
 
+`resolution` is passed through to the `Figure` constructor. Its default value is
+`(600, 400)` if `n` is not passed, or `(600*n, 400)` if `n` is passed.
+
 Extra `kwargs` are passed to the `Axis()` constructor.
 """
-function get_2d_ax(n=nothing; title=nothing, subtitles=nothing, kwargs...)
+function get_2d_ax(n=nothing; title=nothing, subtitles=nothing, resolution=nothing,
+                   kwargs...)
     if n == nothing
-        fig = Figure(resolution=(600, 400))
+        if resolution == nothing
+            resolution = (600, 400)
+        end
+        fig = Figure(resolution=resolution)
         if title !== nothing
             title_layout = fig[1,1] = GridLayout()
             Label(title_layout[1,1:2], title)
@@ -2577,7 +2593,10 @@ function get_2d_ax(n=nothing; title=nothing, subtitles=nothing, kwargs...)
         ax = Axis(fig[irow,1]; kwargs...)
         colorbar_place = fig[irow,2]
     else
-        fig = Figure(resolution=(600*n, 400))
+        if resolution == nothing
+            resolution = (600*n, 400)
+        end
+        fig = Figure(resolution=resolution)
 
         if title !== nothing
             title_layout = fig[1,1] = GridLayout()

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -3890,7 +3890,7 @@ end
 """
     plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothing, is=1,
                            fig=nothing, ax=nothing, outfile=nothing, yscale=identity,
-                           transform=identity, kwargs...)
+                           transform=identity, rasterize=true, kwargs...)
 
 Plot unnormalized distribution function against \$v_\\parallel\$ and z.
 
@@ -3926,6 +3926,11 @@ plotted. For example when using a log scale on data that may contain some negati
 it might be useful to pass `transform=abs` (to plot the absolute value) or
 `transform=positive_or_nan` (to ignore any negative or zero values).
 
+`rasterize` is passed through to Makie's `mesh!()` function. The default is to rasterize
+plots as vectorized plots from `mesh!()` have a very large file size. Pass `false` to keep
+plots vectorized. Pass a number to increase the resolution of the rasterized plot by that
+factor.
+
 Any extra `kwargs` are passed to [`plot_2d`](@ref).
 """
 function plot_f_unnorm_vs_vpa_z end
@@ -3954,8 +3959,9 @@ function plot_f_unnorm_vs_vpa_z(run_info::Tuple; neutral=false, outfile=nothing,
 end
 
 function plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothing, is=1,
-                                fig=nothing, ax=nothing, colorbar_place=nothing,
-                                outfile=nothing, transform=identity, kwargs...)
+                                fig=nothing, ax=nothing, colorbar_place=nothing, title=nothing,
+                                outfile=nothing, transform=identity, rasterize=true,
+                                kwargs...)
     if input === nothing
         if neutral
             input = Dict_to_NamedTuple(input_dict_dfns["f_neutral"])
@@ -4005,8 +4011,8 @@ function plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothi
     f_unnorm = transform.(f_unnorm)
 
     # Rasterize the plot, otherwise the output files are very large
-    hm = plot_2d(dzdt, z, f_unnorm; ax=ax, colorbar_place=colorbar_place, rasterize=true,
-                 kwargs...)
+    hm = plot_2d(dzdt, z, f_unnorm; ax=ax, colorbar_place=colorbar_place,
+                 rasterize=rasterize, kwargs...)
 
     if outfile !== nothing
         if fig === nothing

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -325,6 +325,13 @@ function makie_post_process(run_dir::Union{String,Tuple},
     manufactured_solutions_analysis(run_info; plot_prefix=plot_prefix, nvperp=nvperp)
     manufactured_solutions_analysis_dfns(run_info_dfns; plot_prefix=plot_prefix)
 
+    for ri ∈ run_info
+        close_run_info(ri)
+    end
+    for ri ∈ run_info_dfns
+        close_run_info(ri)
+    end
+
     return nothing
 end
 
@@ -875,6 +882,27 @@ function get_run_info(run_dir, restart_index=nothing; itime_min=1, itime_max=0,
                 z_spectral=z_spectral, r_chunk_size=r_chunk_size,
                 z_chunk_size=z_chunk_size, dfns=dfns)
     end
+end
+
+"""
+    close_run_info(run_info)
+
+Close all the files in a run_info NamedTuple.
+"""
+function close_run_info(run_info)
+    if run_info === nothing
+        return nothing
+    end
+    if !run_info.parallel_io
+        # Files are not kept open, so nothing to do
+        return nothing
+    end
+
+    for f ∈ run_info.files
+        close(f)
+    end
+
+    return nothing
 end
 
 """

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -3941,7 +3941,7 @@ end
 """
     plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothing, is=1,
                            fig=nothing, ax=nothing, outfile=nothing, yscale=identity,
-                           transform=identity, rasterize=true,
+                           transform=identity, rasterize=true, subtitles=nothing,
                            axis_args=Dict{Symbol,Any}(), kwargs...)
 
 Plot unnormalized distribution function against \$v_\\parallel\$ and z.
@@ -3983,6 +3983,9 @@ plots as vectorized plots from `mesh!()` have a very large file size. Pass `fals
 plots vectorized. Pass a number to increase the resolution of the rasterized plot by that
 factor.
 
+When `run_info` is a Tuple, `subtitles` can be passed a Tuple (with the same length as
+`run_info`) to set the subtitle for each subplot.
+
 `axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there to the `Axis`
 constructor.
 
@@ -3991,17 +3994,23 @@ Any extra `kwargs` are passed to [`plot_2d`](@ref).
 function plot_f_unnorm_vs_vpa_z end
 
 function plot_f_unnorm_vs_vpa_z(run_info::Tuple; neutral=false, outfile=nothing,
-                                axis_args=Dict{Symbol,Any}(), kwargs...)
+                                axis_args=Dict{Symbol,Any}(), title=nothing,
+                                subtitles=nothing, kwargs...)
     try
         n_runs = length(run_info)
-        title = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
+        if subtitles === nothing
+            subtitles = Tuple(nothing for _ ∈ 1:n_runs)
+        end
+        if title !== nothing
+            title = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
+        end
         fig, axes, colorbar_places =
             get_2d_ax(n_runs; title=title, xlabel=L"v_\parallel", ylabel=L"z",
                       axis_args...)
 
-        for (ri, ax, colorbar_place) ∈ zip(run_info, axes, colorbar_places)
+        for (ri, ax, colorbar_place, st) ∈ zip(run_info, axes, colorbar_places, subtitles)
             plot_f_unnorm_vs_vpa_z(ri; neutral=neutral, ax=ax, colorbar_place=colorbar_place,
-                                   kwargs...)
+                                   title=st, kwargs...)
         end
 
         if outfile !== nothing
@@ -4039,7 +4048,11 @@ function plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothi
         fig, ax, colorbar_place = get_2d_ax(; title=title, xlabel=L"v_\parallel",
                                             ylabel=L"z", axis_args...)
     else
-        ax.title = run_info.run_name
+        if title === nothing
+            ax.title = run_info.run_name
+        else
+            ax.title = title
+        end
     end
 
     if neutral

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -4110,7 +4110,13 @@ function plot_f_unnorm_vs_vpa(run_info; f_over_vpa2=false, input=nothing, neutra
                                                 run_info.evolve_ppar)
 
     if f_over_vpa2
-        @. f_unnorm /= dzdt^2
+        dzdt2 = dzdt.^2
+        for i ∈ eachindex(dzdt2)
+            if dzdt2[i] == 0.0
+                dzdt2[i] = 1.0
+            end
+        end
+        f_unnorm ./= dzdt2
     end
 
     f_unnorm = transform.(f_unnorm)
@@ -4443,7 +4449,14 @@ function animate_f_unnorm_vs_vpa(run_info; f_over_vpa2=false, input=nothing,
         if f_over_vpa2
             dzdt = vpagrid_to_dzdt(run_info.vpa.grid, vth[it], upar[it],
                                    run_info.evolve_ppar, run_info.evolve_upar)
-            f_unnorm = @. copy(f_unnorm) / dzdt^2
+            dzdt2 = dzdt.^2
+            for i ∈ eachindex(dzdt2)
+                if dzdt2[i] == 0.0
+                    dzdt2[i] = 1.0
+                end
+            end
+
+            f_unnorm = @. copy(f_unnorm) / dzdt2
         end
 
         return f_unnorm

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -903,6 +903,7 @@ function postproc_load_variable(run_info, variable_name; it=nothing, is=nothing,
         it = run_info.itime_min:run_info.itime_skip:run_info.itime_max
     elseif isa(it, mk_int)
         nt = 1
+        it = collect(run_info.itime_min:run_info.itime_skip:run_info.itime_max)[it]
     else
         nt = length(it)
     end
@@ -1707,6 +1708,7 @@ for dim ∈ one_dimension_combinations
                  end
                  if data === nothing
                      dim_slices = get_dimension_slice_indices($(QuoteNode(dim));
+                                                              run_info=run_info,
                                                               input=input, it=it, is=is,
                                                               ir=ir, iz=iz, ivperp=ivperp,
                                                               ivpa=ivpa, ivzeta=ivzeta,
@@ -1874,6 +1876,7 @@ for (dim1, dim2) ∈ two_dimension_combinations
                  if data === nothing
                      dim_slices = get_dimension_slice_indices($(QuoteNode(dim1)),
                                                               $(QuoteNode(dim2));
+                                                              run_info=run_info,
                                                               input=input, it=it, is=is,
                                                               ir=ir, iz=iz, ivperp=ivperp,
                                                               ivpa=ivpa, ivzeta=ivzeta,
@@ -2091,6 +2094,7 @@ for dim ∈ one_dimension_combinations_no_t
                  end
                  if data === nothing
                      dim_slices = get_dimension_slice_indices(:t, $(QuoteNode(dim));
+                                                              run_info=run_info,
                                                               input=input, it=it, is=is,
                                                               ir=ir, iz=iz, ivperp=ivperp,
                                                               ivpa=ivpa, ivzeta=ivzeta,
@@ -2297,6 +2301,7 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                  if data === nothing
                      dim_slices = get_dimension_slice_indices(:t, $(QuoteNode(dim1)),
                                                               $(QuoteNode(dim2));
+                                                              run_info=run_info,
                                                               input=input, it=it, is=is,
                                                               ir=ir, iz=iz, ivperp=ivperp,
                                                               ivpa=ivpa, ivzeta=ivzeta,
@@ -3459,9 +3464,10 @@ The indices are taken from `input`, unless they are passed as keyword arguments
 The dimensions in `keep_dims` are not given a slice (those are the dimensions we want in
 the variable after slicing).
 """
-function get_dimension_slice_indices(keep_dims...; input, it=nothing, is=nothing,
-                                     ir=nothing, iz=nothing, ivperp=nothing, ivpa=nothing,
-                                     ivzeta=nothing, ivr=nothing, ivz=nothing)
+function get_dimension_slice_indices(keep_dims...; run_info, input, it=nothing,
+                                     is=nothing, ir=nothing, iz=nothing, ivperp=nothing,
+                                     ivpa=nothing, ivzeta=nothing, ivr=nothing,
+                                     ivz=nothing)
     if isa(input, AbstractDict)
         input = Dict_to_NamedTuple(input)
     end

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -11,8 +11,11 @@ julia --project run_makie_post_processing.jl dir1 [dir2 [dir3 ...]]
 module makie_post_processing
 
 export makie_post_process, generate_example_input_file, get_variable,
-       setup_makie_post_processing_input!, get_run_info, irregular_heatmap,
-       irregular_heatmap!, postproc_load_variable, positive_or_nan
+       setup_makie_post_processing_input!, get_run_info
+export animate_f_unnorm_vs_vpa, animate_f_unnorm_vs_vpa_z, get_1d_ax, get_2d_ax,
+       irregular_heatmap, irregular_heatmap!, plot_f_unnorm_vs_vpa,
+       plot_f_unnorm_vs_vpa_z, positive_or_nan, postproc_load_variable, positive_or_nan,
+       put_legend_above, put_legend_below, put_legend_left, put_legend_right
 
 using ..analysis: analyze_fields_data, check_Chodura_condition, get_r_perturbation,
                   get_Fourier_modes_2D, get_Fourier_modes_1D, steady_state_residuals,

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -2032,7 +2032,7 @@ for dim ∈ one_dimension_combinations_no_t
                      frame_index = Observable(1)
                      if length(run_info) == 1 ||
                          all(ri.nt == run_info[1].nt &&
-                             wall(isapprox.(ri.time, run_info[1].time))
+                             all(isapprox.(ri.time, run_info[1].time))
                              for ri ∈ run_info[2:end])
                          # All times are the same
                          title = lift(i->string("t = ", run_info[1].time[i]), frame_index)

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -3977,7 +3977,9 @@ function plot_f_unnorm_vs_vpa_z(run_info; input=nothing, neutral=false, it=nothi
     end
 
     if ax === nothing
-        title = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
+        if title === nothing
+            title = neutral ? L"f_{n,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
+        end
         fig, ax, colorbar_place = get_2d_ax(title=title, xlabel=L"v_\parallel", ylabel=L"z")
     else
         ax.title = run_info.run_name

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -4091,7 +4091,7 @@ function animate_f_unnorm_vs_vpa(run_info::Tuple; neutral=false, outfile=nothing
             title = lift(i->LaTeXString(string("t = ", run_info[1].time[i])), frame_index)
         else
             title = lift(i->LaTeXString(join((string("t", irun, " = ", ri.time[i])
-                                              for (irun,t) ∈ enumerate(run_info)), "; ")),
+                                              for (irun,ri) ∈ enumerate(run_info)), "; ")),
                          frame_index)
         end
         fig, ax = get_1d_ax(xlabel=L"v_\parallel", ylabel=ylabel, title=title)

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -2339,7 +2339,7 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
 
              function $function_name(run_info, var_name; is=1, data=nothing,
                                      input=nothing, frame_index=nothing, ax=nothing,
-                                     fig=nothing, colorbar_place=colorbar_place,
+                                     fig=nothing, colorbar_place=nothing,
                                      title=nothing, outfile=nothing,
                                      axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing,
                                      iz=nothing, ivperp=nothing, ivpa=nothing,
@@ -2353,6 +2353,11 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                  end
                  if isa(input, AbstractDict)
                      input = Dict_to_NamedTuple(input)
+                 end
+                 if frame_index === nothing
+                     ind = Observable(1)
+                 else
+                     ind = frame_index
                  end
                  if data === nothing
                      dim_slices = get_dimension_slice_indices(:t, $(QuoteNode(dim1)),
@@ -2378,11 +2383,11 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                  if title === nothing && ax == nothing
                      title = lift(i->string(get_variable_symbol(var_name), "\nt = ",
                                             run_info.time[i]),
-                                  frame_index)
+                                  ind)
                  end
 
                  if ax === nothing
-                     fig, ax = get_2d_ax(; title=title, axis_args...)
+                     fig, ax, colorbar_place = get_2d_ax(; title=title, axis_args...)
                      ax_was_nothing = true
                  else
                      ax_was_nothing = false
@@ -2396,10 +2401,10 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                  if $idim1 !== nothing
                      y = y[$idim1]
                  end
-                 fig = animate_2d(x, y, data; xlabel="$($dim2_str)",
-                                  ylabel="$($dim1_str)", frame_index=frame_index, ax=ax,
-                                  colorbar_place=colorbar_place, colormap=colormap,
-                                  kwargs...)
+                 anim = animate_2d(x, y, data; xlabel="$($dim2_str)",
+                                   ylabel="$($dim1_str)", frame_index=ind, ax=ax,
+                                   colorbar_place=colorbar_place, colormap=colormap,
+                                   kwargs...)
 
                  if input.show_element_boundaries
                      element_boundary_positions = run_info.$dim2.grid[begin:run_info.$dim2.ngrid-1:end]
@@ -2414,14 +2419,14 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                      if outfile === nothing
                          error("`outfile` is required for $($function_name_str)")
                      end
-                     if fig === nothing
+                     if ax_was_nothing && fig === nothing
                          error("When `outfile` is passed to save the plot, must either pass both "
                                * "`fig` and `ax` or neither. Only `ax` was passed.")
                      end
                      if isa(data, VariableCache)
                          nt = data.n_tinds
                      else
-                         nt = size(data, 2)
+                         nt = size(data, 3)
                      end
                      save_animation(fig, ind, nt, outfile)
                  end

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -1556,7 +1556,7 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, is_1D=fals
                 if moment_kinetic && input[Symbol(:plot, log, :_unnorm_vs_vz_z)]
                     outfile = var_prefix * "unnorm_vs_vz_z.pdf"
                     plot_f_unnorm_vs_vpa_z(run_info; input=input, neutral=true, is=is,
-                                           outfile=outfile, yscale=yscale,
+                                           outfile=outfile, colorscale=yscale,
                                            transform=transform)
                 end
                 if moment_kinetic && input[Symbol(:animate, log, :_unnorm_vs_vz)]
@@ -1580,7 +1580,7 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, is_1D=fals
                 if moment_kinetic && input[Symbol(:plot, log, :_unnorm_vs_vpa_z)]
                     outfile = var_prefix * "unnorm_vs_vpa_z.pdf"
                     plot_f_unnorm_vs_vpa_z(run_info; input=input, is=is, outfile=outfile,
-                                           yscale=yscale, transform=transform)
+                                           colorscale=yscale, transform=transform)
                 end
                 if moment_kinetic && input[Symbol(:animate, log, :_unnorm_vs_vpa)]
                     outfile = var_prefix * "unnorm_vs_vpa." * input.animation_ext

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -1680,7 +1680,7 @@ for dim ∈ one_dimension_combinations
              function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, yscale=nothing,
                                      transform=identity, axis_args=Dict{Symbol,Any}(),
-                                     kwargs...)
+                                     $idim=nothing, kwargs...)
 
                  try
                      if data === nothing
@@ -1698,14 +1698,18 @@ for dim ∈ one_dimension_combinations
                                          yscale=yscale, axis_args...)
                      for (d, ri) ∈ zip(data, run_info)
                          $function_name(ri, var_name, is=is, data=d, input=input, ax=ax,
-                                        transform=transform, label=ri.run_name, kwargs...)
+                                        transform=transform, label=ri.run_name,
+                                        $idim=$idim, kwargs...)
                      end
 
                      if input.show_element_boundaries && Symbol($dim_str) != :t
                          # Just plot element boundaries from first run, assuming that all
                          # runs being compared use the same grid.
                          ri = run_info[1]
-                         element_boundary_positions = ri.$dim.grid[begin:ri.$dim.ngrid-1:end]
+                         element_boundary_inds =
+                             [i for i ∈ 1:ri.$dim.ngrid-1:ri.$dim.n_global
+                                if $idim === nothing || i ∈ $idim]
+                         element_boundary_positions = ri.$dim.grid[element_boundary_inds]
                          vlines!(ax, element_boundary_positions, color=:black, alpha=0.3)
                      end
 
@@ -1770,7 +1774,10 @@ for dim ∈ one_dimension_combinations
                  plot_1d(x, data; label=label, ax=ax, kwargs...)
 
                  if input.show_element_boundaries && Symbol($dim_str) != :t && ax_was_nothing
-                     element_boundary_positions = run_info.$dim.grid[begin:run_info.$dim.ngrid-1:end]
+                     element_boundary_inds =
+                         [i for i ∈ 1:run_info.$dim.ngrid-1:run_info.$dim.n_global
+                            if $idim === nothing || i ∈ $idim]
+                     element_boundary_positions = run_info.$dim.grid[element_boundary_inds]
                      vlines!(ax, element_boundary_positions, color=:black, alpha=0.3)
                  end
 
@@ -1959,11 +1966,17 @@ for (dim1, dim2) ∈ two_dimension_combinations
                          colormap=colormap, kwargs...)
 
                  if input.show_element_boundaries && Symbol($dim2_str) != :t
-                     element_boundary_positions = run_info.$dim2.grid[begin:run_info.$dim2.ngrid-1:end]
+                     element_boundary_inds =
+                         [i for i ∈ 1:run_info.$dim2.ngrid-1:run_info.$dim2.n_global
+                            if $idim2 === nothing || i ∈ $idim2]
+                     element_boundary_positions = run_info.$dim2.grid[element_boundary_inds]
                      vlines!(ax, element_boundary_positions, color=:white, alpha=0.5)
                  end
                  if input.show_element_boundaries && Symbol($dim1_str) != :t
-                     element_boundary_positions = run_info.$dim1.grid[begin:run_info.$dim1.ngrid-1:end]
+                     element_boundary_inds =
+                         [i for i ∈ 1:run_info.$dim1.ngrid-1:run_info.$dim1.n_global
+                            if $idim1 === nothing || i ∈ $idim1]
+                     element_boundary_positions = run_info.$dim1.grid[element_boundary_inds]
                      hlines!(ax, element_boundary_positions, color=:white, alpha=0.5)
                  end
 
@@ -2060,7 +2073,7 @@ for dim ∈ one_dimension_combinations_no_t
              function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, yscale=nothing,
                                      ylims=nothing, axis_args=Dict{Symbol,Any}(),
-                                     it=nothing, kwargs...)
+                                     it=nothing, $idim=nothing, kwargs...)
 
                  try
                      if data === nothing
@@ -2095,14 +2108,17 @@ for dim ∈ one_dimension_combinations_no_t
                      for (d, ri) ∈ zip(data, run_info)
                          $function_name(ri, var_name; is=is, data=d, input=input,
                                         ylims=ylims, frame_index=frame_index, ax=ax,
-                                        it=it, kwargs...)
+                                        it=it, $idim=$idim, kwargs...)
                      end
 
                      if input.show_element_boundaries
                          # Just plot element boundaries from first run, assuming that all
                          # runs being compared use the same grid.
                          ri = run_info[1]
-                         element_boundary_positions = ri.$dim.grid[begin:ri.$dim.ngrid-1:end]
+                         element_boundary_inds =
+                             [i for i ∈ 1:ri.$dim.ngrid-1:ri.$dim.n_global
+                                if $idim === nothing || i ∈ $idim]
+                         element_boundary_positions = ri.$dim.grid[element_boundary_inds]
                          vlines!(ax, element_boundary_positions, color=:black, alpha=0.3)
                      end
 
@@ -2177,7 +2193,10 @@ for dim ∈ one_dimension_combinations_no_t
                             label=run_info.run_name, kwargs...)
 
                  if input.show_element_boundaries && fig !== nothing
-                     element_boundary_positions = run_info.$dim.grid[begin:run_info.$dim.ngrid-1:end]
+                     element_boundary_inds =
+                         [i for i ∈ 1:run_info.$dim.ngrid-1:run_info.$dim.n_global
+                            if $idim === nothing || i ∈ $idim]
+                     element_boundary_positions = run_info.$dim.grid[element_boundary_inds]
                      vlines!(ax, element_boundary_positions, color=:black, alpha=0.3)
                  end
 
@@ -2407,11 +2426,17 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
                                    kwargs...)
 
                  if input.show_element_boundaries
-                     element_boundary_positions = run_info.$dim2.grid[begin:run_info.$dim2.ngrid-1:end]
+                     element_boundary_inds =
+                         [i for i ∈ 1:run_info.$dim2.ngrid-1:run_info.$dim2.n_global
+                            if $idim2 === nothing || i ∈ $idim2]
+                     element_boundary_positions = run_info.$dim2.grid[element_boundary_inds]
                      vlines!(ax, element_boundary_positions, color=:white, alpha=0.5)
                  end
                  if input.show_element_boundaries
-                     element_boundary_positions = run_info.$dim1.grid[begin:run_info.$dim1.ngrid-1:end]
+                     element_boundary_inds =
+                         [i for i ∈ 1:run_info.$dim1.ngrid-1:run_info.$dim1.n_global
+                            if $idim1 === nothing || i ∈ $idim1]
+                     element_boundary_positions = run_info.$dim1.grid[element_boundary_inds]
                      hlines!(ax, element_boundary_positions, color=:white, alpha=0.5)
                  end
 

--- a/src/moment_kinetics.jl
+++ b/src/moment_kinetics.jl
@@ -256,7 +256,7 @@ reload data from time index given by `restart_time_index` for a restart.
 `debug_loop_type` and `debug_loop_parallel_dims` are used to force specific set ups for
 parallel loop ranges, and are only used by the tests in `debug_test/`.
 """
-function setup_moment_kinetics(input_dict::Dict;
+function setup_moment_kinetics(input_dict::AbstractDict;
         restart::Union{Bool,AbstractString}=false, restart_time_index::mk_int=-1,
         debug_loop_type::Union{Nothing,NTuple{N,Symbol} where N}=nothing,
         debug_loop_parallel_dims::Union{Nothing,NTuple{N,Symbol} where N}=nothing)

--- a/test/restart_interpolation_tests.jl
+++ b/test/restart_interpolation_tests.jl
@@ -139,7 +139,7 @@ function run_test(test_input, message, rtol, atol; tol_3V, kwargs...)
             # Read the output data
             path = joinpath(realpath(input["base_directory"]), name)
 
-            run_info = get_run_info(path, -1; dfns=true)
+            run_info = get_run_info((path, -1); dfns=true)
             time = run_info.time
             n_ion_species = run_info.n_ion_species
             n_neutral_species = run_info.n_neutral_species


### PR DESCRIPTION
Collection of small fixes and enhancements for Makie-based post processing module.

Several enhancements make interactive use of the module in the Julia REPL better.

Also:
* Plot checks of constraints on normalised distribution function for moment-kinetic runs (i.e. numerically calculate first 3 moments)
* Add a plot of f/vpa^2 to the 'wall plots'
* Allow the sound speed and Mach number to be calculated/plotted/animated (currently using `c_s = sqrt((T_e + gamma*T_i)/m_i)`, with `gamma = 3` which is the value for purely 1D1V flow