### PR TITLE
Support loading from older output files that did not have some variables

### DIFF
--- a/moment_kinetics/src/load_data.jl
+++ b/moment_kinetics/src/load_data.jl
@@ -257,7 +257,12 @@ function load_coordinate_data(fid, name; printout=false, irank=nothing, nrank=no
     L = load_variable(coord_group, "L")
     discretization = load_variable(coord_group, "discretization")
     fd_option = load_variable(coord_group, "fd_option")
-    cheb_option = load_variable(coord_group, "cheb_option")
+    if "cheb_option" ∈ keys(coord_group)
+        cheb_option = load_variable(coord_group, "cheb_option")
+    else
+        # Old output file
+        cheb_option = "FFT"
+    end
     bc = load_variable(coord_group, "bc")
     if "element_spacing_option" ∈ keys(coord_group)
         element_spacing_option = load_variable(coord_group, "element_spacing_option")
@@ -697,13 +702,21 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
             moments.charged.qpar .= load_moment("parallel_heat_flux")
             moments.charged.qpar_updated .= true
             moments.charged.vth .= load_moment("thermal_speed")
-            if parallel_io || z.irank == 0
-                moments.charged.chodura_integral_lower .= load_slice(dynamic, "chodura_integral_lower",
-                                                                     r_range, :, time_index)
+            if z.irank == 0
+                if "chodura_integral_lower" ∈ keys(dynamic)
+                    moments.charged.chodura_integral_lower .= load_slice(dynamic, "chodura_integral_lower",
+                                                                         r_range, :, time_index)
+                else
+                    moments.charged.chodura_integral_lower .= 0.0
+                end
             end
-            if parallel_io || z.irank == z.nrank - 1
-                moments.charged.chodura_integral_upper .= load_slice(dynamic, "chodura_integral_upper",
-                                                                     r_range, :, time_index)
+            if z.irank == z.nrank - 1
+                if "chodura_integral_upper" ∈ keys(dynamic)
+                    moments.charged.chodura_integral_upper .= load_slice(dynamic, "chodura_integral_upper",
+                                                                         r_range, :, time_index)
+                else
+                    moments.charged.chodura_integral_upper .= 0.0
+                end
             end
 
             if "external_source_controller_integral" ∈ get_variable_keys(dynamic) &&
@@ -979,18 +992,6 @@ function reload_evolving_fields!(pdf, moments, boundary_distributions, restart_p
             end
 
             pdf.charged.norm .= load_charged_pdf()
-                if z.irank == 0
-                    moments.charged.chodura_integral_lower .= load_slice(dynamic, "chodura_integral_lower", :, :,
-                                                  time_index)
-                else
-                    moments.charged.chodura_integral_lower .= 0.0
-                end
-                if z.irank == z.nrank - 1
-                    moments.charged.chodura_integral_upper .= load_slice(dynamic, "chodura_integral_upper", :, :,
-                                                  time_index)
-                else
-                    moments.charged.chodura_integral_upper .= 0.0
-                end
             boundary_distributions_io = get_group(fid, "boundary_distributions")
 
             function load_charged_boundary_pdf(var_name, ir)


### PR DESCRIPTION
Also fix a bad merge that result in `chodura_ingteral_lower` and `chodura_integral_upper` being reloaded twice.