### PR TITLE
Fix range setup for `anyv` regions

### DIFF
--- a/moment_kinetics/src/looping.jl
+++ b/moment_kinetics/src/looping.jl
@@ -145,7 +145,7 @@ function get_local_range(sub_block_rank, sub_block_size, dim_size)
     # This calculation is not at all optimized, but is not going to take long, and is
     # only done in initialization, so it is more important to be simple and robust.
 
-    if dim_size == 0
+    if dim_size == 0 || sub_block_rank ≥ sub_block_size
         # No processor includes a grid point
         return 1:0
     end
@@ -269,6 +269,10 @@ function get_ranges_from_split(block_rank, effective_block_size, split, dim_size
     if block_rank ≥ effective_block_size
         # This process is not needed by this split
         return [1:0 for _ ∈ dim_sizes_list]
+    end
+    if effective_block_size < prod(split)
+        error("effective_block_size=$effective_block_size is smaller than "
+              * "prod(split)=", prod(split))
     end
 
     # Get rank of this process in each sub-block (with sub-block sizes given by split).


### PR DESCRIPTION
We may sometimes call `get_local_range()` with a `sub_block_rank` bigger than the `sub_block_size`, in particular for the `anyv` 'serial region'. In this case immediately return `1:0` for the range, as this avoids a potential out-of-bounds array access when accessing `n_points_for_proc`.

Fixes #210.