### PR TITLE
Reduce length of "run_name" in restart_interpolation_tests.jl

### DIFF
--- a/moment_kinetics/test/restart_interpolation_tests.jl
+++ b/moment_kinetics/test/restart_interpolation_tests.jl
@@ -108,7 +108,7 @@ function run_test(test_input, base, message, rtol, atol; tol_3V, args...)
         name = name[1:60]
     end
     if parallel_io
-        name *= "parallel-io"
+        name *= "p-io"
     end
 
     # Provide some progress info


### PR DESCRIPTION
Avoids filename-too-long errors on Github Actions servers.