### PR TITLE
Replace deprecated `resolution` kwarg with `size` for Makie calls

### DIFF
--- a/src/makie_post_processing.jl
+++ b/src/makie_post_processing.jl
@@ -2674,7 +2674,7 @@ end
 
 """
     get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
-              get_legend_place=nothing, kwargs...)
+              get_legend_place=nothing, size=nothing, kwargs...)
 
 Create a new `Figure` `fig` and `Axis` `ax` intended for 1d plots.
 
@@ -2696,13 +2696,13 @@ increased in proportion to `n`.
 When `n` is passed, `subtitles` can be passed a Tuple of length `n` which will be used to
 set a subtitle for each `Axis` in `ax`.
 
-`resolution` is passed through to the `Figure` constructor. Its default value is
-`(600, 400)` if `n` is not passed, or `(600*n, 400)` if `n` is passed.
+`size` is passed through to the `Figure` constructor. Its default value is `(600, 400)` if
+`n` is not passed, or `(600*n, 400)` if `n` is passed.
 
 Extra `kwargs` are passed to the `Axis()` constructor.
 """
 function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
-                   get_legend_place=nothing, resolution=(600, 400), kwargs...)
+                   get_legend_place=nothing, size=nothing, kwargs...)
     valid_legend_places = (nothing, :left, :right, :above, :below)
     if get_legend_place ∉ valid_legend_places
         error("get_legend_place=$get_legend_place is not one of $valid_legend_places")
@@ -2711,10 +2711,10 @@ function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
         kwargs = tuple(kwargs..., :yscale=>yscale)
     end
     if n == nothing
-        if resolution == nothing
-            resolution = (600, 400)
+        if size == nothing
+            size = (600, 400)
         end
-        fig = Figure(resolution=resolution)
+        fig = Figure(size=size)
         ax = Axis(fig[1,1]; kwargs...)
         if get_legend_place === :left
             legend_place = fig[1,0]
@@ -2730,10 +2730,10 @@ function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
             Label(title_layout[1,1:2], title)
         end
     else
-        if resolution == nothing
-            resolution = (600*n, 400)
+        if size == nothing
+            size = (600*n, 400)
         end
-        fig = Figure(resolution=resolution)
+        fig = Figure(size=size)
         plot_layout = fig[1,1] = GridLayout()
 
         if title !== nothing
@@ -2791,7 +2791,7 @@ function get_1d_ax(n=nothing; title=nothing, subtitles=nothing, yscale=nothing,
 end
 
 """
-    get_2d_ax(n=nothing; title=nothing, subtitles=nothing, kwargs...)
+    get_2d_ax(n=nothing; title=nothing, subtitles=nothing, size=nothing, kwargs...)
 
 Create a new `Figure` `fig` and `Axis` `ax` intended for 2d plots.
 
@@ -2807,18 +2807,17 @@ horizontal row, and the width of the figure is increased in proportion to `n`.
 When `n` is passed, `subtitles` can be passed a Tuple of length `n` which will be used to
 set a subtitle for each `Axis` in `ax`.
 
-`resolution` is passed through to the `Figure` constructor. Its default value is
-`(600, 400)` if `n` is not passed, or `(600*n, 400)` if `n` is passed.
+`size` is passed through to the `Figure` constructor. Its default value is `(600, 400)` if
+`n` is not passed, or `(600*n, 400)` if `n` is passed.
 
 Extra `kwargs` are passed to the `Axis()` constructor.
 """
-function get_2d_ax(n=nothing; title=nothing, subtitles=nothing, resolution=nothing,
-                   kwargs...)
+function get_2d_ax(n=nothing; title=nothing, subtitles=nothing, size=nothing, kwargs...)
     if n == nothing
-        if resolution == nothing
-            resolution = (600, 400)
+        if size == nothing
+            size = (600, 400)
         end
-        fig = Figure(resolution=resolution)
+        fig = Figure(size=size)
         if title !== nothing
             title_layout = fig[1,1] = GridLayout()
             Label(title_layout[1,1:2], title)
@@ -2829,10 +2828,10 @@ function get_2d_ax(n=nothing; title=nothing, subtitles=nothing, resolution=nothi
         ax = Axis(fig[irow,1]; kwargs...)
         colorbar_place = fig[irow,2]
     else
-        if resolution == nothing
-            resolution = (600*n, 400)
+        if size == nothing
+            size = (600*n, 400)
         end
-        fig = Figure(resolution=resolution)
+        fig = Figure(size=size)
 
         if title !== nothing
             title_layout = fig[1,1] = GridLayout()


### PR DESCRIPTION
...also fix a bug in the default value for `size` in the `get_1d_ax()` function.