### PR TITLE
Correct 1 d matrix assembly

### DIFF
--- a/moment_kinetics/src/calculus.jl
+++ b/moment_kinetics/src/calculus.jl
@@ -64,7 +64,7 @@ function derivative!(df, f, coord, spectral::Union{null_spatial_dimension_info,
     return nothing
 end
 
-function second_derivative!(d2f, f, coord, spectral; handle_periodic=true)
+function second_derivative!(d2f, f, coord, spectral)
     # computes d^2f / d(coord)^2
     # For spectral element methods, calculate second derivative by applying first
     # derivative twice, with special treatment for element boundaries
@@ -131,7 +131,7 @@ function second_derivative!(d2f, f, coord, spectral; handle_periodic=true)
     return nothing
 end
 
-function laplacian_derivative!(d2f, f, coord, spectral; handle_periodic=true)
+function laplacian_derivative!(d2f, f, coord, spectral)
     # computes (1/coord) d / coord ( coord d f / d(coord)) for vperp coordinate
     # For spectral element methods, calculate second derivative by applying first
     # derivative twice, with special treatment for element boundaries
@@ -207,22 +207,12 @@ is an input.
 """
 function mass_matrix_solve! end
 
-function second_derivative!(d2f, f, coord, spectral::weak_discretization_info; handle_periodic=true)
+function second_derivative!(d2f, f, coord, spectral::weak_discretization_info)
     # obtain the RHS of numerical weak-form of the equation 
     # g = d^2 f / d coord^2, which is 
     # M * g = K * f, with M the mass matrix and K an appropriate stiffness matrix
     # by multiplying by basis functions and integrating by parts    
     mul!(coord.scratch3, spectral.K_matrix, f)
-
-    if handle_periodic && coord.bc == "periodic"
-        if coord.nrank > 1
-            error("second_derivative!() cannot handle periodic boundaries for a "
-                  * "distributed coordinate")
-        end
-
-        coord.scratch3[1] = 0.5 * (coord.scratch3[1] + coord.scratch3[end])
-        coord.scratch3[end] = coord.scratch3[1]
-    end
 
     # solve weak form matrix problem M * g = K * f to obtain g = d^2 f / d coord^2
     if coord.nrank > 1

--- a/moment_kinetics/src/gauss_legendre.jl
+++ b/moment_kinetics/src/gauss_legendre.jl
@@ -122,13 +122,13 @@ function setup_gausslegendre_pseudospectral(coord; collision_operator_dim=true)
 
     dirichlet_bc = (coord.bc in ["zero", "constant"]) # and further options in future
     periodic_bc = (coord.bc == "periodic")
-    setup_global_weak_form_matrix!(mass_matrix, lobatto, radau, coord, "M"; periodic_bc_lhs=periodic_bc)
-    setup_global_weak_form_matrix!(K_matrix, lobatto, radau, coord, "K_with_BC_terms"; periodic_bc_rhs=periodic_bc)
+    setup_global_weak_form_matrix!(mass_matrix, lobatto, radau, coord, "M"; periodic_bc=periodic_bc)
+    setup_global_weak_form_matrix!(K_matrix, lobatto, radau, coord, "K_with_BC_terms"; periodic_bc=periodic_bc)
     setup_global_weak_form_matrix!(L_matrix, lobatto, radau, coord, "L_with_BC_terms")
     mass_matrix_lu = lu(sparse(mass_matrix))
     if dirichlet_bc || periodic_bc
         L_matrix_with_bc = allocate_float(coord.n,coord.n)
-        setup_global_weak_form_matrix!(L_matrix_with_bc, lobatto, radau, coord, "L", dirichlet_bc=dirichlet_bc, periodic_bc_lhs=periodic_bc)
+        setup_global_weak_form_matrix!(L_matrix_with_bc, lobatto, radau, coord, "L", dirichlet_bc=dirichlet_bc, periodic_bc=periodic_bc)
         L_matrix_with_bc = sparse(L_matrix_with_bc )
         L_matrix_lu = lu(sparse(L_matrix_with_bc))
     else
@@ -880,7 +880,7 @@ is supported with boundary conditions.
 function setup_global_weak_form_matrix!(QQ_global::Array{mk_float,2},
                                lobatto::gausslegendre_base_info,
                                radau::gausslegendre_base_info, 
-                               coord,option; dirichlet_bc=false, periodic_bc_lhs=false, periodic_bc_rhs=false)
+                               coord,option; dirichlet_bc=false, periodic_bc=false)
     QQ_j = allocate_float(coord.ngrid,coord.ngrid)
     
     ngrid = coord.ngrid
@@ -915,7 +915,7 @@ function setup_global_weak_form_matrix!(QQ_global::Array{mk_float,2},
         end
         # requires RHS vector b[1],b[end] = boundary values
     end
-    if periodic_bc_lhs || periodic_bc_rhs
+    if periodic_bc
         # Make periodic boundary condition by modifying elements of matrix for duplicate point
         # add assembly contribution to lower endpoint from upper endpoint
         j = coord.nelement_local
@@ -927,15 +927,13 @@ function setup_global_weak_form_matrix!(QQ_global::Array{mk_float,2},
         # All-zero row in RHS matrix sets last element of `b` vector in
         # `mass_matrix.x = b` to zero
         QQ_global[end,:] .= 0.0
-        if periodic_bc_lhs
-            # enforce periodicity `x[1] = x[end]` using the last row of the
-            # `mass_matrix.x = b` system.
-            QQ_global[end,1] = 1.0
-            QQ_global[end,end] = -1.0
-            if option == "L" # or any other derivative (ODE) matrix requiring two BC (periodicity + value at endpoint)
-                QQ_global[1,:] .= 0.0
-                QQ_global[1,1] = 1.0
-            end
+        # enforce periodicity `x[1] = x[end]` using the last row of the
+        # `A.x = b` system.
+        QQ_global[end,1] = 1.0
+        QQ_global[end,end] = -1.0
+        if option == "L" # or any other derivative (ODE) matrix requiring two BC (periodicity + value at endpoint)
+            QQ_global[1,:] .= 0.0
+            QQ_global[1,1] = 1.0
         end
     end
         

--- a/moment_kinetics/src/gauss_legendre.jl
+++ b/moment_kinetics/src/gauss_legendre.jl
@@ -932,6 +932,10 @@ function setup_global_weak_form_matrix!(QQ_global::Array{mk_float,2},
             # `mass_matrix.x = b` system.
             QQ_global[end,1] = 1.0
             QQ_global[end,end] = -1.0
+            if option == "L" # or any other derivative (ODE) matrix requiring two BC (periodicity + value at endpoint)
+                QQ_global[1,:] .= 0.0
+                QQ_global[1,1] = 1.0
+            end
         end
     end
         

--- a/moment_kinetics/test/calculus_tests.jl
+++ b/moment_kinetics/test/calculus_tests.jl
@@ -13,7 +13,7 @@ function runtests()
     @testset "calculus" verbose=use_verbose begin
         println("calculus tests")
         @testset "fundamental theorem of calculus" begin
-            @testset "$discretization $ngrid $nelement" for
+            @testset "$discretization $ngrid $nelement $cheb_option" for
                     (discretization, element_spacing_option, etol, cheb_option) ∈ (("finite_difference", "uniform", 1.0e-15, ""), ("chebyshev_pseudospectral", "uniform", 1.0e-15, "FFT"), ("chebyshev_pseudospectral", "uniform", 2.0e-15, "matrix"), ("chebyshev_pseudospectral", "sqrt", 1.0e-2, "FFT"), ("gausslegendre_pseudospectral", "uniform", 1.0e-14, "")),
                     ngrid ∈ (5,6,7,8,9,10), nelement ∈ (1, 2, 3, 4, 5)
 
@@ -111,6 +111,7 @@ function runtests()
                 rtol = 1.e2 / (nelement*(ngrid-1))^4
                 @test isapprox(df, expected_df, rtol=rtol, atol=1.e-15,
                                norm=maxabs_norm)
+                @test df[1] == df[end]
             end
         end
 
@@ -164,6 +165,7 @@ function runtests()
                     rtol = 1.e2 / (nelement*(ngrid-1))^order
                     @test isapprox(df, expected_df, rtol=rtol, atol=1.e-15,
                                    norm=maxabs_norm)
+                    df[1] == df[end]
                 end
             end
         end
@@ -278,7 +280,7 @@ function runtests()
         end
 
         @testset "Chebyshev pseudospectral derivatives (4 argument), periodic" verbose=false begin
-            @testset "$nelement $ngrid" for (nelement, ngrid, rtol) ∈
+            @testset "$nelement $ngrid $cheb_option" for (nelement, ngrid, rtol) ∈
                     (
                      (1, 5, 8.e-1),
                      (1, 6, 2.e-1),
@@ -469,11 +471,12 @@ function runtests()
 
                 @test isapprox(df, expected_df, rtol=rtol, atol=1.e-14,
                                norm=maxabs_norm)
+                @test df[1] == df[end]
             end
         end
 
         @testset "Chebyshev pseudospectral derivatives upwinding (5 argument), periodic" verbose=false begin
-            @testset "$nelement $ngrid" for (nelement, ngrid, rtol) ∈
+            @testset "$nelement $ngrid $cheb_option" for (nelement, ngrid, rtol) ∈
                     (
                      (1, 5, 8.e-1),
                      (1, 6, 2.e-1),
@@ -668,12 +671,14 @@ function runtests()
 
                     @test isapprox(df, expected_df, rtol=rtol, atol=1.e-12,
                                    norm=maxabs_norm)
+                    @test df[1] == df[end]
                 end
             end
         end
 
         @testset "Chebyshev pseudospectral derivatives (4 argument), polynomials" verbose=false begin
-            @testset "$nelement $ngrid" for bc ∈ ("constant", "zero"), element_spacing_option ∈ ("uniform", "sqrt"),
+            @testset "$nelement $ngrid $bc $element_spacing_option $cheb_option" for
+                    bc ∈ ("constant", "zero"), element_spacing_option ∈ ("uniform", "sqrt"),
                     nelement ∈ (1:5), ngrid ∈ (3:33), cheb_option in ("FFT","matrix")
 
                 # define inputs needed for the test
@@ -721,7 +726,8 @@ function runtests()
         end
 
         @testset "Chebyshev pseudospectral derivatives upwinding (5 argument), polynomials" verbose=false begin
-            @testset "$nelement $ngrid" for bc ∈ ("constant", "zero"), element_spacing_option ∈ ("uniform", "sqrt"),
+            @testset "$nelement $ngrid $bc $element_spacing_option $cheb_option" for
+                    bc ∈ ("constant", "zero"), element_spacing_option ∈ ("uniform", "sqrt"),
                     nelement ∈ (1:5), ngrid ∈ (3:33), cheb_option in ("FFT","matrix")
 
                 # define inputs needed for the test
@@ -884,6 +890,7 @@ function runtests()
 
                 @test isapprox(df, expected_df, rtol=rtol, atol=1.e-14,
                                norm=maxabs_norm)
+                @test df[1] == df[end]
             end
         end
 
@@ -1002,6 +1009,7 @@ function runtests()
 
                     @test isapprox(df, expected_df, rtol=rtol, atol=1.e-12,
                                    norm=maxabs_norm)
+                    @test df[1] == df[end]
                 end
             end
         end
@@ -1107,7 +1115,7 @@ function runtests()
         end
 
         @testset "Chebyshev pseudospectral second derivatives (4 argument), periodic" verbose=false begin
-            @testset "$nelement $ngrid" for (nelement, ngrid, rtol) ∈
+            @testset "$nelement $ngrid $cheb_option" for (nelement, ngrid, rtol) ∈
                     (
                      (1, 5, 8.e-1),
                      (1, 6, 2.e-1),
@@ -1298,11 +1306,12 @@ function runtests()
 
                 @test isapprox(d2f, expected_d2f, rtol=rtol, atol=1.e-10,
                                norm=maxabs_norm)
+                @test d2f[1] == d2f[end]
             end
         end
         
         @testset "Chebyshev pseudospectral cylindrical laplacian derivatives (4 argument), zero" verbose=false begin
-            @testset "$nelement $ngrid" for (nelement, ngrid, rtol) ∈
+            @testset "$nelement $ngrid $cheb_option" for (nelement, ngrid, rtol) ∈
                     (
                      (4, 7, 2.e-1),
                      (4, 8, 2.e-1),
@@ -1497,6 +1506,7 @@ function runtests()
 
                 @test isapprox(d2f, expected_d2f, rtol=rtol, atol=1.e-10,
                                norm=maxabs_norm)
+                @test d2f[1] == d2f[end]
             end
         end
         

--- a/moment_kinetics/test/calculus_tests.jl
+++ b/moment_kinetics/test/calculus_tests.jl
@@ -101,8 +101,9 @@ function runtests()
 
                 # initialize f and expected df
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L + phase)
 
                 # differentiate f
                 derivative!(df, f, x, spectral)
@@ -149,8 +150,9 @@ function runtests()
 
                 # initialize f and expected df
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L + phase)
 
                 for advection ∈ (-1.0, 0.0, 1.0)
                     adv_fac = similar(f)
@@ -285,13 +287,13 @@ function runtests()
                      (1, 9, 5.e-3),
                      (1, 10, 3.e-3),
                      (1, 11, 1.e-4),
-                     (1, 12, 5.e-6),
+                     (1, 12, 1.e-5),
                      (1, 13, 3.e-6),
-                     (1, 14, 8.e-8),
+                     (1, 14, 1.e-7),
                      (1, 15, 4.e-8),
-                     (1, 16, 8.e-10),
+                     (1, 16, 1.e-8),
                      (1, 17, 4.e-10),
-                     (1, 18, 4.e-12),
+                     (1, 18, 1.e-10),
                      (1, 19, 2.e-12),
                      (1, 20, 2.e-13),
                      (1, 21, 2.e-13),
@@ -311,15 +313,15 @@ function runtests()
                      (2, 4, 2.e-1),
                      (2, 5, 4.e-2),
                      (2, 6, 2.e-2),
-                     (2, 7, 4.e-4),
+                     (2, 7, 1.e-3),
                      (2, 8, 2.e-4),
-                     (2, 9, 4.e-6),
+                     (2, 9, 1.e-5),
                      (2, 10, 2.e-6),
-                     (2, 11, 2.e-8),
+                     (2, 11, 1.e-7),
                      (2, 12, 1.e-8),
-                     (2, 13, 1.e-10),
+                     (2, 13, 1.e-9),
                      (2, 14, 5.e-11),
-                     (2, 15, 4.e-13),
+                     (2, 15, 1.e-12),
                      (2, 16, 2.e-13),
                      (2, 17, 2.e-13),
                      (2, 18, 2.e-13),
@@ -455,8 +457,9 @@ function runtests()
                 x, spectral = define_coordinate(input, "coord"; ignore_MPI=true)
 
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L + phase)
 
                 # create array for the derivative df/dx
                 df = similar(f)
@@ -475,17 +478,17 @@ function runtests()
                      (1, 5, 8.e-1),
                      (1, 6, 2.e-1),
                      (1, 7, 1.e-1),
-                     (1, 8, 1.e-2),
+                     (1, 8, 5.e-2),
                      (1, 9, 5.e-3),
                      (1, 10, 3.e-3),
                      (1, 11, 1.e-4),
-                     (1, 12, 5.e-6),
+                     (1, 12, 3.e-5),
                      (1, 13, 3.e-6),
-                     (1, 14, 8.e-8),
+                     (1, 14, 4.e-7),
                      (1, 15, 4.e-8),
-                     (1, 16, 8.e-10),
+                     (1, 16, 4.e-9),
                      (1, 17, 4.e-10),
-                     (1, 18, 4.e-12),
+                     (1, 18, 4.e-11),
                      (1, 19, 2.e-12),
                      (1, 20, 2.e-13),
                      (1, 21, 2.e-13),
@@ -503,17 +506,17 @@ function runtests()
                      (1, 33, 2.e-13),
 
                      (2, 4, 2.e-1),
-                     (2, 5, 4.e-2),
+                     (2, 5, 6.e-2),
                      (2, 6, 2.e-2),
-                     (2, 7, 4.e-4),
+                     (2, 7, 2.e-3),
                      (2, 8, 2.e-4),
-                     (2, 9, 4.e-6),
+                     (2, 9, 2.e-5),
                      (2, 10, 2.e-6),
-                     (2, 11, 2.e-8),
+                     (2, 11, 1.e-7),
                      (2, 12, 1.e-8),
-                     (2, 13, 1.e-10),
+                     (2, 13, 1.e-9),
                      (2, 14, 5.e-11),
-                     (2, 15, 4.e-13),
+                     (2, 15, 2.e-12),
                      (2, 16, 2.e-13),
                      (2, 17, 2.e-13),
                      (2, 18, 2.e-13),
@@ -649,8 +652,9 @@ function runtests()
                 x, spectral = define_coordinate(input, "coord"; ignore_MPI=true)
 
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L + phase)
 
                 # create array for the derivative df/dx
                 df = similar(f)
@@ -780,26 +784,26 @@ function runtests()
                      (1, 9, 5.e-3),
                      (1, 10, 3.e-3),
                      (1, 11, 5.e-4),
-                     (1, 12, 5.e-6),
+                     (1, 12, 1.e-5),
                      (1, 13, 3.e-6),
-                     (1, 14, 8.e-8),
+                     (1, 14, 3.e-7),
                      (1, 15, 4.e-8),
-                     (1, 16, 8.e-10),
+                     (1, 16, 4.e-9),
                      (1, 17, 8.e-10),
                      
 
                      (2, 4, 2.e-1),
                      (2, 5, 4.e-2),
                      (2, 6, 2.e-2),
-                     (2, 7, 4.e-4),
+                     (2, 7, 1.e-3),
                      (2, 8, 2.e-4),
-                     (2, 9, 4.e-6),
+                     (2, 9, 1.e-5),
                      (2, 10, 2.e-6),
-                     (2, 11, 2.e-8),
+                     (2, 11, 1.e-7),
                      (2, 12, 1.e-8),
-                     (2, 13, 1.e-10),
+                     (2, 13, 1.e-9),
                      (2, 14, 5.e-11),
-                     (2, 15, 4.e-13),
+                     (2, 15, 2.e-12),
                      (2, 16, 2.e-13),
                      (2, 17, 2.e-13),
                      
@@ -868,8 +872,9 @@ function runtests()
                 x, spectral = define_coordinate(input, "coord"; ignore_MPI=true, collision_operator_dim=false)
 
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L + phase)
 
                 # create array for the derivative df/dx
                 df = similar(f)
@@ -886,31 +891,31 @@ function runtests()
             @testset "$nelement $ngrid" for (nelement, ngrid, rtol) ∈
                     (
                      (1, 5, 8.e-1),
-                     (1, 6, 2.e-1),
+                     (1, 6, 3.e-1),
                      (1, 7, 1.e-1),
-                     (1, 8, 1.e-2),
+                     (1, 8, 2.e-2),
                      (1, 9, 5.e-3),
                      (1, 10, 3.e-3),
                      (1, 11, 8.e-4),
-                     (1, 12, 5.e-6),
+                     (1, 12, 3.e-5),
                      (1, 13, 3.e-6),
-                     (1, 14, 8.e-8),
+                     (1, 14, 5.e-7),
                      (1, 15, 4.e-8),
-                     (1, 16, 8.e-10),
+                     (1, 16, 8.e-9),
                      (1, 17, 8.e-10),
                      
                      (2, 4, 2.e-1),
-                     (2, 5, 4.e-2),
+                     (2, 5, 8.e-2),
                      (2, 6, 2.e-2),
-                     (2, 7, 4.e-4),
+                     (2, 7, 2.e-3),
                      (2, 8, 2.e-4),
-                     (2, 9, 4.e-6),
+                     (2, 9, 2.e-5),
                      (2, 10, 2.e-6),
-                     (2, 11, 2.e-8),
+                     (2, 11, 2.e-7),
                      (2, 12, 1.e-8),
-                     (2, 13, 1.e-10),
+                     (2, 13, 1.e-9),
                      (2, 14, 5.e-11),
-                     (2, 15, 4.e-13),
+                     (2, 15, 5.e-12),
                      (2, 16, 2.e-13),
                      (2, 17, 2.e-13),
                      
@@ -939,7 +944,7 @@ function runtests()
                      (4, 9, 8.e-8),
                      (4, 10, 4.e-9),
                      (4, 11, 5.e-10),
-                     (4, 12, 4.e-12),
+                     (4, 12, 1.e-11),
                      (4, 13, 2.e-13),
                      (4, 14, 2.e-13),
                      (4, 15, 2.e-13),
@@ -949,7 +954,7 @@ function runtests()
                      (5, 3, 2.e-1),
                      (5, 4, 2.e-2),
                      (5, 5, 2.e-3),
-                     (5, 6, 1.e-4),
+                     (5, 6, 2.e-4),
                      (5, 7, 1.e-5),
                      (5, 8, 4.e-7),
                      (5, 9, 2.e-8),
@@ -981,8 +986,9 @@ function runtests()
                 x, spectral = define_coordinate(input, "coord"; ignore_MPI=true, collision_operator_dim=false)
 
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_df = @. 2.0 * π / L * cospi(2.0 * x.grid / L + phase)
 
                 # create array for the derivative df/dx
                 df = similar(f)
@@ -1106,17 +1112,17 @@ function runtests()
                      (1, 5, 8.e-1),
                      (1, 6, 2.e-1),
                      (1, 7, 1.e-1),
-                     (1, 8, 1.e-2),
+                     (1, 8, 4.e-2),
                      (1, 9, 5.e-3),
                      (1, 10, 3.e-3),
                      (1, 11, 2.e-4),
-                     (1, 12, 5.e-6),
-                     (1, 13, 4.e-6),
-                     (1, 14, 1.e-7),
+                     (1, 12, 2.e-4),
+                     (1, 13, 8.e-6),
+                     (1, 14, 4.e-6),
                      (1, 15, 1.e-7),
-                     (1, 16, 2.e-9),
+                     (1, 16, 1.e-7),
                      (1, 17, 1.e-9),
-                     (1, 18, 4.e-12),
+                     (1, 18, 1.e-9),
                      (1, 19, 2.e-12),
                      (1, 20, 2.e-13),
                      (1, 21, 2.e-13),
@@ -1134,15 +1140,15 @@ function runtests()
                      (1, 33, 2.e-13),
 
                      (2, 4, 2.e-1),
-                     (2, 5, 4.e-2),
+                     (2, 5, 8.e-2),
                      (2, 6, 2.e-2),
-                     (2, 7, 4.e-4),
-                     (2, 8, 2.e-4),
-                     (2, 9, 4.e-6),
+                     (2, 7, 8.e-3),
+                     (2, 8, 4.e-4),
+                     (2, 9, 2.e-4),
                      (2, 10, 4.e-6),
-                     (2, 11, 4.e-8),
+                     (2, 11, 2.e-6),
                      (2, 12, 4.e-8),
-                     (2, 13, 2.e-10),
+                     (2, 13, 2.e-8),
                      (2, 14, 2.e-10),
                      (2, 15, 4.e-13),
                      (2, 16, 2.e-13),
@@ -1167,7 +1173,7 @@ function runtests()
                      (3, 3, 4.e-1),
                      (3, 4, 1.e-1),
                      (3, 5, 2.e-2),
-                     (3, 6, 4.e-3),
+                     (3, 6, 8.e-3),
                      (3, 7, 1.e-3),
                      (3, 8, 1.e-4),
                      (3, 9, 1.e-5),
@@ -1230,7 +1236,7 @@ function runtests()
 
                      (5, 3, 4.e-1),
                      (5, 4, 4.e-2),
-                     (5, 5, 4.e-3),
+                     (5, 5, 8.e-3),
                      (5, 6, 1.e-3),
                      (5, 7, 4.e-5),
                      (5, 8, 1.e-5),
@@ -1280,8 +1286,9 @@ function runtests()
                 x, spectral = define_coordinate(input, "coord"; ignore_MPI=true)
 
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_d2f = @. -4.0 * π^2 / L^2 * sinpi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_d2f = @. -4.0 * π^2 / L^2 * sinpi(2.0 * x.grid / L + phase)
 
                 # create array for the derivative d2f/dx2
                 d2f = similar(f)
@@ -1478,8 +1485,9 @@ function runtests()
                 x, spectral = define_coordinate(input, "coord"; ignore_MPI=true, collision_operator_dim=false)
 
                 offset = randn(rng)
-                f = @. sinpi(2.0 * x.grid / L) + offset
-                expected_d2f = @. -4.0 * π^2 / L^2 * sinpi(2.0 * x.grid / L)
+                phase = 0.42
+                f = @. sinpi(2.0 * x.grid / L + phase) + offset
+                expected_d2f = @. -4.0 * π^2 / L^2 * sinpi(2.0 * x.grid / L + phase)
 
                 # create array for the derivative d2f/dx2
                 d2f = similar(f)

--- a/test_scripts/GaussLobattoLegendre_test.jl
+++ b/test_scripts/GaussLobattoLegendre_test.jl
@@ -261,12 +261,13 @@ using moment_kinetics.type_definitions: OptionsDict
                 # test 1D ODE solve
                 # form RHS vector
                 mul!(b,y_spectral.mass_matrix,d2fperiodic_exact)
-                b[end] = 0.0
+                b[1] = 0.0 # fixes constant piece of solution
+                b[end] = 0.0 # makes sure periodicity is enforced
                 # solve ODE
                 ldiv!(fperiodic_num,y_spectral.L_matrix_lu,b)
-                # subtract constant piece (constant offset is allowed solution)
-                F_num = sum(y.wgts.*fperiodic_num)/sum(y.wgts)
-                @. fperiodic_num -= F_num
+                ## subtract constant piece (constant offset is allowed solution)
+                #F_num = sum(y.wgts.*fperiodic_num)/sum(y.wgts)
+                #@. fperiodic_num -= F_num
                 @. fperiodic_err = abs(fperiodic_num - fperiodic_exact)
                 println("max(fperiodic_err) (weak form): ",maximum(fperiodic_err))
                 plot([y.grid, y.grid], [fperiodic_num, fperiodic_exact], xlabel="z", label=["num" "exact"], ylabel="")

--- a/test_scripts/GaussLobattoLegendre_test.jl
+++ b/test_scripts/GaussLobattoLegendre_test.jl
@@ -1,8 +1,6 @@
 export gausslegendre_test
 
-using FastGaussQuadrature
-using LegendrePolynomials: Pl
-using LinearAlgebra: mul!, lu, inv, cond
+using LinearAlgebra: mul!, cond
 using Printf
 using Plots
 using LaTeXStrings

--- a/test_scripts/GaussLobattoLegendre_test.jl
+++ b/test_scripts/GaussLobattoLegendre_test.jl
@@ -1,6 +1,6 @@
 export gausslegendre_test
 
-using LinearAlgebra: mul!, cond
+using LinearAlgebra: mul!, cond, ldiv!
 using Printf
 using Plots
 using LaTeXStrings
@@ -42,26 +42,31 @@ using moment_kinetics.type_definitions: OptionsDict
         #nelement = 4
         y_ngrid = ngrid #number of points per element 
         y_nelement_local = nelement # number of elements per rank
-        y_nelement_global = y_nelement_local # total number of elements 
-        bc = "zero" 
+        y_nelement_global = y_nelement_local # total number of elements  
         discretization = "gausslegendre_pseudospectral"
         # fd_option and adv_input not actually used so given values unimportant
         element_spacing_option = "uniform"
         # create the 'input' struct containing input info needed to create a
         # coordinate
-        for y_name in ["vpa","vperp"]
+        for y_name in ["vpa","vperp","z"]
             println("")
             println("$y_name test")
             println("")
             if y_name == "vperp"
-                y_L = L_in #physical box size in reference units 
-            else 
+                y_L = L_in #physical box size in reference units
+                bc = "zero"
+            elseif y_name =="vpa" 
                 y_L = 2*L_in
+                bc = "zero"
+            elseif y_name == "z"
+                y_L = L_in
+                bc = "periodic"
             end
             input = OptionsDict(y_name => OptionsDict("ngrid"=>y_ngrid, "nelement"=>y_nelement_global,
                                                       "nelement_local"=>y_nelement_local, "L"=>y_L,
                                                       "discretization"=>discretization,
-                                                      "element_spacing_option"=>element_spacing_option))
+                                                      "element_spacing_option"=>element_spacing_option,
+                                                      "bc"=>bc))
             # create the coordinate struct 'x'
             # This test runs effectively in serial, so use `ignore_MPI=true` to avoid
             # errors due to communicators not being fully set up.
@@ -91,11 +96,15 @@ using moment_kinetics.type_definitions: OptionsDict
             #print_vector(y_spectral.lobatto.D0,"local lobatto D matrix D0",y.ngrid)
             
             f_exact = Array{Float64,1}(undef,y.n)
+            f_num = Array{Float64,1}(undef,y.n)
+            f_err = Array{Float64,1}(undef,y.n)
             df_exact = Array{Float64,1}(undef,y.n)
             df_num = Array{Float64,1}(undef,y.n)
             df_err = Array{Float64,1}(undef,y.n)
             g_exact = Array{Float64,1}(undef,y.n)
             h_exact = Array{Float64,1}(undef,y.n)
+            h_num = Array{Float64,1}(undef,y.n)
+            h_err = Array{Float64,1}(undef,y.n)
             divg_exact = Array{Float64,1}(undef,y.n)
             divg_num = Array{Float64,1}(undef,y.n)
             divg_err = Array{Float64,1}(undef,y.n)
@@ -105,6 +114,12 @@ using moment_kinetics.type_definitions: OptionsDict
             d2f_exact = Array{Float64,1}(undef,y.n)
             d2f_num = Array{Float64,1}(undef,y.n)
             d2f_err = Array{Float64,1}(undef,y.n)
+            fperiodic_err = Array{Float64,1}(undef,y.n)
+            fperiodic_num = Array{Float64,1}(undef,y.n)
+            fperiodic_exact = Array{Float64,1}(undef,y.n)
+            d2fperiodic_exact = Array{Float64,1}(undef,y.n)
+            d2fperiodic_num = Array{Float64,1}(undef,y.n)
+            d2fperiodic_err = Array{Float64,1}(undef,y.n)
             b = Array{Float64,1}(undef,y.n)
             for iy in 1:y.n
                 f_exact[iy] = exp(-y.grid[iy]^2)
@@ -119,28 +134,32 @@ using moment_kinetics.type_definitions: OptionsDict
                 #h_exact[iy] = exp(-y.grid[iy]^3)
                 #laph_exact[iy] = 9.0*y.grid[iy]*(y.grid[iy]^3 - 1.0)*exp(-y.grid[iy]^3)
                 #f_exact[iy] = -2.0*y.grid[iy]*exp(-y.grid[iy]^2)
-                
+                fperiodic_exact[iy] = sin(2.0*pi*y.grid[iy]/y.L)
+                d2fperiodic_exact[iy] = -((2.0*pi/y.L)^2)*sin(2.0*pi*y.grid[iy]/y.L)
             end
-            if y.name == "vpa" 
-                F_exact = sqrt(pi)
-            elseif y.name == "vperp"
-                F_exact = 1.0
-            end
-            # do a test integration
-            #println(f_exact)
-            F_num = sum(y.wgts.*f_exact)
-            F_err = abs(F_num - F_exact)
-            #for ix in 1:ngrid
-            #    F_num += w[ix]*df_exact[ix]
-            #end
-            println("F_err: ", F_err,  " F_exact: ",F_exact, " F_num: ", F_num)
             
-            derivative!(df_num, f_exact, y, y_spectral)
-            @. df_err = df_num - df_exact
-            println("max(df_err) (interpolation): ",maximum(df_err))
-            derivative!(d2f_num, df_num, y, y_spectral)
-            @. d2f_err = d2f_num - d2f_exact
-            println("max(d2f_err) (double first derivative by interpolation): ",maximum(d2f_err))  
+            if y.name in ["vpa","vperp"]
+                if y.name == "vpa" 
+                    F_exact = sqrt(pi)
+                elseif y.name == "vperp"
+                    F_exact = 1.0
+                end
+                # do a test integration
+                #println(f_exact)
+                F_num = sum(y.wgts.*f_exact)
+                F_err = abs(F_num - F_exact)
+                #for ix in 1:ngrid
+                #    F_num += w[ix]*df_exact[ix]
+                #end
+                println("F_err: ", F_err,  " F_exact: ",F_exact, " F_num: ", F_num)
+                
+                derivative!(df_num, f_exact, y, y_spectral)
+                @. df_err = df_num - df_exact
+                println("max(df_err) (interpolation): ",maximum(df_err))
+                derivative!(d2f_num, df_num, y, y_spectral)
+                @. d2f_err = d2f_num - d2f_exact
+                println("max(d2f_err) (double first derivative by interpolation): ",maximum(d2f_err))  
+            end
             if y.name == "vpa"
                 mul!(b,y_spectral.S_matrix,f_exact)
                 mass_matrix_solve!(df_num,b,y_spectral)
@@ -157,6 +176,20 @@ using moment_kinetics.type_definitions: OptionsDict
                 println("max(d2f_err) (weak form): ",maximum(d2f_err))
                 plot([y.grid, y.grid], [d2f_num, d2f_exact], xlabel="vpa", label=["num" "exact"], ylabel="")
                 outfile = "vpa_test.pdf"
+                savefig(outfile)
+                
+                # test 1D ODE solve
+                # form RHS vector
+                mul!(b,y_spectral.mass_matrix,d2f_exact)
+                # Dirichlet zero BCs
+                b[1] = 0.0
+                b[end] = 0.0
+                # solve ODE
+                ldiv!(f_num,y_spectral.L_matrix_lu,b)
+                @. f_err = abs(f_num - f_exact)
+                println("max(f_err) (weak form): ",maximum(f_err))
+                plot([y.grid, y.grid], [f_num, f_exact], xlabel="vpa", label=["num" "exact"], ylabel="")
+                outfile = "vpa_test_ode.pdf"
                 savefig(outfile)
                 
             elseif y.name == "vperp"
@@ -207,6 +240,39 @@ using moment_kinetics.type_definitions: OptionsDict
                 @. laph_err = abs(laph_num - laph_exact)
                 println("max(laph_err) (interpolation): ",maximum(laph_err))
                 
+                # test 1D ODE solve
+                # form RHS vector
+                mul!(b,y_spectral.mass_matrix,laph_exact)
+                # Dirichlet zero BC at upper endpoint
+                b[end] = 0.0
+                # solve ODE
+                ldiv!(h_num,y_spectral.L_matrix_lu,b)
+                @. h_err = abs(h_num - h_exact)
+                println("max(h_err) (weak form): ",maximum(h_err))
+                plot([y.grid, y.grid], [h_num, h_exact], xlabel="vperp", label=["num" "exact"], ylabel="")
+                outfile = "vperp_test_ode.pdf"
+                savefig(outfile)
+            elseif y.name == "z"
+                # test 1D differentiation
+                second_derivative!(d2fperiodic_num, fperiodic_exact, y, y_spectral)
+                @. d2fperiodic_err = abs(d2fperiodic_num - d2fperiodic_exact)
+                println("max(d2fperiodic_err) (weak form): ",maximum(d2fperiodic_err))
+                
+                # test 1D ODE solve
+                # form RHS vector
+                mul!(b,y_spectral.mass_matrix,d2fperiodic_exact)
+                b[end] = 0.0
+                # solve ODE
+                ldiv!(fperiodic_num,y_spectral.L_matrix_lu,b)
+                # subtract constant piece (constant offset is allowed solution)
+                F_num = sum(y.wgts.*fperiodic_num)/sum(y.wgts)
+                @. fperiodic_num -= F_num
+                @. fperiodic_err = abs(fperiodic_num - fperiodic_exact)
+                println("max(fperiodic_err) (weak form): ",maximum(fperiodic_err))
+                plot([y.grid, y.grid], [fperiodic_num, fperiodic_exact], xlabel="z", label=["num" "exact"], ylabel="")
+                outfile = "periodic_test_ode.pdf"
+                savefig(outfile)
+            
             end
         end
     end


### PR DESCRIPTION
Changes to correct the 1D matrix assembly functions. Documentation, simplification. Boundary conditions are now clearly only imposed when solving and ODE. Tests of this functionality could be added if desired. Demonstrated here so far is that differentiation does not require boundary conditions.