### PR TITLE
Reduce max output file path lengths in restart_interpolation_tests.jl

### DIFF
--- a/moment_kinetics/test/restart_interpolation_tests.jl
+++ b/moment_kinetics/test/restart_interpolation_tests.jl
@@ -104,8 +104,8 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, args...)
         name = string(name, "_", (stringify_arg(k, v) for (k, v) in args)...)
     end
     # Make sure name is not too long
-    if length(name) > 90
-        name = name[1:90]
+    if length(name) > 80
+        name = name[1:80]
     end
     if parallel_io
         name *= "parallel-io"


### PR DESCRIPTION
In the macOS CI job, temp directories have longer paths than on Linux, so our output file names must be a bit shorter.