### PR TITLE
Fix examples introduced in #147

### DIFF
--- a/examples/wall-bc/wall-bc_volumerecycle.toml
+++ b/examples/wall-bc/wall-bc_volumerecycle.toml
@@ -82,7 +82,7 @@ source_T = 2.0
 
 [neutral_source]
 active = true
-controller_type = "recycling"
+source_type = "recycling"
 recycling_controller_fraction = 0.25
 
 [numerical_dissipation]

--- a/examples/wall-bc/wall-bc_volumerecycle_split1.toml
+++ b/examples/wall-bc/wall-bc_volumerecycle_split1.toml
@@ -82,7 +82,7 @@ source_T = 2.0
 
 [neutral_source]
 active = true
-controller_type = "recycling"
+source_type = "recycling"
 recycling_controller_fraction = 0.25
 
 [numerical_dissipation]

--- a/examples/wall-bc/wall-bc_volumerecycle_split2.toml
+++ b/examples/wall-bc/wall-bc_volumerecycle_split2.toml
@@ -82,7 +82,7 @@ source_T = 2.0
 
 [neutral_source]
 active = true
-controller_type = "recycling"
+source_type = "recycling"
 recycling_controller_fraction = 0.25
 
 [numerical_dissipation]

--- a/examples/wall-bc/wall-bc_volumerecycle_split3.toml
+++ b/examples/wall-bc/wall-bc_volumerecycle_split3.toml
@@ -82,7 +82,7 @@ source_T = 2.0
 
 [neutral_source]
 active = true
-controller_type = "recycling"
+source_type = "recycling"
 recycling_controller_fraction = 0.25
 
 [numerical_dissipation]

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -1233,17 +1233,17 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
                                       parallel_io, z, r)
                 if moments.evolve_density
                     append_to_dynamic_var(io_moments.external_source_neutral_density_amplitude,
-                                          moments.charged.external_source_neutral_density_amplitude,
+                                          moments.neutral.external_source_density_amplitude,
                                           t_idx, parallel_io, z, r)
                 end
                 if moments.evolve_upar
                     append_to_dynamic_var(io_moments.external_source_neutral_momentum_amplitude,
-                                          moments.charged.external_source_neutral_momentum_amplitude,
+                                          moments.neutral.external_source_momentum_amplitude,
                                           t_idx, parallel_io, z, r)
                 end
                 if moments.evolve_ppar
                     append_to_dynamic_var(io_moments.external_source_neutral_pressure_amplitude,
-                                          moments.charged.external_source_neutral_pressure_amplitude,
+                                          moments.neutral.external_source_pressure_amplitude,
                                           t_idx, parallel_io, z, r)
                 end
             end

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -1236,7 +1236,7 @@ function write_moments_data_to_binary(moments, fields, t, n_ion_species,
                                           moments.charged.external_source_neutral_density_amplitude,
                                           t_idx, parallel_io, z, r)
                 end
-                if moments.evolve_uparr
+                if moments.evolve_upar
                     append_to_dynamic_var(io_moments.external_source_neutral_momentum_amplitude,
                                           moments.charged.external_source_neutral_momentum_amplitude,
                                           t_idx, parallel_io, z, r)

--- a/src/neutral_vz_advection.jl
+++ b/src/neutral_vz_advection.jl
@@ -223,10 +223,10 @@ function update_speed_n_u_evolution_neutral!(advect, fvec, moments, vz, z, r, co
         density = fvec.density_neutral
         uz = fvec.uz_neutral
         vth = moments.neutral.vth
-        @loop_s_r_z is ir iz begin
-            term = source_amplitude[iz,ir] * uz[iz,ir,is] / density[iz,ir,is]
-            @loop_vperp_vpa ivperp ivpa begin
-                advect[is].speed[ivpa,ivperp,iz,ir] += term
+        @loop_sn_r_z isn ir iz begin
+            term = source_amplitude[iz,ir] * uz[iz,ir,isn] / density[iz,ir,isn]
+            @loop_vzeta_vr_vz ivzeta ivr ivz begin
+                advect[isn].speed[ivz,ivr,ivzeta,iz,ir] += term
             end
         end
     end


### PR DESCRIPTION
The option `controller_type` was renamed to `source_type` after #147 was written, so needs fixing. Also fix a couple of typos that caused bugs in the 'volumerecycle' examples added in #147.