### PR TITLE
Fix HDF5 setup when `separate_postproc_projects="y"`

### DIFF
--- a/machines/shared/add_dependencies_to_project.jl
+++ b/machines/shared/add_dependencies_to_project.jl
@@ -3,6 +3,7 @@ using Pkg, TOML
 if abspath(PROGRAM_FILE) == @__FILE__
     prompt_for_hdf5 = true
     repo_dir = dirname(Pkg.project().path)
+    project_dir = repo_dir
     local_preferences_filename = joinpath(repo_dir, "LocalPreferences.toml")
     local_preferences = TOML.parsefile(local_preferences_filename)
     mk_preferences = local_preferences["moment_kinetics"]
@@ -177,11 +178,17 @@ elseif machine_settings["hdf5_library_setting"] == "prompt"
 
     # Reload local_preferences and mk_preferences as they may have been modified by MPI
     # setup
-    local_preferences_filename = joinpath(repo_dir, "LocalPreferences.toml")
+    local_preferences_filename = joinpath(project_dir, "LocalPreferences.toml")
     local_preferences = TOML.parsefile(local_preferences_filename)
-    mk_preferences = local_preferences["moment_kinetics"]
+    if abspath(PROGRAM_FILE) == @__FILE__
+        # Only need to do this for the top-level project. When adding dependencies to
+        # makie_post_processing or plots_post_processing, do not need to set "hdf5_dir" in
+        # `mk_preferences` to go in the `moment_kinetics` section - this only needs to be
+        # done for the top-level project.
+        mk_preferences = local_preferences["moment_kinetics"]
 
-    mk_preferences["hdf5_dir"] = hdf5_dir
+        mk_preferences["hdf5_dir"] = hdf5_dir
+    end
 
     # Delete any existing preferences for HDF5 and HDF5.jll because they may prevent
     # `using HDF5` if the libraries do not exist.

--- a/machines/shared/makie_post_processing_setup.jl
+++ b/machines/shared/makie_post_processing_setup.jl
@@ -12,6 +12,7 @@ if mk_preferences["use_makie"] == "y"
     if batch_system || mk_preferences["separate_postproc_projects"] == "y"
         touch(joinpath("makie_post_processing", "Project.toml"))
         Pkg.activate("makie_post_processing")
+        project_dir = dirname(Pkg.project().path)
 
         include("add_dependencies_to_project.jl")
         Pkg.add(["Makie", "CairoMakie"])

--- a/machines/shared/plots_post_processing_setup.jl
+++ b/machines/shared/plots_post_processing_setup.jl
@@ -12,6 +12,7 @@ if mk_preferences["use_plots"] == "y"
     if batch_system || mk_preferences["separate_postproc_projects"] == "y"
         touch(joinpath("plots_post_processing", "Project.toml"))
         Pkg.activate("plots_post_processing")
+        project_dir = dirname(Pkg.project().path)
 
         include("add_dependencies_to_project.jl")
         Pkg.add("Plots")


### PR DESCRIPTION
When using separate post-processing packages and setting up `makie_post_processing` and/or `plots_post_processing`, the machine setup scripts should be editing `makie_post_processing/LocalPreferences.toml` and/or `plots_post_processing/LocalPreferences.toml`. Before this PR the top-level `LocalPreferences.toml` was accidentally modified, which led to the HDF5 library not being linked when using separate post-processing packages (falling back to the bundled-with-Julia HDF5, which meant parallel I/O was not available).