### PR TITLE
Make machine setup scripts work on MacOS

### DIFF
--- a/machines/generic-batch-template/compile_dependencies.sh
+++ b/machines/generic-batch-template/compile_dependencies.sh
@@ -79,7 +79,7 @@ fi
 if [[ $BUILDHDF5 == "y" ]]; then
   HDF5=hdf5-1.14.3
   # Download and extract the source
-  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2-2/?wpdmdl=18564
+  wget -O ${HDF5}.tar.bz2 https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/src/hdf5-1.14.3.tar.bz2
   tar xjf ${HDF5}.tar.bz2
 
   cd $HDF5

--- a/machines/generic-batch-template/compile_dependencies.sh
+++ b/machines/generic-batch-template/compile_dependencies.sh
@@ -79,7 +79,7 @@ fi
 if [[ $BUILDHDF5 == "y" ]]; then
   HDF5=hdf5-1.14.3
   # Download and extract the source
-  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2/?wpdmdl=18469
+  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2-2/?wpdmdl=18564
   tar xjf ${HDF5}.tar.bz2
 
   cd $HDF5

--- a/machines/generic-pc/compile_dependencies.sh
+++ b/machines/generic-pc/compile_dependencies.sh
@@ -73,7 +73,7 @@ fi
 if [[ $BUILDHDF5 == "y" ]]; then
   HDF5=hdf5-1.14.3
   # Download and extract the source
-  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2/?wpdmdl=18469
+  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2-2/?wpdmdl=18564
   tar xjf ${HDF5}.tar.bz2
 
   cd $HDF5

--- a/machines/generic-pc/compile_dependencies.sh
+++ b/machines/generic-pc/compile_dependencies.sh
@@ -73,7 +73,7 @@ fi
 if [[ $BUILDHDF5 == "y" ]]; then
   HDF5=hdf5-1.14.3
   # Download and extract the source
-  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2-2/?wpdmdl=18564
+  wget -O ${HDF5}.tar.bz2 https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/src/hdf5-1.14.3.tar.bz2
   tar xjf ${HDF5}.tar.bz2
 
   cd $HDF5

--- a/machines/marconi/compile_dependencies.sh
+++ b/machines/marconi/compile_dependencies.sh
@@ -32,7 +32,7 @@ fi
 if [ $BUILDHDF5 -eq 0 ]; then
   HDF5=hdf5-1.14.3
   # Download and extract the source
-  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2-2/?wpdmdl=18564
+  wget -O ${HDF5}.tar.bz2 https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/src/hdf5-1.14.3.tar.bz2
   tar xjf ${HDF5}.tar.bz2
 
   cd $HDF5

--- a/machines/marconi/compile_dependencies.sh
+++ b/machines/marconi/compile_dependencies.sh
@@ -32,7 +32,7 @@ fi
 if [ $BUILDHDF5 -eq 0 ]; then
   HDF5=hdf5-1.14.3
   # Download and extract the source
-  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2/?wpdmdl=18469
+  wget -O ${HDF5}.tar.bz2 https://www.hdfgroup.org/package/hdf5-1-14-3-tar-bz2-2/?wpdmdl=18564
   tar xjf ${HDF5}.tar.bz2
 
   cd $HDF5


### PR DESCRIPTION
Replace `realpath` with Python in machine setup script. `realpath` is not necessarily portable, while we already require Python to be available for the Julia-downloader script. Using Python's `os` module should be pretty portable.

Fixes #183.