### PR TITLE
Cross species collisions

### DIFF
--- a/examples/fokker-planck/fokker-planck-relaxation-slowing-down-beam.toml
+++ b/examples/fokker-planck/fokker-planck-relaxation-slowing-down-beam.toml
@@ -1,0 +1,64 @@
+# cheap input file for a 0D2V relaxation to a collisional Maxwellian distribution with self-ion collisions.
+n_ion_species = 1
+n_neutral_species = 0
+electron_physics = "boltzmann_electron_response"
+evolve_moments_density = false
+evolve_moments_parallel_flow = false
+evolve_moments_parallel_pressure = false
+evolve_moments_conservation = false
+T_e = 1.0
+T_wall = 1.0
+initial_density1 = 0.5
+initial_temperature1 = 1.0
+initial_density2 = 0.5
+initial_temperature2 = 1.0
+z_IC_option1 = "sinusoid"
+z_IC_density_amplitude1 = 0.001
+z_IC_density_phase1 = 0.0
+z_IC_upar_amplitude1 = 0.0
+z_IC_upar_phase1 = 0.0
+z_IC_temperature_amplitude1 = 0.0
+z_IC_temperature_phase1 = 0.0
+z_IC_option2 = "sinusoid"
+z_IC_density_amplitude2 = 0.001
+z_IC_density_phase2 = 0.0
+z_IC_upar_amplitude2 = 0.0
+z_IC_upar_phase2 = 0.0
+z_IC_temperature_amplitude2 = 0.0
+z_IC_temperature_phase2 = 0.0
+vpa_IC_option1 = "isotropic-beam"
+charge_exchange_frequency = 0.0
+ionization_frequency = 0.0
+constant_ionization_rate = false
+# nuii sets the normalised input C[F,F] Fokker-Planck collision frequency
+nuii = 1.0
+slowing_down_test = true
+nstep = 1000
+dt = 1.0e-5
+nwrite = 50
+nwrite_dfns = 50
+use_semi_lagrange = false
+n_rk_stages = 4
+split_operators = false
+z_ngrid = 1
+z_nelement = 1
+z_nelement_local = 1
+z_bc = "wall"
+z_discretization = "chebyshev_pseudospectral"
+r_ngrid = 1
+r_nelement = 1
+r_nelement_local = 1
+r_bc = "periodic"
+r_discretization = "chebyshev_pseudospectral"
+vpa_ngrid = 5
+vpa_nelement = 32
+vpa_L = 6.0
+vpa_bc = "zero"
+vpa_discretization = "gausslegendre_pseudospectral"
+vperp_ngrid = 5
+vperp_nelement = 16
+vperp_L = 3.0
+vperp_discretization = "gausslegendre_pseudospectral"
+# Fokker-Planck operator requires the "gausslegendre_pseudospectral
+# options for the vpa and vperp grids
+

--- a/examples/fokker-planck/fokker-planck-relaxation-slowing-down.toml
+++ b/examples/fokker-planck/fokker-planck-relaxation-slowing-down.toml
@@ -1,0 +1,63 @@
+# cheap input file for a 0D2V relaxation to a collisional Maxwellian distribution with self-ion collisions.
+n_ion_species = 1
+n_neutral_species = 0
+electron_physics = "boltzmann_electron_response"
+evolve_moments_density = false
+evolve_moments_parallel_flow = false
+evolve_moments_parallel_pressure = false
+evolve_moments_conservation = false
+T_e = 1.0
+T_wall = 1.0
+initial_density1 = 0.5
+initial_temperature1 = 1.0
+initial_density2 = 0.5
+initial_temperature2 = 1.0
+z_IC_option1 = "sinusoid"
+z_IC_density_amplitude1 = 0.001
+z_IC_density_phase1 = 0.0
+z_IC_upar_amplitude1 = 0.0
+z_IC_upar_phase1 = 0.0
+z_IC_temperature_amplitude1 = 0.0
+z_IC_temperature_phase1 = 0.0
+z_IC_option2 = "sinusoid"
+z_IC_density_amplitude2 = 0.001
+z_IC_density_phase2 = 0.0
+z_IC_upar_amplitude2 = 0.0
+z_IC_upar_phase2 = 0.0
+z_IC_temperature_amplitude2 = 0.0
+z_IC_temperature_phase2 = 0.0
+charge_exchange_frequency = 0.0
+ionization_frequency = 0.0
+constant_ionization_rate = false
+# nuii sets the normalised input C[F,F] Fokker-Planck collision frequency
+nuii = 1.0
+slowing_down_test = true
+nstep = 1000
+dt = 1.0e-5
+nwrite = 50
+nwrite_dfns = 50
+use_semi_lagrange = false
+n_rk_stages = 4
+split_operators = false
+z_ngrid = 1
+z_nelement = 1
+z_nelement_local = 1
+z_bc = "wall"
+z_discretization = "chebyshev_pseudospectral"
+r_ngrid = 1
+r_nelement = 1
+r_nelement_local = 1
+r_bc = "periodic"
+r_discretization = "chebyshev_pseudospectral"
+vpa_ngrid = 5
+vpa_nelement = 32
+vpa_L = 6.0
+vpa_bc = "zero"
+vpa_discretization = "gausslegendre_pseudospectral"
+vperp_ngrid = 5
+vperp_nelement = 16
+vperp_L = 3.0
+vperp_discretization = "gausslegendre_pseudospectral"
+# Fokker-Planck operator requires the "gausslegendre_pseudospectral
+# options for the vpa and vperp grids
+

--- a/moment_kinetics/src/communication.jl
+++ b/moment_kinetics/src/communication.jl
@@ -117,8 +117,10 @@ const global_Win_store = Vector{MPI.Win}(undef, 0)
 """
 """
 function __init__()
-    MPI.Init()
-
+    if !MPI.Initialized()
+        MPI.Init()
+    end
+    
     comm_world.val = MPI.COMM_WORLD.val
 
     global_rank[] = MPI.Comm_rank(comm_world)

--- a/moment_kinetics/src/coordinates.jl
+++ b/moment_kinetics/src/coordinates.jl
@@ -98,6 +98,8 @@ struct coordinate
     element_shift::Array{mk_float,1}
     # option used to set up element spacing
     element_spacing_option::String
+    # list of element boundaries
+    element_boundaries::Array{mk_float,1}
 end
 
 """
@@ -166,7 +168,8 @@ function define_coordinate(input, parallel_io::Bool=false; init_YY::Bool=true)
         cell_width, igrid, ielement, imin, imax, igrid_full, input.discretization, input.fd_option, input.cheb_option,
         input.bc, wgts, uniform_grid, duniform_dgrid, scratch, copy(scratch), copy(scratch),
         scratch_2d, copy(scratch_2d), advection, send_buffer, receive_buffer, input.comm,
-        local_io_range, global_io_range, element_scale, element_shift, input.element_spacing_option)
+        local_io_range, global_io_range, element_scale, element_shift, input.element_spacing_option,
+        element_boundaries)
 
     if coord.n == 1 && occursin("v", coord.name)
         spectral = null_velocity_dimension_info()

--- a/moment_kinetics/src/fokker_planck.jl
+++ b/moment_kinetics/src/fokker_planck.jl
@@ -227,7 +227,7 @@ The result is stored in the array `fkpl_arrays.CC`.
 
 The normalised collision frequency is defined by
 ```math
-\\nu_{ss'} = \\frac{\\gamma_{ss'} n_\\mathrm{ref}}{2 m_s^2 c_\\mathrm{ref}^3}
+\\tilde{\\nu}_{ss'} = \\frac{L_\\mathrm{ref}}{c_\\mathrm{ref}}\\frac{\\gamma_{ss'} n_\\mathrm{ref}}{2 m_s^2 c_\\mathrm{ref}^3}
 ```
 with \$\\gamma_{ss'} = 2 \\pi (Z_s Z_{s'})^2 e^4 \\ln \\Lambda_{ss'} / (4 \\pi
 \\epsilon_0)^2\$.

--- a/moment_kinetics/src/fokker_planck_calculus.jl
+++ b/moment_kinetics/src/fokker_planck_calculus.jl
@@ -29,6 +29,7 @@ export enforce_zero_bc!
 export allocate_rosenbluth_potential_boundary_data
 export calculate_rosenbluth_potential_boundary_data_exact!
 export test_rosenbluth_potential_boundary_data
+export interpolate_2D_vspace!
 
 # Import moment_kinetics so that we can refer to it in docstrings
 import moment_kinetics
@@ -2315,6 +2316,99 @@ function enforce_vpavperp_BCs!(pdf,vpa,vperp,vpa_spectral,vperp_spectral)
         @views @. buffer = D0[2:ngrid_vperp] * pdf[ivpa,2:ngrid_vperp]
         pdf[ivpa,1] = -sum(buffer)/D0[1]
     end
+end
+
+"""
+function to interpolate f(vpa,vperp) from one 
+velocity grid to another, assuming that both 
+grids are represented by vpa, vperp in normalised units,
+but have different normalisation factors 
+defining the meaning of these grids in physical units.
+
+E.g. vpai, vperpi = ci * vpa, ci * vperp
+     vpae, vperpe = ce * vpa, ce * vperp
+     
+with ci = sqrt(Ti/mi), ce = sqrt(Te/mi)
+
+scalefac = ci / ce is the ratio of the
+two reference speeds
+
+"""
+function interpolate_2D_vspace!(pdf_out,pdf_in,vpa,vperp,scalefac)
+    
+    begin_anyv_vperp_vpa_region()
+    # loop over points in the output interpolated dataset
+    @loop_vperp ivperp begin
+        vperp_val = vperp.grid[ivperp]*scalefac
+        # get element for interpolation data
+        iel_vperp = ielement_loopup(vperp_val,vperp)
+        if iel_vperp < 1 # vperp_interp outside of range of vperp.grid
+            @loop_vpa ivpa begin
+                pdf_out[ivpa,ivperp] = 0.0
+            end
+            continue
+        else
+            # get nodes for interpolation
+            ivperpmin, ivperpmax = vperp.igrid_full[1,iel_vperp], vperp.igrid_full[vperp.ngrid,iel_vperp]
+            vperp_nodes = vperp.grid[ivperpmin:ivperpmax]
+            #print("vperp: ",iel_vperp, " ", vperp_nodes," ",vperp_val)
+                   
+        end
+        @loop_vpa ivpa begin
+            vpa_val = vpa.grid[ivpa]*scalefac
+            # get element for interpolation data
+            iel_vpa = ielement_loopup(vpa_val,vpa)
+            if iel_vpa < 1 # vpa_interp outside of range of vpa.grid
+                pdf_out[ivpa,ivperp] = 0.0
+                continue
+            else
+                # get nodes for interpolation
+                ivpamin, ivpamax = vpa.igrid_full[1,iel_vpa], vpa.igrid_full[vpa.ngrid,iel_vpa]
+                vpa_nodes = vpa.grid[ivpamin:ivpamax]
+                #print("vpa: ", iel_vpa, " ", vpa_nodes," ",vpa_val)
+                   
+                # do the interpolation
+                pdf_out[ivpa,ivperp] = 0.0
+                for ivperpgrid in 1:vperp.ngrid
+                   # index for referencing pdf_in on orginal grid
+                   ivperpp = vperp.igrid_full[ivperpgrid,iel_vperp]
+                   # interpolating polynomial value at ivperpp for interpolation
+                   vperppoly = lagrange_poly(ivperpgrid,vperp_nodes,vperp_val)
+                   for ivpagrid in 1:vpa.ngrid
+                       # index for referencing pdf_in on orginal grid
+                       ivpap = vpa.igrid_full[ivpagrid,iel_vpa]
+                       # interpolating polynomial value at ivpap for interpolation
+                       vpapoly = lagrange_poly(ivpagrid,vpa_nodes,vpa_val)
+                       pdf_out[ivpa,ivperp] += vpapoly*vperppoly*pdf_in[ivpap,ivperpp]
+                   end
+                end
+            end
+        end
+    end
+    return nothing
+end
+
+"""
+function to find the element in which x sits
+"""
+function ielement_loopup(x,coord)
+    xebs = coord.element_boundaries
+    nelement = coord.nelement_global
+    zero = 1.0e-14
+    ielement = -1
+    # find the element
+    for j in 1:nelement
+        # check for internal points
+        if (x - xebs[j])*(xebs[j+1] - x) > zero
+            ielement = j
+            break
+        # check for boundary points
+        elseif (abs(x-xebs[j]) < 100*zero) || (abs(x-xebs[j+1]) < 100*zero && j == nelement)
+            ielement = j
+            break
+        end
+    end
+    return ielement
 end
 
 end

--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -323,6 +323,17 @@ mutable struct collisions_input
     # nu_{ss'} = gamma_{ss'} n_{ref} / 2 (m_s)^2 (c_{ref})^3
     # with gamma_ss' = 2 pi (Z_s Z_s')^2 e^4 ln \Lambda_{ss'} / (4 pi \epsilon_0)^2
     nuii::mk_float
+    # option to determine which FP collision operator is used
+    slowing_down_test::Bool
+end
+
+"""
+"""
+Base.@kwdef struct fkpl_collisions_input
+    # ion-ion self collision frequency
+    # nu_{ss'} = gamma_{ss'} n_{ref} / 2 (m_s)^2 (c_{ref})^3
+    # with gamma_ss' = 2 pi (Z_s Z_s')^2 e^4 ln \Lambda_{ss'} / (4 pi \epsilon_0)^2
+    nuii::mk_float
 end
 
 """

--- a/moment_kinetics/src/moment_kinetics_input.jl
+++ b/moment_kinetics/src/moment_kinetics_input.jl
@@ -192,6 +192,7 @@ function mk_input(scan_input=Dict(); save_inputs_to_txt=false, ignore_MPI=true)
     end
     # set the Fokker-Planck collision frequency
     collisions.nuii = get(scan_input, "nuii", 0.0)
+    collisions.slowing_down_test = get(scan_input, "slowing_down_test", false)
     
     # parameters related to the time stepping
     nstep = get(scan_input, "nstep", 5)
@@ -1014,7 +1015,7 @@ function load_defaults(n_ion_species, n_neutral_species, electron_physics)
     krook_collision_frequency_prefactor = -1.0
     nuii = 0.0
     collisions = collisions_input(charge_exchange, ionization, constant_ionization_rate,
-                                  krook_collision_frequency_prefactor,"none", nuii)
+                                  krook_collision_frequency_prefactor,"none", nuii, false)
 
     return z, r, vpa, vperp, gyrophase, vz, vr, vzeta, species, composition, drive, evolve_moments, collisions
 end

--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -55,6 +55,7 @@ using ..force_balance: force_balance!, neutral_force_balance!
 using ..energy_equation: energy_equation!, neutral_energy_equation!
 using ..em_fields: setup_em_fields, update_phi!
 using ..fokker_planck: init_fokker_planck_collisions_weak_form, explicit_fokker_planck_collisions_weak_form!
+using ..fokker_planck: explicit_fp_collisions_weak_form_Maxwellian_cross_species!
 using ..manufactured_solns: manufactured_sources
 using ..advection: advection_info
 using ..utils: to_minutes
@@ -1764,9 +1765,15 @@ function euler_time_advance!(fvec_out, fvec_in, pdf, fields, moments,
     # advance with the Fokker-Planck self-collision operator
     if advance.explicit_weakform_fp_collisions
         update_entropy_diagnostic = (istage == 1)
-        explicit_fokker_planck_collisions_weak_form!(fvec_out.pdf,fvec_in.pdf,moments.charged.dSdt,composition,collisions,dt,
-                                             fp_arrays,r,z,vperp,vpa,vperp_spectral,vpa_spectral,scratch_dummy,
+        if collisions.slowing_down_test
+            explicit_fp_collisions_weak_form_Maxwellian_cross_species!(fvec_out.pdf,fvec_in.pdf,moments.charged.dSdt,composition,collisions,dt,
+                                             fp_arrays,r,z,vperp,vpa,vperp_spectral,vpa_spectral;
                                              diagnose_entropy_production = update_entropy_diagnostic)
+        else
+            explicit_fokker_planck_collisions_weak_form!(fvec_out.pdf,fvec_in.pdf,moments.charged.dSdt,composition,collisions,dt,
+                                                 fp_arrays,r,z,vperp,vpa,vperp_spectral,vpa_spectral,scratch_dummy,
+                                                 diagnose_entropy_production = update_entropy_diagnostic)
+        end
     end
     
     # End of advance for distribution function


### PR DESCRIPTION
Addition of a test collision operator that consists of the self collision operator, plus cross-species collisions with two fixed Maxwellian species, representing slow ions and electrons. Example input files are added. The distributions functions shown in the attached .gif files show the relaxation of the distribution function towards cold ash. Comments on the outstanding tasks below would be especially appreciated, as these have to do with the input parameters for collision operators generally (@LucasMontoya4 FYI do not feel pressured to read the code in detail at this point, but ideas for whether or not you are happy to restructure the collisions input struct would be very useful).

![fokker-planck-relaxation-slowing-down-init_pdf_vs_vperp_vpa_iz01_ir01_ion](https://github.com/mabarnes/moment_kinetics/assets/29800382/402aa49c-43b5-4ad3-b71b-99a167291fe2)
![fokker-planck-relaxation-slowing-down_pdf_vs_vperp_vpa_iz01_ir01_ion](https://github.com/mabarnes/moment_kinetics/assets/29800382/e051de6e-06dd-404d-be96-97cc967d32e8)

- [ ] Make consistent input options for beam initial condition to permit user control without hard-coding the beam parameters.
- [ ] Make the fixed Maxwellian species density, thermal speed and parallel flow to be input parameters.
- [ ] Restructure the collision operator input namelists to separate Fokker-Planck collision options from Krook options for future convenience, perhaps easing the two tasks above.
- [ ] Use this test to construct a true multi-species collision operator in the moment-kinetics framework.