### PR TITLE
Update CI jobs and documentation build to Julia-1.11

### DIFF
--- a/.github/workflows/debug_checks.yml
+++ b/.github/workflows/debug_checks.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
           arch: x64
       - uses: julia-actions/cache@v2
       - name: Debug test

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
-      #- uses: julia-actions/cache@v2
+          version: '1.11'
+      - uses: julia-actions/cache@v2
       - name: Install dependencies
         run: |
           # Version 3.9.0 of matplotlib causes an error with PyPlot.jl, so pin
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - name: Install dependencies
         run: |
           # Version 3.9.0 of matplotlib causes an error with PyPlot.jl, so pin

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - name: Test examples
         run: |

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
           arch: x64
       - uses: julia-actions/cache@v2
       - run: |
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - run: |
           touch Project.toml

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 210
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
-    timeout-minutes: 50
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - name: Test test_scripts
         run: |

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,7 +4,7 @@ Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 makie_post_processing = "4dd1b173-c370-4c56-9cc2-d797e41ae9f0"
 moment_kinetics = "b5ff72cc-06fc-4161-ad14-dba1c22ed34e"
-#plots_post_processing = "c3e9b6e6-652c-46aa-9ac0-1bc582aad122"
+plots_post_processing = "c3e9b6e6-652c-46aa-9ac0-1bc582aad122"
 
 [compat]
 Documenter = "0.27"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,10 +1,15 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 makie_post_processing = "4dd1b173-c370-4c56-9cc2-d797e41ae9f0"
 moment_kinetics = "b5ff72cc-06fc-4161-ad14-dba1c22ed34e"
 plots_post_processing = "c3e9b6e6-652c-46aa-9ac0-1bc582aad122"
 
-[sources]
-makie_post_processing = {path = "../makie_post_processing/makie_post_processing"}
-moment_kinetics = {path = "../moment_kinetics/"}
-plots_post_processing = {path = "../plots_post_processing/plots_post_processing"}
+[sources.makie_post_processing]
+path = "../makie_post_processing/makie_post_processing"
+
+[sources.moment_kinetics]
+path = "../moment_kinetics/"
+
+[sources.plots_post_processing]
+path = "../plots_post_processing/plots_post_processing"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,10 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 makie_post_processing = "4dd1b173-c370-4c56-9cc2-d797e41ae9f0"
 moment_kinetics = "b5ff72cc-06fc-4161-ad14-dba1c22ed34e"
 plots_post_processing = "c3e9b6e6-652c-46aa-9ac0-1bc582aad122"
 
-[compat]
-Documenter = "0.27"
+[sources]
+makie_post_processing = {path = "../makie_post_processing/makie_post_processing"}
+moment_kinetics = {path = "../moment_kinetics/"}
+plots_post_processing = {path = "../plots_post_processing/plots_post_processing"}

--- a/docs/make-pdf.jl
+++ b/docs/make-pdf.jl
@@ -14,13 +14,12 @@ using Pkg
 repo_dir = dirname(dirname(@__FILE__))
 Pkg.develop([PackageSpec(path=joinpath(repo_dir, "moment_kinetics")),
              PackageSpec(path=joinpath(repo_dir, "makie_post_processing", "makie_post_processing")),
-             #PackageSpec(path=joinpath(repo_dir, "plots_post_processing", "plots_post_processing"))
-            ])
+             PackageSpec(path=joinpath(repo_dir, "plots_post_processing", "plots_post_processing"))])
 Pkg.instantiate()
 
 using Documenter
 using Glob
-using moment_kinetics, makie_post_processing#, plots_post_processing
+using moment_kinetics, makie_post_processing, plots_post_processing
 
 doc_files = glob("src/*.md")
 
@@ -36,10 +35,7 @@ end
 makedocs(
     sitename = "momentkinetics",
     format = Documenter.LaTeX(; latex_kwargs...),
-    modules = [moment_kinetics,
-               makie_post_processing,
-               #plots_post_processing
-              ],
+    modules = [moment_kinetics, makie_post_processing, plots_post_processing],
     authors = "M. Barnes, J.T. Omotani, M. Hardman",
     pages = doc_files
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,12 +3,11 @@ using Pkg
 repo_dir = dirname(dirname(@__FILE__))
 Pkg.develop([PackageSpec(path=joinpath(repo_dir, "moment_kinetics")),
              PackageSpec(path=joinpath(repo_dir, "makie_post_processing", "makie_post_processing")),
-             #PackageSpec(path=joinpath(repo_dir, "plots_post_processing", "plots_post_processing")),
-            ])
+             PackageSpec(path=joinpath(repo_dir, "plots_post_processing", "plots_post_processing"))])
 Pkg.instantiate()
 
 using Documenter
-using moment_kinetics, makie_post_processing#, plots_post_processing
+using moment_kinetics, makie_post_processing, plots_post_processing
 
 if get(ENV, "CI", nothing) == "true"
     # On the CI, run in strict mode to turn warnings into errors, so that we don't deploy
@@ -21,10 +20,7 @@ end
 makedocs(
     sitename = "moment_kinetics",
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
-    modules = [moment_kinetics,
-               makie_post_processing,
-               #plots_post_processing
-              ],
+    modules = [moment_kinetics, makie_post_processing, plots_post_processing],
     strict = strict,
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,19 +9,10 @@ Pkg.instantiate()
 using Documenter
 using moment_kinetics, makie_post_processing, plots_post_processing
 
-if get(ENV, "CI", nothing) == "true"
-    # On the CI, run in strict mode to turn warnings into errors, so that we don't deploy
-    # documentation with formatting bugs.
-    strict = true
-else
-    strict = false
-end
-
 makedocs(
     sitename = "moment_kinetics",
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
     modules = [moment_kinetics, makie_post_processing, plots_post_processing],
-    strict = strict,
 )
 
 if get(ENV, "CI", nothing) == "true"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,10 @@ using moment_kinetics, makie_post_processing, plots_post_processing
 
 makedocs(
     sitename = "moment_kinetics",
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true",
+                             size_threshold = 1000000,
+                             size_threshold_warn = 500000,
+                            ),
     modules = [moment_kinetics, makie_post_processing, plots_post_processing],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,5 @@
 using Pkg
 
-repo_dir = dirname(dirname(@__FILE__))
-Pkg.develop([PackageSpec(path=joinpath(repo_dir, "moment_kinetics")),
-             PackageSpec(path=joinpath(repo_dir, "makie_post_processing", "makie_post_processing")),
-             PackageSpec(path=joinpath(repo_dir, "plots_post_processing", "plots_post_processing"))])
 Pkg.instantiate()
 
 using Documenter

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Pkg
 
 Pkg.instantiate()
 
-using Documenter
+using Documenter, UUIDs
 using moment_kinetics, makie_post_processing, plots_post_processing
 
 makedocs(
@@ -10,6 +10,13 @@ makedocs(
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true",
                              size_threshold = 1000000,
                              size_threshold_warn = 500000,
+                             # Use the following horrible incantation to get the version
+                             # of moment_kinetics. moment_kinetics is the package with the
+                             # UUID being used here. We need to do this because the
+                             # Project.toml in the top-level directory is user-generated
+                             # and does not have a version, but this is the Project.toml
+                             # that would be used by default by Documenter.jl.
+                             inventory_version = Pkg.dependencies()[UUID("b5ff72cc-06fc-4161-ad14-dba1c22ed34e")].version,
                             ),
     modules = [moment_kinetics, makie_post_processing, plots_post_processing],
 )

--- a/docs/src/zz_plot_MMS_sequence.md
+++ b/docs/src/zz_plot_MMS_sequence.md
@@ -1,8 +1,6 @@
 `plot_MMS_sequence`
 ===================
 
-````
 ```@autodocs
 Modules = [plots_post_processing.plot_MMS_sequence]
 ```
-````

--- a/docs/src/zz_plot_sequence.md
+++ b/docs/src/zz_plot_sequence.md
@@ -1,8 +1,6 @@
 `plot_sequence`
 ===============
 
-````
 ```@autodocs
 Modules = [plots_post_processing.plot_sequence]
 ```
-````

--- a/docs/src/zz_plots_post_processing.md
+++ b/docs/src/zz_plots_post_processing.md
@@ -1,15 +1,6 @@
 `plots_post_processing`
 =======================
 
-As of 20/1/2025, importing `Plots` in the Github Actions CI causes an error, so
-for now we skip building the documentation for `plots_post_processing` as we
-cannot import the module without its `Plots` dependency. When this is fixed,
-remove the quadruple-backticks that comment out the `@autodocs` block below, in
-`docs/src/zz_plot_sequence.md` and in `docs/src/zz_plot_MMS_sequence.md`, and
-uncomment the lines  with `plots_post_processing` in `docs/make.jl`,
-`docs/make-pdf.jl`, and `docs/Project.toml`.
-````
 ```@autodocs
 Modules = [plots_post_processing, plots_post_processing.post_processing_input, plots_post_processing.shared_utils]
 ```
-````

--- a/moment_kinetics/Project.toml
+++ b/moment_kinetics/Project.toml
@@ -32,6 +32,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
@@ -51,6 +52,7 @@ manufactured_solns_ext = ["Symbolics", "IfElse"]
 
 [compat]
 julia = "1.9.0"
+StableRNGs = "1"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -5,6 +5,7 @@ module moment_kinetics
 export run_moment_kinetics
 
 using MPI
+using StableRNGs # Included so it can be imported conveniently into tests. Not used within moment_kinetics.
 using StatsBase
 
 # Include submodules from other source files

--- a/moment_kinetics/test/calculus_tests.jl
+++ b/moment_kinetics/test/calculus_tests.jl
@@ -664,7 +664,7 @@ function runtests()
         @testset "Chebyshev pseudospectral derivatives (4 argument), polynomials" verbose=false begin
             @testset "$nelement $ngrid $bc $element_spacing_option $cheb_option" for
                     bc ∈ ("constant", "zero"), element_spacing_option ∈ ("uniform", "sqrt"),
-                    nelement ∈ (1:5), ngrid ∈ (3:33), cheb_option in ("FFT","matrix")
+                    nelement ∈ (1:5), ngrid ∈ (3:24), cheb_option in ("FFT","matrix")
 
                 # define inputs needed for the test
                 L = 1.0

--- a/moment_kinetics/test/calculus_tests.jl
+++ b/moment_kinetics/test/calculus_tests.jl
@@ -71,7 +71,7 @@ function runtests()
             end
         end
 
-        rng = MersenneTwister(42)
+        rng = StableRNG(42)
 
         @testset "finite_difference derivatives (4 argument), periodic" verbose=false begin
             @testset "$nelement $ngrid" for nelement ∈ (1:5), ngrid ∈ (9:33)

--- a/moment_kinetics/test/calculus_tests.jl
+++ b/moment_kinetics/test/calculus_tests.jl
@@ -668,7 +668,6 @@ function runtests()
 
                 # define inputs needed for the test
                 L = 1.0
-                bc = "constant"
                 # create the coordinate struct 'x'
                 # This test runs effectively in serial, so implicitly uses
                 # `ignore_MPI=true` to avoid errors due to communicators not being fully

--- a/moment_kinetics/test/setup.jl
+++ b/moment_kinetics/test/setup.jl
@@ -9,6 +9,7 @@ Included in test files as `include("setup.jl")`
 ##########################
 using Test: @testset, @test
 using moment_kinetics
+using moment_kinetics.StableRNGs
 
 module MKTestUtilities
 


### PR DESCRIPTION
I got these updates ready, but I'm finding there are a few glitches with Julia-1.11.0 (it seems to crash when I try to use the `pkg>` interface from the REPL). There seems to be a fix for that problem which will be released in 1.11.1, so probably best to hold off on merging this at least until 1.11.1 is released.