### PR TITLE
Include @views to reduce allocations in electron functions

### DIFF
--- a/moment_kinetics/src/electron_vpa_advection.jl
+++ b/moment_kinetics/src/electron_vpa_advection.jl
@@ -81,7 +81,7 @@ function update_electron_speed_vpa!(advect, density, upar, ppar, moments, vpa,
                         ppar[iz] +
                     0.5 * source_density_amplitude[iz] / density[iz]
                 @loop_vperp ivperp begin
-                    @. speed[:,ivperp,iz] += term1 + vpa * term2_over_vpa
+                    @views @. speed[:,ivperp,iz] += term1 + vpa * term2_over_vpa
                 end
             end
         end

--- a/moment_kinetics/src/external_sources.jl
+++ b/moment_kinetics/src/external_sources.jl
@@ -1057,7 +1057,7 @@ Note that this function operates on a single point in `r`, given by `ir`, and `p
             # Factor of 1/sqrt(π) (for 1V) or 1/π^(3/2) (for 2V/3V) is absorbed by the
             # normalisation of F
             vperp_unnorm = vperp_grid[ivperp] * this_vth
-            @. pdf_out[:,ivperp,iz] +=
+            @views @. pdf_out[:,ivperp,iz] +=
                 this_prefactor *
                 exp(-(vperp_unnorm^2 + (vpa_grid * this_vth + this_upar)^2) * me_over_mi / source_T)
         end
@@ -1065,9 +1065,9 @@ Note that this function operates on a single point in `r`, given by `ir`, and `p
 
     if electron_source.source_type == "energy"
         # Take particles out of pdf so source does not change density
-        @loop_z_vperp_vpa iz ivperp ivpa begin
-            pdf_out[ivpa,ivperp,iz] -= dt * source_amplitude[iz] *
-                                            pdf_in[ivpa,ivperp,iz]
+        @loop_z_vperp iz ivperp begin
+            @views @. pdf_out[:,ivperp,iz] -= dt * source_amplitude[iz] *
+                                              pdf_in[:,ivperp,iz]
         end
     end
 


### PR DESCRIPTION
Not sure why these lines cannot get to zero allocations, might be a 'bug' in the Julia compiler...