### PR TITLE
Handle updated timestepping options in restart_interpolation_tests.jl

### DIFF
--- a/.github/workflows/debug_checks.yml
+++ b/.github/workflows/debug_checks.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: 'openmpi'
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
           arch: x64

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.10'
-          arch: x64
       - uses: julia-actions/cache@v1
       - name: Test examples
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
       - uses: julia-actions/cache@v1

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
       - uses: julia-actions/cache@v1

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.10'
-          arch: x64
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: 'openmpi'
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
           arch: x64
@@ -49,7 +49,7 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: 'openmpi'
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
       - uses: julia-actions/cache@v1

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -54,8 +54,9 @@ jobs:
           version: '1.10'
       - uses: julia-actions/cache@v1
       - run: |
+          MPILIBPATH=$(find /opt/homebrew/Cellar/open-mpi/ -name libmpi.dylib)
           touch Project.toml
-          julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.add(["MPI", "MPIPreferences"]); using MPIPreferences; MPIPreferences.use_system_binary()'
+          julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.add(["MPI", "MPIPreferences"]); using MPIPreferences; MPIPreferences.use_system_binary(library_names="/opt/homebrew/Cellar/open-mpi/5.0.3/lib/libmpi.dylib")'
           julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.add(["NCDatasets", "Random", "SpecialFunctions", "Test"]); Pkg.develop(path="moment_kinetics/")'
           julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.precompile()'
           # Need to use openmpi so that the following arguments work:

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -52,7 +52,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.10'
-          arch: x64
       - uses: julia-actions/cache@v1
       - run: |
           touch Project.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
       - uses: julia-actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.10'
-          arch: x64
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/moment_kinetics/test/restart_interpolation_tests.jl
+++ b/moment_kinetics/test/restart_interpolation_tests.jl
@@ -92,10 +92,15 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, kwargs...)
     println("    - testing ", message)
 
     # Convert from Tuple of Pairs with symbol keys to Dict with String keys
-    modified_inputs = Dict(String(k) => v for (k, v) in kwargs)
+    modified_inputs = Dict(String(k) => v for (k, v) in kwargs
+                           if String(k) ∉ keys(test_input["timestepping"]))
+    modified_timestepping_inputs = Dict(String(k) => v for (k, v) in kwargs
+                                        if String(k) ∈ keys(test_input["timestepping"]))
 
     # Update default inputs with values to be changed
     input = merge(test_input, modified_inputs)
+    input["timestepping"] = merge(test_input["timestepping"],
+                                  modified_timestepping_inputs)
 
     input["run_name"] = name
 
@@ -299,7 +304,7 @@ function runtests()
                                        Dict("evolve_moments_parallel_pressure" => true,
                                             "vpa_L" => 1.5*vpa_L, "vz_L" => 1.5*vpa_L))
 
-        for (base, base_label) ∈ ((base_input, "full-f"),
+        for (base, base_label) ∈ ((base_input_full_f, "full-f"),
                                   (base_input_evolve_density, "split 1"),
                                   (base_input_evolve_upar, "split 2"),
                                   (base_input_evolve_ppar, "split 3"))


### PR DESCRIPTION
This was missed in #194, and made the 'long tests' very slow, so that they timed out.