### PR TITLE
Temporarily pin matplotlib==3.8.3 for documentation CI job

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,10 @@ jobs:
       - uses: julia-actions/cache@v1
       - name: Install dependencies
         run: |
-          pip3 install --user matplotlib
+          # Version 3.9.0 of matplotlib causes an error with PyPlot.jl, so pin
+          # matplotlib version to 3.8.3 until this is fixed. See
+          # https://github.com/JuliaPy/PyPlot.jl/issues/582).
+          pip3 install --user "matplotlib==3.8.3"
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Authenticate with GitHub Actions token
@@ -33,6 +36,9 @@ jobs:
           version: '1.10'
       - name: Install dependencies
         run: |
-          pip3 install --user matplotlib
+          # Version 3.9.0 of matplotlib causes an error with PyPlot.jl, so pin
+          # matplotlib version to 3.8.3 until this is fixed. See
+          # https://github.com/JuliaPy/PyPlot.jl/issues/582).
+          pip3 install --user "matplotlib==3.8.3"
       - name: Build and deploy
         run: julia --project=docs/ docs/make-pdf.jl


### PR DESCRIPTION
This prevents a current issue (see https://github.com/JuliaPy/PyPlot.jl/issues/582) with `get_cmap()` deprecation in matplotlib-3.9.0 from causing the documentation build to fail. Once the PyPlot.jl issue is resolved, and a fixed version is released, we can go back to using the latest version of matplotlib.

Note failing macOS parallel tests are fixed in #222.