### PR TITLE
Update the 'checkout' action in CI jobs to version 4

### DIFF
--- a/.github/workflows/debug_checks.yml
+++ b/.github/workflows/debug_checks.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 240
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: 'openmpi'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.8'

--- a/.github/workflows/documentation_cleanup.yml
+++ b/.github/workflows/documentation_cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
       - name: Delete preview and history + push changes

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 35
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: 'openmpi'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 50
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'


### PR DESCRIPTION
Resolves deprecation warning about version 2.