### PR TITLE
Script to get the Jacobian matrix for a kinetic electron solve

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -4,7 +4,7 @@ name: Check test_scripts
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  examples:
+  check-test-scripts:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,4 +22,4 @@ jobs:
         run: |
           touch Project.toml
           julia -O3 --project -e 'import Pkg; Pkg.develop(path="moment_kinetics/"); Pkg.add(["FastGaussQuadrature", "LaTeXStrings", "LegendrePolynomials", "Measures", "MPI", "Plots", "SpecialFunctions"]); Pkg.precompile()'
-          julia -O3 --project -e 'include("test_scripts/2D_FEM_assembly_test.jl"); run_assembly_test(); include("test_scripts/chebyshev_radau_test.jl"); chebyshevradau_test(); include("test_scripts/fkpl_direct_integration_test.jl"); test_rosenbluth_potentials_direct_integration(); include("test_scripts/GaussLobattoLegendre_test.jl"); gausslegendre_test(); include("test_scripts/gyroaverage_test.jl"); gyroaverage_test()'
+          julia -O3 --project -e 'include("test_scripts/2D_FEM_assembly_test.jl"); run_assembly_test(); include("test_scripts/chebyshev_radau_test.jl"); chebyshevradau_test(); include("test_scripts/fkpl_direct_integration_test.jl"); test_rosenbluth_potentials_direct_integration(); include("test_scripts/GaussLobattoLegendre_test.jl"); gausslegendre_test(); include("test_scripts/gyroaverage_test.jl"); gyroaverage_test(); include("test_scripts/check-MKJacobianUtils.jl")'

--- a/docs/make-pdf.jl
+++ b/docs/make-pdf.jl
@@ -20,6 +20,7 @@ Pkg.instantiate()
 using Documenter
 using Glob
 using moment_kinetics, makie_post_processing, plots_post_processing
+include("../util/MKJacobianUtils.jl")
 
 doc_files = glob("src/*.md")
 
@@ -35,7 +36,7 @@ end
 makedocs(
     sitename = "momentkinetics",
     format = Documenter.LaTeX(; latex_kwargs...),
-    modules = [moment_kinetics, makie_post_processing, plots_post_processing],
+    modules = [moment_kinetics, makie_post_processing, plots_post_processing, MKJacobianUtils],
     authors = "M. Barnes, J.T. Omotani, M. Hardman",
     pages = doc_files
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ Pkg.instantiate()
 
 using Documenter, UUIDs
 using moment_kinetics, makie_post_processing, plots_post_processing
+include("../util/MKJacobianUtils.jl")
 
 makedocs(
     sitename = "moment_kinetics",
@@ -18,7 +19,7 @@ makedocs(
                              # that would be used by default by Documenter.jl.
                              inventory_version = Pkg.dependencies()[UUID("b5ff72cc-06fc-4161-ad14-dba1c22ed34e")].version,
                             ),
-    modules = [moment_kinetics, makie_post_processing, plots_post_processing],
+    modules = [moment_kinetics, makie_post_processing, plots_post_processing, MKJacobianUtils],
 )
 
 if get(ENV, "CI", nothing) == "true"

--- a/docs/src/zz_MKJacobianUtils.md
+++ b/docs/src/zz_MKJacobianUtils.md
@@ -1,0 +1,6 @@
+`MKJacobianUtils`
+=================
+
+```@autodocs
+Modules = [MKJacobianUtils]
+```

--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -214,7 +214,8 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
                          debug_loop_type::Union{Nothing,NTuple{N,Symbol} where N}=nothing,
                          debug_loop_parallel_dims::Union{Nothing,NTuple{N,Symbol} where N}=nothing,
                          skip_electron_solve::Bool=false,
-                         write_output::Bool=true) = begin
+                         write_output::Bool=true,
+                         warn_unexpected_input::Bool=false) = begin
 
     setup_start_time = now()
 
@@ -226,7 +227,8 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
         flush(stdout)
     end
 
-    input = mk_input(input_dict; save_inputs_to_txt=true, ignore_MPI=false)
+    input = mk_input(input_dict; save_inputs_to_txt=true, ignore_MPI=false,
+                     warn_unexpected=warn_unexpected_input)
     # obtain input options from moment_kinetics_input.jl
     # and check input to catch errors
     io_input, evolve_moments, t_input, z, z_spectral, r, r_spectral, vpa, vpa_spectral,

--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -213,7 +213,8 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
                          restart_time_index::mk_int=-1,
                          debug_loop_type::Union{Nothing,NTuple{N,Symbol} where N}=nothing,
                          debug_loop_parallel_dims::Union{Nothing,NTuple{N,Symbol} where N}=nothing,
-                         skip_electron_solve::Bool=false) = begin
+                         skip_electron_solve::Bool=false,
+                         write_output::Bool=true) = begin
 
     setup_start_time = now()
 
@@ -354,26 +355,34 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
     # output file
     setup_end_time = now()
     time_for_setup = to_minutes(setup_end_time - setup_start_time)
-    # setup i/o
-    ascii_io, io_moments, io_dfns = setup_file_io(io_input, boundary_distributions, vz,
-        vr, vzeta, vpa, vperp, z, r, composition, collisions, moments.evolve_density,
-        moments.evolve_upar, moments.evolve_ppar, external_source_settings, input_dict,
-        restart_time_index, previous_runs_info, time_for_setup, t_params,
-        nl_solver_params)
-    # write initial data to ascii files
-    write_data_to_ascii(pdf, moments, fields, vz, vr, vzeta, vpa, vperp, z, r,
-        t_params.t[], composition.n_ion_species, composition.n_neutral_species, ascii_io)
-    # write initial data to binary files
 
-    t_params.moments_output_counter[] += 1
-    write_all_moments_data_to_binary(scratch, moments, fields, composition.n_ion_species,
-        composition.n_neutral_species, io_moments, t_params.moments_output_counter[], 0.0,
-        t_params, nl_solver_params, r, z)
-    t_params.dfns_output_counter[] += 1
-    write_all_dfns_data_to_binary(scratch, scratch_electron, moments, fields,
-        composition.n_ion_species, composition.n_neutral_species, io_dfns,
-        t_params.dfns_output_counter[], 0.0, t_params, nl_solver_params, r, z, vperp, vpa,
-        vzeta, vr, vz)
+    if write_output
+        # setup i/o
+        ascii_io, io_moments, io_dfns = setup_file_io(io_input, boundary_distributions,
+            vz, vr, vzeta, vpa, vperp, z, r, composition, collisions,
+            moments.evolve_density, moments.evolve_upar, moments.evolve_ppar,
+            external_source_settings, input_dict, restart_time_index, previous_runs_info,
+            time_for_setup, t_params, nl_solver_params)
+        # write initial data to ascii files
+        write_data_to_ascii(pdf, moments, fields, vz, vr, vzeta, vpa, vperp, z, r,
+            t_params.t[], composition.n_ion_species, composition.n_neutral_species,
+            ascii_io)
+        # write initial data to binary files
+
+        t_params.moments_output_counter[] += 1
+        write_all_moments_data_to_binary(scratch, moments, fields,
+            composition.n_ion_species, composition.n_neutral_species, io_moments,
+            t_params.moments_output_counter[], 0.0, t_params, nl_solver_params, r, z)
+        t_params.dfns_output_counter[] += 1
+        write_all_dfns_data_to_binary(scratch, scratch_electron, moments, fields,
+            composition.n_ion_species, composition.n_neutral_species, io_dfns,
+            t_params.dfns_output_counter[], 0.0, t_params, nl_solver_params, r, z, vperp,
+            vpa, vzeta, vr, vz)
+    else
+        ascii_io = nothing
+        io_moments = nothing
+        io_dfns = nothing
+    end
 
     begin_s_r_z_vperp_region()
 

--- a/test_scripts/check-MKJacobianUtils.jl
+++ b/test_scripts/check-MKJacobianUtils.jl
@@ -1,0 +1,81 @@
+# Script to test that get_electron_Jacobian_matrix() function runs. Uses very low
+# resolution input, so results are likely to be garbage.
+
+using moment_kinetics
+using moment_kinetics.type_definitions: OptionsDict
+
+include("../util/MKJacobianUtils.jl")
+
+# Create a temporary directory for test output
+test_output_directory = tempname()
+mkpath(test_output_directory)
+
+input = OptionsDict("output" => OptionsDict("run_name" => "precompilation",
+                                            "base_directory" => test_output_directory),
+                    "evolve_moments" => OptionsDict("density" => true,
+                                                    "parallel_flow" => true,
+                                                    "parallel_pressure" => true),
+                    "composition" => OptionsDict("electron_physics" => "kinetic_electrons"),
+                    "r" => OptionsDict("ngrid" => 1,
+                                       "nelement" => 1,
+                                       "bc" => "periodic",
+                                       "discretization" => "gausslegendre_pseudospectral"),
+                    "z" => OptionsDict("ngrid" => 5,
+                                       "nelement" => 4,
+                                       "bc" => "wall",
+                                       "discretization" => "gausslegendre_pseudospectral"),
+                    "vperp" => OptionsDict("ngrid" => 1,
+                                           "nelement" => 1,
+                                           "bc" => "zero",
+                                           "L" => 4.0,
+                                           "discretization" => "gausslegendre_pseudospectral"),
+                    "vpa" => OptionsDict("ngrid" => 7,
+                                         "nelement" => 8,
+                                         "bc" => "zero",
+                                         "L" => 8.0,
+                                         "discretization" => "gausslegendre_pseudospectral"),
+                    "vzeta" => OptionsDict("ngrid" => 1,
+                                           "nelement" => 1,
+                                           "bc" => "zero",
+                                           "L" => 4.0,
+                                           "discretization" => "gausslegendre_pseudospectral"),
+                    "vr" => OptionsDict("ngrid" => 1,
+                                        "nelement" => 1,
+                                        "bc" => "zero",
+                                        "L" => 4.0,
+                                        "discretization" => "gausslegendre_pseudospectral"),
+                    "vz" => OptionsDict("ngrid" => 7,
+                                        "nelement" => 8,
+                                        "bc" => "zero",
+                                        "L" => 8.0,
+                                        "discretization" => "gausslegendre_pseudospectral"),
+                    "timestepping" => OptionsDict("type" => "KennedyCarpenterARK324",
+                                                  "nstep" => 1,
+                                                  "dt" => 2.0e-11),
+                    "electron_timestepping" => OptionsDict("nstep" => 1,
+                                                           "dt" => 2.0e-11,
+                                                           "initialization_residual_value" => 1.0e10,
+                                                           "converged_residual_value" => 1.0e10,
+                                                           "rtol" => 1.0e10,
+                                                           "no_restart" => true))
+
+
+run_moment_kinetics(input)
+
+run_directory = joinpath(input["output"]["base_directory"], input["output"]["run_name"])
+
+# Run with all terms
+get_electron_Jacobian_matrix(run_directory)
+
+# Run each term individually
+get_electron_Jacobian_matrix(run_directory; include_z_advection=true)
+get_electron_Jacobian_matrix(run_directory; include_vpa_advection=true)
+get_electron_Jacobian_matrix(run_directory; include_electron_pdf_term=true)
+get_electron_Jacobian_matrix(run_directory; include_dissipation=true)
+get_electron_Jacobian_matrix(run_directory; include_krook=true)
+get_electron_Jacobian_matrix(run_directory; include_external_source=true)
+get_electron_Jacobian_matrix(run_directory; include_constraint_forcing=true)
+get_electron_Jacobian_matrix(run_directory; include_energy_equation=true)
+get_electron_Jacobian_matrix(run_directory; include_ion_dt_forcing=true)
+get_electron_Jacobian_matrix(run_directory; include_wall_bc=true)
+nothing

--- a/util/MKJacobianUtils.jl
+++ b/util/MKJacobianUtils.jl
@@ -1,0 +1,288 @@
+# Import SparseArrays so that we can use the package after `include()`'ing this script.
+using SparseArrays
+
+module MKJacobianUtils
+
+export get_electron_Jacobian_matrix
+
+using moment_kinetics
+using moment_kinetics.array_allocation: allocate_shared_float
+using moment_kinetics.derivatives: derivative_z!
+using moment_kinetics.electron_kinetic_equation: fill_electron_kinetic_equation_Jacobian!,
+                                                 add_electron_z_advection_to_Jacobian!,
+                                                 add_electron_vpa_advection_to_Jacobian!,
+                                                 add_contribution_from_electron_pdf_term_to_Jacobian!,
+                                                 add_electron_dissipation_term_to_Jacobian!,
+                                                 add_ion_dt_forcing_of_electron_ppar_to_Jacobian!,
+                                                 add_total_external_electron_source_to_Jacobian!,
+                                                 add_electron_energy_equation_to_Jacobian!,
+                                                 add_ion_dt_forcing_of_electron_ppar_to_Jacobian!
+using moment_kinetics: setup_moment_kinetics
+using moment_kinetics.load_data: open_readonly_output_file, load_input
+using moment_kinetics.looping
+
+"""
+    get_electron_Jacobian_matrix(run_directory; restart_time_index=1,
+                                 restart_index=nothing,
+                                 include_z_advection=true,
+                                 include_vpa_advection=true,
+                                 include_electron_pdf_term=true,
+                                 include_dissipation=true,
+                                 include_krook=true,
+                                 include_external_source=true,
+                                 include_constraint_forcing=true,
+                                 include_energy_equation=true,
+                                 include_ion_dt_forcing=true)
+
+Calculate and return a Jacobian matrix for the kinetic electron solve.
+
+To use this function, first include the script containing it
+```julia
+include("util/MKJacobianUtils.jl")
+```
+then you can call the function.
+
+To avoid extreme behaviour due to an arbitrary initial condition, this script expects to
+'restart' from an existing simulation. By default it returns the Jacobian matrix that
+would be used at the start of the first ion timestep (after the initialisation stage where
+electrons are relaxed towards steady state treating the ions as a fixed background).
+
+`run_directory` is the path to the directory where the run to 'restart' from is stored.
+
+`restart_time_index` can be passed an integer value if you want the Jacobian for an output
+step other than the initial one. `restart_time_index=-1` would give the final time point
+of the simulation in `run_directory`.
+
+If there were multiple restarts of the simulation in `run_directory`, `restart_index` can
+be used to select which restart to read from. Reads from the latest one by default.
+Numerical values can only be used for restarts before the latest one - e.g. if the run was
+not restarted, `restart_index=1` is not valid, only the default `restart_index=nothing`
+can be used.
+
+The `include_*` arguments can be used to select which particular terms to include in the
+Jacobian. By default all terms are included.
+"""
+function get_electron_Jacobian_matrix(run_directory; restart_time_index=1,
+                                      restart_index=nothing,
+                                      include_z_advection=true,
+                                      include_vpa_advection=true,
+                                      include_electron_pdf_term=true,
+                                      include_dissipation=true,
+                                      include_krook=true,
+                                      include_external_source=true,
+                                      include_constraint_forcing=true,
+                                      include_energy_equation=true,
+                                      include_ion_dt_forcing=true,
+                                      include_wall_bc=true)
+
+    # Read the simulation input from the output file, to ensure we are consistent with
+    # what was run.
+    ##################################################################################
+    if isfile(run_directory)
+        # run_directory is actually a filename. Assume it is a moment_kinetics output file
+        # and infer the directory and the run_name from the filename.
+
+        filename = basename(run_directory)
+        run_directory = dirname(run_directory)
+
+        if occursin(".moments.", filename)
+            run_name = split(filename, ".moments.")[1]
+        elseif occursin(".dfns.", filename)
+            run_name = split(filename, ".dfns.")[1]
+        elseif occursin(".initial_electron.", filename)
+            run_name = split(filename, ".initial_electron.")[1]
+        elseif occursin(".electron_debug.", filename)
+            run_name = split(filename, ".electron_debug.")[1]
+            electron_debug = true
+        else
+            error("Cannot recognise '$run_directory/$filename' as a moment_kinetics output file")
+        end
+    elseif isdir(run_directory)
+        # Normalise by removing any trailing slash - with a slash basename() would return an
+        # empty string
+        run_directory = rstrip(run_directory, '/')
+
+        run_name = basename(run_directory)
+    else
+        error("$run_directory does not exist")
+    end
+    base_prefix = joinpath(run_directory, run_name)
+    if restart_index === nothing
+        run_prefix = base_prefix
+    elseif restart_index > 0
+        run_prefix = base_prefix * "_$restart_index"
+    else
+        error("Invalid restart_index=$restart_index")
+    end
+    restart_file = open_readonly_output_file(run_prefix, "dfns", printout=false)
+    input = load_input(restart_file)
+    close(restart_file)
+
+    # For now, just run in serial. Need to figure out how to bodge this to get partial
+    # matrices for domain-decomposed case...
+    input["z"]["nelement_local"] = input["z"]["nelement"]
+
+    # Make the output directory a temporary directory to avoid moving around files in the
+    # run's directory, which would otherwise happen because we are 'restarting' the run.
+    temp_dir = tempname()
+    mkpath(temp_dir)
+    input["output"]["base_directory"] = temp_dir
+
+    # Get the profiles to use from the output files. For `restart_time_index=1` these are
+    # the initial profiles, but after the inital relaxation of electrons on a fixed ion
+    # background. The 'inital' ion profiles will usually be the final state of a Boltzmann
+    # electron simulation.
+    mk_state = setup_moment_kinetics(input; restart=run_prefix * ".dfns.h5",
+                                     restart_time_index=restart_time_index,
+                                     write_output=false, warn_unexpected_input=true)
+
+    # Extract separate variables from mk_state Tuple
+    pdf, scratch, scratch_implicit, scratch_electron, t_params, vz, vr, vzeta, vpa, vperp,
+        gyrophase, z, r, moments, fields, spectral_objects, advect_objects, composition,
+        collisions, geometry, gyroavs, boundary_distributions, external_source_settings,
+        num_diss_params, nl_solver_params, advance, advance_implicit, fp_arrays,
+        scratch_dummy, manufactured_source_list, ascii_io, io_moments, io_dfns = mk_state
+
+    # Allocate an array for the Jacobian matrix
+    pdf_size = length(pdf.electron.norm)
+    ppar_size = length(moments.electron.ppar)
+    jacobian_size = pdf_size + ppar_size
+    jacobian_matrix = allocate_shared_float(jacobian_size, jacobian_size)
+
+    # Fill the Jacobian matrix with the chosen terms
+    ################################################
+
+    # r-index - assume this is always 1 because we only consider 1D simulations
+    ir = 1
+
+    # Ion timestep within the first Runge-Kutta stage (t_params.dt[] is the length of the
+    # full Runge-Kutta timestep).
+    ion_dt = t_params.dt[] * t_params.rk_coefs_implicit[1,1]
+
+    f = @view pdf.electron.norm[:,:,:,ir]
+    ppar = @view moments.electron.ppar[:,ir]
+    dens = @view moments.electron.dens[:,ir]
+    upar = @view moments.electron.upar[:,ir]
+    vth = @view moments.electron.vth[:,ir]
+    qpar = @view moments.electron.qpar[:,ir]
+    me = composition.me_over_mi
+    dt = t_params.electron.dt[]
+    ddens_dz = @view moments.electron.ddens_dz[:,ir]
+    dppar_dz = @view moments.electron.dppar_dz[:,ir]
+    dqpar_dz = @view moments.electron.dqpar_dz[:,ir]
+
+    z_spectral = spectral_objects.z_spectral
+    vpa_spectral = spectral_objects.vpa_spectral
+    vperp_spectral = spectral_objects.vperp_spectral
+
+    z_advect = advect_objects.z_advect
+    vpa_advect = advect_objects.vpa_advect
+
+    # Reconstruct w_∥^3 moment of g_e from already-calculated qpar
+    third_moment = scratch_dummy.buffer_z_1
+    dthird_moment_dz = scratch_dummy.buffer_z_2
+    buffer_1 = @view scratch_dummy.buffer_rs_1[ir,1]
+    buffer_2 = @view scratch_dummy.buffer_rs_2[ir,1]
+    buffer_3 = @view scratch_dummy.buffer_rs_3[ir,1]
+    buffer_4 = @view scratch_dummy.buffer_rs_4[ir,1]
+    begin_z_region()
+    @loop_z iz begin
+        third_moment[iz] = 0.5 * qpar[iz] / ppar[iz] / vth[iz]
+    end
+    derivative_z!(dthird_moment_dz, third_moment, buffer_1, buffer_2,
+                  buffer_3, buffer_4, z_spectral, z)
+
+    if all([include_z_advection, include_vpa_advection, include_electron_pdf_term,
+            include_dissipation, include_krook, include_external_source,
+            include_constraint_forcing, include_energy_equation, include_ion_dt_forcing])
+        fill_electron_kinetic_equation_Jacobian!(
+            jacobian_matrix, f, ppar, moments, fields.phi, collisions, composition, z,
+            vperp, vpa, z_spectral, vperp_spectral, vpa_spectral, z_advect, vpa_advect,
+            scratch_dummy, external_source_settings, num_diss_params, t_params.electron,
+            ion_dt, ir, true)
+    else
+        # Allow any combination of terms, selected by the include_* flags
+
+        z_speed = @view z_advect[1].speed[:,:,:,ir]
+        dpdf_dz = @view scratch_dummy.buffer_vpavperpzr_1[:,:,:,ir]
+        begin_vperp_vpa_region()
+        update_electron_speed_z!(z_advect[1], upar, vth, vpa.grid, ir)
+        @loop_vperp_vpa ivperp ivpa begin
+            @views z_advect[1].adv_fac[:,ivpa,ivperp,ir] = -z_speed[:,ivpa,ivperp]
+        end
+        #calculate the upwind derivative
+        @views derivative_z_pdf_vpavperpz!(dpdf_dz, f, z_advect[1].adv_fac[:,:,:,ir],
+                                           scratch_dummy.buffer_vpavperpr_1[:,:,ir],
+                                           scratch_dummy.buffer_vpavperpr_2[:,:,ir],
+                                           scratch_dummy.buffer_vpavperpr_3[:,:,ir],
+                                           scratch_dummy.buffer_vpavperpr_4[:,:,ir],
+                                           scratch_dummy.buffer_vpavperpr_5[:,:,ir],
+                                           scratch_dummy.buffer_vpavperpr_6[:,:,ir],
+                                           z_spectral, z)
+
+        if include_z_advection
+            add_electron_z_advection_to_Jacobian!(
+                jacobian_matrix, f, dens, upar, ppar, vth, dpdf_dz, me, z, vperp, vpa,
+                z_spectral, z_advect, z_speed, scratch_dummy, dt, ir;
+                ppar_offset=pdf_size)
+        end
+        if include_vpa_advection
+            add_electron_vpa_advection_to_Jacobian!(
+                jacobian_matrix, f, dens, upar, ppar, vth, third_moment, dpdf_dz,
+                ddens_dz, dppar_dz, dthird_moment_dz, moments, me, z, vperp, vpa,
+                z_spectral, vpa_spectral, vpa_advect, z_speed, scratch_dummy,
+                external_source_settings, dt, ir; ppar_offset=pdf_size)
+        end
+        if include_electron_pdf_term
+            add_contribution_from_electron_pdf_term_to_Jacobian!(
+                jacobian_matrix, f, dens, upar, ppar, vth, third_moment, ddens_dz,
+                dppar_dz, dvth_dz, dqpar_dz, dthird_moment_dz, moments, me,
+                external_source_settings, z, vperp, vpa, z_spectral, z_speed,
+                scratch_dummy, dt, ir; ppar_offset=pdf_size)
+        end
+        if include_dissipation
+            add_electron_dissipation_term_to_Jacobian!(
+                jacobian_matrix, f, num_diss_params, z, vperp, vpa, vpa_spectral, z_speed,
+                dt, ir)
+        end
+        if include_krook
+            add_electron_krook_collisions_to_Jacobian!(
+                jacobian_matrix, f, dens, upar, ppar, vth, upar_ion, collisions, z, vperp,
+                vpa, z_speed, dt, ir; ppar_offset=pdf_size)
+        end
+        if include_external_source
+            add_total_external_electron_source_to_Jacobian!(
+                jacobian_matrix, f, moments, me, z_speed,
+                external_source_settings.electron, z, vperp, vpa, dt, ir;
+                ppar_offset=pdf_size)
+        end
+        if include_constraint_forcing
+            add_electron_implicit_constraint_forcing_to_Jacobian!(
+                jacobian_matrix, f, z_speed, z, vperp, vpa,
+                t_params.constraint_forcing_rate, dt, ir)
+        end
+        if include_energy_equation
+            add_electron_energy_equation_to_Jacobian!(
+                jacobian_matrix, f, dens, upar, ppar, vth, third_moment, ddens_dz,
+                dupar_dz, dppar_dz, dthird_moment_dz, collisions, composition, z, vperp,
+                vpa, z_spectral, num_diss_params, dt, ir; ppar_offset=pdf_size)
+        end
+        if include_ion_dt_forcing && ion_dt !== nothing
+            add_ion_dt_forcing_of_electron_ppar_to_Jacobian!(
+                jacobian_matrix, z, dt, ion_dt, ir; ppar_offset=pdf_size)
+        end
+        if include_wall_bc && t_params.electron.include_wall_bc_in_preconditioner
+            add_wall_boundary_condition_to_Jacobian!(
+                jacobian_matrix, fields.phi, f, ppar, vth, upar, z, vperp, vpa,
+                vperp_spectral, vpa_spectral, vpa_advect, moments,
+                num_diss_params.electron.vpa_dissipation_coefficient, me, ir;
+                ppar_offset=pdf_size)
+        end
+    end
+
+    return jacobian_matrix
+end
+
+end # MKJacobianUtils
+
+using .MKJacobianUtils


### PR DESCRIPTION
It might be useful to inspect the Jacobian matrix that is used as a preconditioner for the kinetic electron solve. This PR adds a function to do this, which takes as input an existing kinetic electron simulation, assuming that it is most interesting to look at a 'typical' matrix from a somewhat settled-down simulation rather than one just produced by arbitrary initial conditions. To use:
```julia
julia> include("util/MKJacobianUtils.jl")
julia> J = get_electron_Jacobian_matrix(run_dir)
```
where `run_dir` is the path to the simulation to restart from. For more details [see the docs](https://mabarnes.github.io/moment_kinetics/previews/PR319/zz_MKJacobianUtils/#Main.MKJacobianUtils.get_electron_Jacobian_matrix-Tuple{Any}).