### PR TITLE
In tests, get StatsBase dependency from moment_kinetics package

### DIFF
--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -5,6 +5,7 @@ module moment_kinetics
 export run_moment_kinetics
 
 using MPI
+using StatsBase
 
 # Include submodules from other source files
 # Note that order of includes matters - things used in one module must already

--- a/moment_kinetics/test/jacobian_matrix_tests.jl
+++ b/moment_kinetics/test/jacobian_matrix_tests.jl
@@ -36,7 +36,7 @@ using moment_kinetics.moment_constraints: electron_implicit_constraint_forcing!,
 using moment_kinetics.type_definitions: mk_float
 using moment_kinetics.velocity_moments: calculate_electron_moment_derivatives_no_r!
 
-using StatsBase
+using moment_kinetics.StatsBase
 
 # Small parameter used to create perturbations to test Jacobian against
 epsilon = 1.0e-6


### PR DESCRIPTION
Avoids need to install StatsBase directly in base environment.