### PR TITLE
Remove mpi4py setup in parallel CI jobs

### DIFF
--- a/.github/workflows/debug_checks.yml
+++ b/.github/workflows/debug_checks.yml
@@ -15,9 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -14,9 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
@@ -47,9 +44,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'


### PR DESCRIPTION
Don't think it should cause a problem, but is unneeded now that we use OpenMPI from the Julia package manager for the CI jobs, and maybe there is some conflict that is causing intermittent failures in the parallel tests.