### PR TITLE
Update precompilation input deck to reflect updated collisions options.

### DIFF
--- a/examples/geometry/1D-mirror.toml
+++ b/examples/geometry/1D-mirror.toml
@@ -42,10 +42,6 @@ vpa_IC_temperature_phase2 = 0.0
 charge_exchange_frequency = 0.5
 ionization_frequency = 0.05
 constant_ionization_rate = true
-nstep = 10000
-dt = 1.0e-3
-nwrite = 50
-nwrite_dfns = 50
 use_semi_lagrange = false
 n_rk_stages = 4
 split_operators = false
@@ -82,3 +78,9 @@ DeltaB=0.5
 #option="constant-helical"
 pitch=1.0
 rhostar= 1.0
+
+[timestepping]
+nstep = 10000
+dt = 1.0e-3
+nwrite = 50
+nwrite_dfns = 50

--- a/examples/gk-ions/2D-periodic-gk.toml
+++ b/examples/gk-ions/2D-periodic-gk.toml
@@ -43,10 +43,6 @@ vpa_IC_temperature_phase2 = 0.0
 charge_exchange_frequency = 0.5
 ionization_frequency = 0.05
 constant_ionization_rate = true
-nstep = 50
-dt = 1.0e-3
-nwrite = 10
-nwrite_dfns = 10
 use_semi_lagrange = false
 n_rk_stages = 4
 split_operators = false
@@ -89,3 +85,9 @@ vperp_dissipation_coefficient = 1.0e-3 #1.0e-2 #1.0e-1
 [neutral_numerical_dissipation]
 moment_dissipation_coefficient = 0.0001
 vz_dissipation_coefficient = 0.01
+
+[timestepping]
+nstep = 50
+dt = 1.0e-3
+nwrite = 10
+nwrite_dfns = 10

--- a/util/precompile_run.jl
+++ b/util/precompile_run.jl
@@ -72,7 +72,11 @@ collisions_input = merge(wall_bc_cheb_input, Dict("n_neutral_species" => 0,
                                                   "vperp_discretization" => "gausslegendre_pseudospectral",
                                                   "vpa_discretization" => "gausslegendre_pseudospectral",
                                                  ))
-push!(inputs_list, collisions_input)
+# add an additional input for every geometry option available in addition to the default
+geo_input1 = merge(wall_bc_cheb_input, Dict("n_neutral_species" => 0,
+                                            "geometry" => Dict{String,Any}("option" => "1D-mirror", "DeltaB" => 0.5, "pitch" => 0.5, "rhostar" => 1.0))) 
+
+push!(inputs_list, collisions_input, geo_input1)
 
 for input in inputs_list
     run_moment_kinetics(input)

--- a/util/precompile_run.jl
+++ b/util/precompile_run.jl
@@ -67,7 +67,8 @@ for input ∈ [base_input, cheb_input, wall_bc_input, wall_bc_cheb_input]
 end
 
 collisions_input = merge(wall_bc_cheb_input, Dict("n_neutral_species" => 0,
-                                                  "nuii" => 1.0,
+                                                  "krook_collisions" => Dict{String,Any}("use_krook" => true),
+                                                  "fokker_planck_collisions" => Dict{String,Any}("use_fokker_planck" => true, "self_collisions" => true, "slowing_down_test" => true),
                                                   "vperp_discretization" => "gausslegendre_pseudospectral",
                                                   "vpa_discretization" => "gausslegendre_pseudospectral",
                                                  ))


### PR DESCRIPTION
Changes to the precompile_run.jl file to make sure collisions and geometric features are available in the moment_kinetics.so.

Also update some example files with the new timestepping options. Query whether or not the example input files still contain redundant flags.