### PR TITLE
Make sure MPI.Init() is only ever called once

### DIFF
--- a/moment_kinetics/src/communication.jl
+++ b/moment_kinetics/src/communication.jl
@@ -117,7 +117,9 @@ const global_Win_store = Vector{MPI.Win}(undef, 0)
 """
 """
 function __init__()
-    MPI.Init()
+    if !MPI.Initialized()
+        MPI.Init()
+    end
 
     comm_world.val = MPI.COMM_WORLD.val
 


### PR DESCRIPTION
Seems to fix issue where loading `Symbolics` would cause MPI error messages. When this happened, running MMS simulations could hang at the end of a run, even though the run completed successfully. The problem seems to have been that somehow loading `Symbolics` caused `MPI.Init()` to be called - it is not allowed to call `MPI.Init()` twice, so when it was called when starting `moment_kinetics`, something bad happened.