### PR TITLE
Attempt to fix intermittent CI failures

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -30,5 +30,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project=moment_kinetics/ -e 'import Pkg; Pkg.test(; test_args=["--long", "--force-optional-dependencies"])'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project=moment_kinetics/ -e 'import Pkg; Pkg.test(; test_args=["--ci", "--long", "--force-optional-dependencies"])'
         shell: bash

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -26,9 +26,9 @@ jobs:
           julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.add(["Random", "SpecialFunctions", "Test"]); Pkg.develop(path="moment_kinetics/")'
           julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.precompile()'
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores
-          ./mpiexecjl -np 3 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --debug 1
-          ./mpiexecjl -np 4 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --debug 1
-          ./mpiexecjl -np 2 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --debug 1 --long
+          ./mpiexecjl -np 3 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --ci --debug 1
+          ./mpiexecjl -np 4 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --ci --debug 1
+          ./mpiexecjl -np 2 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --ci --debug 1 --long
           # Note: MPI.jl's default implementation is mpich, which has a similar option
           # `--with-device=ch3:sock`, but that needs to be set when compiling mpich.
         shell: bash
@@ -51,7 +51,7 @@ jobs:
           julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.add(["Random", "SpecialFunctions", "Test"]); Pkg.develop(path="moment_kinetics/")'
           julia --project -O3 --check-bounds=no -e 'import Pkg; Pkg.precompile()'
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores
-          ./mpiexecjl -np 4 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --debug 1
+          ./mpiexecjl -np 4 --oversubscribe julia --project -O3 --check-bounds=no moment_kinetics/test/runtests.jl --ci --debug 1
           # Note: MPI.jl's default implementation is mpich, which has a similar option
           # `--with-device=ch3:sock`, but that needs to be set when compiling mpich.
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project=moment_kinetics/ -e 'import Pkg; Pkg.test(; test_args=["--force-optional-dependencies"])'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project=moment_kinetics/ -e 'import Pkg; Pkg.test(; test_args=["--ci", "--force-optional-dependencies"])'
         shell: bash

--- a/moment_kinetics/src/command_line_options.jl
+++ b/moment_kinetics/src/command_line_options.jl
@@ -42,6 +42,9 @@ const s = ArgParseSettings()
     "--verbose", "-v"
         help = "Print verbose output from tests."
         action = :store_true
+    "--ci"
+        help = "Indicates that tests are running on the CI server."
+        action = :store_true
     # Options for performance tests and plotting
     "--machine-name"
         help = "Which machine to plot for when using plot_performance.jl?"

--- a/moment_kinetics/test/setup.jl
+++ b/moment_kinetics/test/setup.jl
@@ -90,7 +90,13 @@ Get a single temporary directory that is the same on all MPI ranks
 """
 function get_MPI_tempdir()
     if global_rank[] == 0
-        test_output_directory = tempname()
+        if get_options()["ci"]
+            runs_dir = abspath("runs/")
+            mkpath(runs_dir)
+            test_output_directory = tempname(runs_dir)
+        else
+            test_output_directory = tempname()
+        end
         mkpath(test_output_directory)
     else
         test_output_directory = ""


### PR DESCRIPTION
On CI server, don't use `/tmp/` for output files.

I think putting files in `/tmp/` on the Github Actions CI servers might be the cause of the occasional failures of the tests we've been seeing recently. Maybe the files in `/tmp` get cleaned out frequently, and occasionally that cleaning happens while we are still using the file? Instead, put the test output files in subdirectories of `runs/`, but only when running on the CI server - otherwise still use `/tmp/` as normal.