### PR TITLE
'Auto' bounds checks for 'long tests' CI job

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -30,5 +30,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project=moment_kinetics/ -e 'import Pkg; Pkg.test(; test_args=["--ci", "--long", "--force-optional-dependencies"])'
+          julia --color=yes --depwarn=yes --project=moment_kinetics/ -e 'import Pkg; Pkg.test(; test_args=["--ci", "--long", "--force-optional-dependencies"], julia_args=["--check-bounds=auto"])'
         shell: bash


### PR DESCRIPTION
Try to avoid timeout causing tests to fail. Possibly with Julia-1.11.x, `--check-bounds=yes` runs have become significantly slower than with Julia-1.10.x, so going back to `--check-bounds=auto` might help significantly?