### PR TITLE
When we catch an exception, print it to stderr before calling MPI.Abort

### DIFF
--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -148,8 +148,8 @@ function run_moment_kinetics(to::Union{TimerOutput,Nothing}, input_dict=Dict();
         # Stop code from hanging when running on multiple processes if only one of them
         # throws an error
         if global_size[] > 1
-            println("$(typeof(e)) on process $(global_rank[]):")
-            showerror(stdout, e, catch_backtrace())
+            println(stderr, "$(typeof(e)) on process $(global_rank[]):")
+            showerror(stderr, e, catch_backtrace())
             flush(stdout)
             flush(stderr)
             MPI.Abort(comm_world, 1)


### PR DESCRIPTION
Previously, we were printing to stdout, but this makes it more likely for the error message and stack trace to get lost, e.g. when `quietoutput()` is used in the tests.