### PR TITLE
Fix length of t dimension for timing variables

### DIFF
--- a/moment_kinetics/src/file_io.jl
+++ b/moment_kinetics/src/file_io.jl
@@ -2735,7 +2735,10 @@ function write_timing_data(io_moments, t_idx, dfns=false)
             # If we got the length of `time:$this_name`, the variable might have
             # the wrong length (e.g. if it has only just been created and has
             # length 1).
-            t_idx = length(io_group["time:" * first(keys(timer_names_all_ranks))])
+            length_check_var = io_group["time:" * first(keys(timer_names_all_ranks))]
+            this_t_idx = size(length_check_var, ndims(length_check_var))
+        else
+            this_t_idx = t_idx
         end
         if parallel_io
             timer_coord = (local_io_range=1:block_size[],
@@ -2748,12 +2751,12 @@ function write_timing_data(io_moments, t_idx, dfns=false)
             io_time = io_group["time:" * this_name]
             io_ncalls = io_group["ncalls:" * this_name]
             io_allocs = io_group["allocs:" * this_name]
-            @views append_to_dynamic_var(io_time, gathered_times_data[counter,:], t_idx,
-                                         parallel_io, timer_coord)
+            @views append_to_dynamic_var(io_time, gathered_times_data[counter,:],
+                                         this_t_idx, parallel_io, timer_coord)
             @views append_to_dynamic_var(io_ncalls, gathered_ncalls_data[counter,:],
-                                         t_idx, parallel_io, timer_coord)
+                                         this_t_idx, parallel_io, timer_coord)
             @views append_to_dynamic_var(io_allocs, gathered_allocs_data[counter,:],
-                                         t_idx, parallel_io, timer_coord)
+                                         this_t_idx, parallel_io, timer_coord)
             counter += 1
             for (sub_name, sub_dict) ∈ pairs(names_dict)
                 write_level(sub_dict, this_name * ";" * sub_name)


### PR DESCRIPTION
#292 introduced a bug, where the length of the time dimension was not set correctly. Especially on large numbers of cores, this could make output files very large. Bug is fixed by this PR.