### PR TITLE
Optimise `@debug_shared_array`

### DIFF
--- a/debug_test/restart_interpolation_inputs.jl
+++ b/debug_test/restart_interpolation_inputs.jl
@@ -64,11 +64,10 @@ base_input = Dict(
 
 test_input =
     merge(base_input,
-          Dict("run_name" => "split1",
+          Dict("run_name" => "full-f",
                "z_nelement" => 3,
                "vpa_nelement" => 3,
-               "vz_nelement" => 3,
-               "evolve_moments_density" => true))
+               "vz_nelement" => 3))
 
 test_input_split1 =
     merge(test_input,


### PR DESCRIPTION
Add a Bool flag that records whether an array has been accessed at all. If it has not been (on any process in a shared-memory block), can skip the rest of the checks. This significantly speeds up the debug checks.