### PR TITLE
Fix a couple of small errors in the setup process

### DIFF
--- a/docs/src/post_processing_notes.md
+++ b/docs/src/post_processing_notes.md
@@ -19,6 +19,11 @@ julia> makie_post_process("runs/example-run1/", "runs/example-run2/", "runs/exam
 What this function does is controlled by the settings in an input file, by
 default `post_processing_input.toml`.
 
+!!! note "Example input file"
+    You can generate an example input file, with all the options shown (with
+    their default values) but commented out, by running
+    `makie_post_processing.generate_example_input_file()`.
+
 To run from the command line
 ```julia
 julia --project run_makie_post_processing.jl dir1 [dir2 [dir3 ...]]

--- a/machines/shared/machine_setup_stage_two.jl
+++ b/machines/shared/machine_setup_stage_two.jl
@@ -11,7 +11,7 @@ batch_system = mk_preferences["batch_system"]
 if mk_preferences["use_plots"] == "y"
     python_venv_path = joinpath(repo_dir, "machines", "artifacts", "mk_venv")
     activate_path = joinpath(python_venv_path, "bin", "activate")
-    run(`bash -c "python -m venv --system-site-packages $python_venv_path; source $activate_path; PYTHONNOUSERSITE=1 pip install matplotlib"`)
+    run(`bash -c "/usr/bin/env python3 -m venv --system-site-packages $python_venv_path; source $activate_path; PYTHONNOUSERSITE=1 pip install matplotlib"`)
     if batch_system
         open("julia.env", "a") do io
             println(io, "source $activate_path")

--- a/makie_post_processing/makie_post_processing/src/makie_post_processing.jl
+++ b/makie_post_processing/makie_post_processing/src/makie_post_processing.jl
@@ -826,7 +826,7 @@ function _setup_single_input!(this_input_dict::OrderedDict{String,Any},
         include_patterns=String[],
         exclude_patterns=String[],
         ranks=mk_int[],
-        figsize=(600,800)
+        figsize=[600,800]
        )
 
     # We allow top-level options in the post-processing input file
@@ -8492,7 +8492,7 @@ function timing_data(run_info::Tuple; plot_prefix=nothing, threshold=nothing,
 
     if figsize === nothing
         if input !== nothing
-            figsize = input.figsize
+            figsize = Tuple(input.figsize)
         else
             figsize = (600,800)
         end
@@ -8602,7 +8602,7 @@ function timing_data(run_info; plot_prefix=nothing, threshold=nothing,
 
     if figsize === nothing
         if input !== nothing
-            figsize = input.figsize
+            figsize = Tuple(input.figsize)
         else
             figsize = (600,800)
         end


### PR DESCRIPTION
* Fixes `makie_post_processing.generate_example_input_file()`
* More portable call for Python from `machines/machine_setup.sh` when setting up a venv to use with `plots_post_processing`
* Mention `makie_post_processing.generate_example_input_file()` in the docs