### PR TITLE
Fix failures of 'long tests' CI job

### DIFF
--- a/moment_kinetics/test/restart_interpolation_tests.jl
+++ b/moment_kinetics/test/restart_interpolation_tests.jl
@@ -104,8 +104,8 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, args...)
         name = string(name, "_", (stringify_arg(k, v) for (k, v) in args)...)
     end
     # Make sure name is not too long
-    if length(name) > 80
-        name = name[1:80]
+    if length(name) > 60
+        name = name[1:60]
     end
     if parallel_io
         name *= "parallel-io"


### PR DESCRIPTION
Reduce maximum file name length in the restart interpolation test, to prevent an HDF5 error.

Hopefully fixes #272.