### PR TITLE
Fix 'longtest' CI job

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -36,5 +36,5 @@ jobs:
         #
       - run: |
           pip3 install --user matplotlib
-          julia --check-bounds=yes --color=yes --depwarn=yes --inline=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = :true, test_args=["--long"])'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project=@. -e 'import Pkg; Pkg.test(; test_args=["--long"])'
         shell: bash

--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -11,7 +11,7 @@ julia --project run_makie_post_processing.jl dir1 [dir2 [dir3 ...]]
 module makie_post_processing
 
 export makie_post_process, generate_example_input_file, get_variable,
-       setup_makie_post_processing_input!, get_run_info
+       setup_makie_post_processing_input!, get_run_info, close_run_info
 export animate_f_unnorm_vs_vpa, animate_f_unnorm_vs_vpa_z, get_1d_ax, get_2d_ax,
        irregular_heatmap, irregular_heatmap!, plot_f_unnorm_vs_vpa,
        plot_f_unnorm_vs_vpa_z, positive_or_nan, postproc_load_variable, positive_or_nan,

--- a/test/restart_interpolation_tests.jl
+++ b/test/restart_interpolation_tests.jl
@@ -16,7 +16,8 @@ using moment_kinetics.load_data: open_readonly_output_file, load_coordinate_data
                                  load_neutral_particle_moments_data,
                                  load_neutral_pdf_data, load_time_data, load_species_data
 using moment_kinetics.interpolation: interpolate_to_grid_z, interpolate_to_grid_vpa
-using moment_kinetics.makie_post_processing: get_run_info, postproc_load_variable
+using moment_kinetics.makie_post_processing: get_run_info, close_run_info,
+                                             postproc_load_variable
 using moment_kinetics.type_definitions: mk_float
 
 include("nonlinear_sound_wave_inputs_and_expected_data.jl")
@@ -164,6 +165,8 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, kwargs...)
             vr_spectral = run_info.vr_spectral
             vz = run_info.vz
             vz_spectral = run_info.vz_spectral
+
+            close_run_info(run_info)
 
             # Delete output because output files for 3V tests can be large
             rm(joinpath(realpath(input["base_directory"]), name); recursive=true)

--- a/test/restart_interpolation_tests.jl
+++ b/test/restart_interpolation_tests.jl
@@ -137,6 +137,16 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, kwargs...)
             path = joinpath(realpath(input["base_directory"]), name)
 
             run_info = get_run_info((path, -1); dfns=true)
+            z = run_info.z
+            z_spectral = run_info.z_spectral
+            vpa = run_info.vpa
+            vpa_spectral = run_info.vpa_spectral
+            vzeta = run_info.vzeta
+            vzeta_spectral = run_info.vzeta_spectral
+            vr = run_info.vr
+            vr_spectral = run_info.vr_spectral
+            vz = run_info.vz
+            vz_spectral = run_info.vz_spectral
             time = run_info.time
             n_ion_species = run_info.n_ion_species
             n_neutral_species = run_info.n_neutral_species
@@ -151,20 +161,14 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, kwargs...)
             ppar_neutral_zrst = postproc_load_variable(run_info, "pz_neutral")
             qpar_neutral_zrst = postproc_load_variable(run_info, "qz_neutral")
             v_t_neutral_zrst = postproc_load_variable(run_info, "thermal_speed_neutral")
-            f_neutral_vzvrvzetazrst   = postproc_load_variable(run_info, "f_neutral")
+            # Slice f_neutral while loading to save memory, and avoid termination of the
+            # 'long tests' CI job.
+            f_neutral_vzvrvzetazrst = postproc_load_variable(run_info, "f_neutral",
+                                                             ivzeta=(vzeta.n+1)÷2,
+                                                             ivr=(vr.n+1)÷2)
             phi_zrt = postproc_load_variable(run_info, "phi")
             Er_zrt = postproc_load_variable(run_info, "Er")
             Ez_zrt = postproc_load_variable(run_info, "Ez")
-            z = run_info.z
-            z_spectral = run_info.z_spectral
-            vpa = run_info.vpa
-            vpa_spectral = run_info.vpa_spectral
-            vzeta = run_info.vzeta
-            vzeta_spectral = run_info.vzeta_spectral
-            vr = run_info.vr
-            vr_spectral = run_info.vr_spectral
-            vz = run_info.vz
-            vz_spectral = run_info.vz_spectral
 
             close_run_info(run_info)
 
@@ -183,7 +187,7 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, kwargs...)
             ppar_neutral = ppar_neutral_zrst[:,1,:,:]
             qpar_neutral = qpar_neutral_zrst[:,1,:,:]
             v_t_neutral = v_t_neutral_zrst[:,1,:,:]
-            f_neutral = f_neutral_vzvrvzetazrst[:,(vr.n+1)÷2,(vzeta.n+1)÷2,:,1,:,:]
+            f_neutral = f_neutral_vzvrvzetazrst[:,:,1,:,:]
 
             # Unnormalize f
             if input["evolve_moments_density"]


### PR DESCRIPTION
The 'longtest' job only runs when a PR is merged to `master`, so we didn't see the failure before merging #150.

Best guess is the failure was caused by an out-of-memory error on the Ubuntu runner - although I don't understand why that happened for the 'longtest' job which runs in serial but not for the 'parallel tests' job which does run all the 'long tests' in one of its calls!
Anyway, re-jigging to avoid loading a full 2D3V neutral distribution function into memory seems to fix the problem.