### PR TITLE
Allow printing of @enum values to TOML as Strings

### DIFF
--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -633,6 +633,13 @@ function get(d::Dict, key, default::Enum)
     end
 end
 
+using TOML
+import TOML.Internals.Printer: to_toml_value
+# Define a method of TOML.to_toml_value that handles Enum
+function to_toml_value(f::TOML.Internals.Printer.MbyFunc, value::Enum)
+    return string(value)
+end
+
 """
 Set the defaults for options in the top level of the input, and check that there are not
 any unexpected options (i.e. options that have no default).


### PR DESCRIPTION
Adds a method of `TOML.Internals.Printer.to_toml_value` that handles `Enum` values, allowing `Enum`s to be printed to TOML format strings or files.

Counterpart to the `get(d::Dict, key, default::Enum)` that lets us read `Enum`s from `Dict`s, which means we can read them from TOML files by supplying a value of the `Enum` as the default.

Slightly hacky because `TOML.Internals.Printer.to_toml_value` appears to be an internal method, not part of the public API, but `TOML.jl` does not change very much, so in practice this should be fine.