### PR TITLE
Precompile on rank-0 first in run_moment_kinetics.jl

### DIFF
--- a/run_moment_kinetics.jl
+++ b/run_moment_kinetics.jl
@@ -2,6 +2,19 @@
 using Pkg
 Pkg.activate(".")
 
-using moment_kinetics
+using MPI
+MPI.Init()
+is_rank0 = (MPI.Comm_rank(MPI.COMM_WORLD) == 0)
+
+# Use MPI Barriers to ensure `using moment_kinetics` is completed on rank-0 (in order to
+# complete precompilation of moment_kinetics and dependencies) before being run on all the
+# other MPI ranks.
+if is_rank0
+    using moment_kinetics
+    MPI.Barrier(MPI.COMM_WORLD)
+else
+    MPI.Barrier(MPI.COMM_WORLD)
+    using moment_kinetics
+end
 
 run_moment_kinetics()


### PR DESCRIPTION
When running from the command line using the `run_moment_kinetics.jl` script, call `using moment_kinetics` first on rank-0, and only after that has completed call it on all other ranks. Hopefully this avoids precompilation clashes (when multiple MPI ranks try to precompile the same package simultaneously) which might corrupt files. It does not solve the clash issue for importing MPI, because `using MPI` is needed to get the MPI commands to synchronize between rank-0 and the other processes, but hopefully minimises the chance of problems.