### PR TITLE
Fix "wall_exp_decay" source for distributed MPI

### DIFF
--- a/moment_kinetics/src/external_sources.jl
+++ b/moment_kinetics/src/external_sources.jl
@@ -407,8 +407,9 @@ function get_source_profile(profile_type, width, relative_minimum, coord)
         return profile
     elseif profile_type == "wall_exp_decay"
         x = coord.grid
-        return @. (1.0 - relative_minimum) * exp(-(x-x[1]) / width) + relative_minimum +
-                  (1.0 - relative_minimum) * exp(-(x[end]-x) / width) + relative_minimum
+        L = coord.L
+        return @. (1.0 - relative_minimum) * exp(-(x+0.5*L) / width) + relative_minimum +
+                  (1.0 - relative_minimum) * exp(-(0.5*L-x) / width) + relative_minimum
     else
         error("Unrecognised source profile type '$profile_type'.")
     end


### PR DESCRIPTION
When distributed-memory MPI parallelism is used, `coord.grid` only has the positions of points in the local grid, not the global grid, so it doesn't necessarily contain the end points of the global grid. We have to use `coord.L` to get the locations of the walls instead.