### PR TITLE
Disable cache in documentation workflow

### DIFF
--- a/.github/workflows/debug_checks.yml
+++ b/.github/workflows/debug_checks.yml
@@ -3,6 +3,10 @@ name: Debug checks for correctness
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   debug-checks:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,10 @@ on:
     tags: '*'
   pull_request:
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,10 +7,6 @@ on:
     tags: '*'
   pull_request:
 
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,7 +15,6 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.11'
-      - uses: julia-actions/cache@v2
       - name: Install dependencies
         run: |
           # Version 3.9.0 of matplotlib causes an error with PyPlot.jl, so pin

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,6 +3,10 @@ name: Check examples
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   examples:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -8,6 +8,10 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -3,6 +3,10 @@ name: Check test_scripts
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   check-test-scripts:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Even after clearing the cache manually, the documentation workflow still fails unless we remove the julia-actions/cache action entirely. Don't understand why - error seems to be something to do with Conda.