### PR TITLE
Install NCDatasets in 'debug checks' CI test

### DIFF
--- a/.github/workflows/debug_checks.yml
+++ b/.github/workflows/debug_checks.yml
@@ -28,9 +28,7 @@ jobs:
           sed -i -e "s/_debug_level = get_options.*/_debug_level = 2/" moment_kinetics/src/debugging.jl
 
           touch Project.toml
-          # Not sure why installing "NCDatasets" fails at the moment (8/10/2024), but precompilation hangs for this job if it is included, so skip for now.
-          #julia --project -O3 --check-bounds=yes -e 'using Pkg; Pkg.add(["MPI", "MPIPreferences", "NCDatasets", "PackageCompiler", "Symbolics"]); using MPIPreferences; MPIPreferences.use_jll_binary("OpenMPI_jll")'
-          julia --project -O3 --check-bounds=yes -e 'using Pkg; Pkg.add(["MPI", "MPIPreferences", "PackageCompiler", "Symbolics"]); using MPIPreferences; MPIPreferences.use_jll_binary("OpenMPI_jll")'
+          julia --project -O3 --check-bounds=yes -e 'using Pkg; Pkg.add(["MPI", "MPIPreferences", "NCDatasets", "PackageCompiler", "Symbolics"]); using MPIPreferences; MPIPreferences.use_jll_binary("OpenMPI_jll")'
           julia --project -O3 --check-bounds=yes -e 'using MPI; MPI.install_mpiexecjl(; destdir=".")'
           julia --project -O3 --check-bounds=yes -e 'using Pkg; Pkg.develop(path="moment_kinetics/"); Pkg.precompile()'
           julia --project -O3 --check-bounds=yes precompile-with-check-bounds.jl --debug 2


### PR DESCRIPTION
HDF5 fails to precompile when using OpenMPI_jll unless NCDatasets is also installed. NCDatasets was originally removed from the 'debug checks' CI test only because it didn't work for some reason, so makes sense to add it back now that it works again on the CI server, and for some strange reason helps HDF5 to precompile (https://github.com/JuliaIO/HDF5.jl/issues/1191).