### PR TITLE
Convert _block_synchronize() and begin_*_region() to macros, more efficient debug check for synchronization consistency

### DIFF
--- a/moment_kinetics/src/analysis.jl
+++ b/moment_kinetics/src/analysis.jl
@@ -681,7 +681,7 @@ function steady_state_square_residuals(variable, variable_at_previous_time, dt,
         t_dim = ndims(variable)
     end
     if use_mpi
-        begin_r_z_region()
+        @begin_r_z_region()
         if !only_max_abs && variable_max === nothing
             local_max = 0.0
             @loop_r_z ir iz begin

--- a/moment_kinetics/src/array_allocation.jl
+++ b/moment_kinetics/src/array_allocation.jl
@@ -7,7 +7,7 @@ export allocate_float, allocate_int, allocate_complex, allocate_bool, allocate_s
 using ..type_definitions: mk_float, mk_int
 using ..communication
 using ..debugging
-@debug_initialize_NaN using ..communication: block_rank, _block_synchronize
+@debug_initialize_NaN using ..communication: block_rank
 
 using MPI
 

--- a/moment_kinetics/src/boundary_conditions.jl
+++ b/moment_kinetics/src/boundary_conditions.jl
@@ -28,7 +28,7 @@ also enforce boundary conditions in z on all separately evolved velocity space m
                          vperp_adv, z_adv, r_adv, composition, scratch_dummy, r_diffusion,
                          vpa_diffusion, vperp_diffusion) = begin
     if vpa.n > 1
-        begin_s_r_z_vperp_region()
+        @begin_s_r_z_vperp_region()
         @loop_s_r_z_vperp is ir iz ivperp begin
             # enforce the vpa BC
             # use that adv.speed independent of vpa
@@ -38,12 +38,12 @@ also enforce boundary conditions in z on all separately evolved velocity space m
         end
     end
     if vperp.n > 1
-        begin_s_r_z_vpa_region()
+        @begin_s_r_z_vpa_region()
         enforce_vperp_boundary_condition!(f, vperp.bc, vperp, vperp_spectral,
                              vperp_adv, vperp_diffusion)
     end
     if z.n > 1
-        begin_s_r_vperp_vpa_region()
+        @begin_s_r_vperp_vpa_region()
         # enforce the z BC on the evolved velocity space moments of the pdf
         enforce_z_boundary_condition_moments!(density, moments, z_bc)
         enforce_z_boundary_condition!(f, density, upar, ppar, phi, moments, z_bc, z_adv, z,
@@ -55,7 +55,7 @@ also enforce boundary conditions in z on all separately evolved velocity space m
 
     end
     if r.n > 1
-        begin_s_z_vperp_vpa_region()
+        @begin_s_z_vperp_vpa_region()
         enforce_r_boundary_condition!(f, f_r_bc, r_bc, r_adv, vpa, vperp, z, r,
                                       composition, scratch_dummy.buffer_vpavperpzs_1,
                                       scratch_dummy.buffer_vpavperpzs_2,
@@ -145,7 +145,7 @@ function enforce_z_boundary_condition!(pdf, density, upar, ppar, phi, moments, b
     # 'constant' BC is time-independent f at upwind boundary
     # and constant f beyond boundary
     if bc == "constant"
-        begin_s_r_vperp_vpa_region()
+        @begin_s_r_vperp_vpa_region()
         density_offset = 1.0
         vwidth = 1.0
         if z.irank == 0
@@ -188,7 +188,7 @@ function enforce_z_boundary_condition!(pdf, density, upar, ppar, phi, moments, b
         end
     # 'periodic' BC enforces periodicity by taking the average of the boundary points
     elseif bc == "periodic" && z.nelement_global == z.nelement_local
-        begin_s_r_vperp_vpa_region()
+        @begin_s_r_vperp_vpa_region()
         @loop_s_r_vperp_vpa is ir ivperp ivpa begin
             pdf[ivpa,ivperp,1,ir,is] = 0.5*(pdf[ivpa,ivperp,z.n,ir,is]+pdf[ivpa,ivperp,1,ir,is])
             pdf[ivpa,ivperp,z.n,ir,is] = pdf[ivpa,ivperp,1,ir,is]
@@ -197,7 +197,7 @@ function enforce_z_boundary_condition!(pdf, density, upar, ppar, phi, moments, b
     elseif bc == "wall"
         # Need integrals over vpa at wall boundaries in z, so cannot parallelize over z
         # or vpa.
-        begin_s_r_region()
+        @begin_s_r_region()
         @loop_s is begin
             # zero incoming BC for ions, as they recombine at the wall
             if moments.evolve_upar
@@ -233,7 +233,7 @@ enforce boundary conditions on neutral particle distribution function
     # advection or diffusion in these coordinates
 
     if vzeta_adv !== nothing && vzeta.n_global > 1 && vzeta.bc != "none"
-        begin_sn_r_z_vr_vz_region()
+        @begin_sn_r_z_vr_vz_region()
         @loop_sn_r_z_vr_vz isn ir iz ivr ivz begin
             # enforce the vz BC
             @views enforce_v_boundary_condition_local!(f_neutral[ivz,ivr,:,iz,ir,isn],
@@ -243,7 +243,7 @@ enforce boundary conditions on neutral particle distribution function
         end
     end
     if vr_adv !== nothing && vr.n_global > 1 && vr.bc != "none"
-        begin_sn_r_z_vzeta_vz_region()
+        @begin_sn_r_z_vzeta_vz_region()
         @loop_sn_r_z_vzeta_vz isn ir iz ivzeta ivz begin
             # enforce the vz BC
             @views enforce_v_boundary_condition_local!(f_neutral[ivz,:,ivzeta,iz,ir,isn],
@@ -253,7 +253,7 @@ enforce boundary conditions on neutral particle distribution function
         end
     end
     if vz_adv !== nothing && vz.n_global > 1 && vz.bc != "none"
-        begin_sn_r_z_vzeta_vr_region()
+        @begin_sn_r_z_vzeta_vr_region()
         @loop_sn_r_z_vzeta_vr isn ir iz ivzeta ivr begin
             # enforce the vz BC
             @views enforce_v_boundary_condition_local!(f_neutral[:,ivr,ivzeta,iz,ir,isn],
@@ -264,7 +264,7 @@ enforce boundary conditions on neutral particle distribution function
     end
     # f_initial contains the initial condition for enforcing a fixed-boundary-value condition
     if z.n > 1
-        begin_sn_r_vzeta_vr_vz_region()
+        @begin_sn_r_vzeta_vr_vz_region()
         enforce_neutral_z_boundary_condition!(f_neutral, density_neutral, uz_neutral,
             pz_neutral, moments, density_ion, upar_ion, Er, boundary_distributions,
             z_adv, z, vzeta, vr, vz, composition, geometry,
@@ -272,7 +272,7 @@ enforce boundary conditions on neutral particle distribution function
             scratch_dummy.buffer_vzvrvzetarsn_3, scratch_dummy.buffer_vzvrvzetarsn_4)
     end
     if r.n > 1
-        begin_sn_z_vzeta_vr_vz_region()
+        @begin_sn_z_vzeta_vr_vz_region()
         enforce_neutral_r_boundary_condition!(f_neutral, boundary_distributions.pdf_rboundary_neutral,
                                     r_adv, vz, vr, vzeta, z, r, composition,
                                     scratch_dummy.buffer_vzvrvzetazsn_1, scratch_dummy.buffer_vzvrvzetazsn_2,
@@ -354,7 +354,7 @@ function enforce_neutral_z_boundary_condition!(pdf, density, uz, pz, moments, de
     # 'constant' BC is time-independent f at upwind boundary
     # and constant f beyond boundary
     if z.bc == "constant"
-        begin_sn_r_vzeta_vr_vz_region()
+        @begin_sn_r_vzeta_vr_vz_region()
         density_offset = 1.0
         vwidth = 1.0
         if z.irank == 0
@@ -399,7 +399,7 @@ function enforce_neutral_z_boundary_condition!(pdf, density, uz, pz, moments, de
         end
     # 'periodic' BC enforces periodicity by taking the average of the boundary points
     elseif z.bc == "periodic" && z.nelement_global == z.nelement_local
-        begin_sn_r_vzeta_vr_vz_region()
+        @begin_sn_r_vzeta_vr_vz_region()
         @loop_sn_r_vzeta_vr_vz isn ir ivzeta ivr ivz begin
             pdf[ivz,ivr,ivzeta,1,ir,isn] = 0.5*(pdf[ivz,ivr,ivzeta,1,ir,isn] +
                                                 pdf[ivz,ivr,ivzeta,end,ir,isn])
@@ -409,7 +409,7 @@ function enforce_neutral_z_boundary_condition!(pdf, density, uz, pz, moments, de
     elseif z.bc == "wall"
         # Need integrals over vpa at wall boundaries in z, so cannot parallelize over z
         # or vpa.
-        begin_sn_r_region()
+        @begin_sn_r_region()
         @loop_sn isn begin
             # BC for neutrals
             @loop_r ir begin
@@ -1006,7 +1006,7 @@ enforce the z boundary condition on the evolved velocity space moments of f
 """
 function enforce_z_boundary_condition_moments!(density, moments, bc::String)
     ## TODO: parallelise
-    #begin_serial_region()
+    #@begin_serial_region()
     #@serial_region begin
     #    # enforce z boundary condition on density if it is evolved separately from f
     #	if moments.evolve_density

--- a/moment_kinetics/src/calculus.jl
+++ b/moment_kinetics/src/calculus.jl
@@ -12,7 +12,7 @@ using ..timer_utils
 using ..type_definitions: mk_float, mk_int
 using MPI
 using ..communication: block_rank
-using ..communication: _block_synchronize
+using ..communication: @_block_synchronize
 using ..looping
 
 using LinearAlgebra
@@ -490,7 +490,7 @@ end
     # synchronize buffers
     # -- this all-to-all block communicate here requires that this function is NOT called from within a parallelised loop
     # -- or from a @serial_region or from an if statment isolating a single rank on a block
-    _block_synchronize()
+    @_block_synchronize()
     #if block_rank[] == 0 # lead process on this shared-memory block
     @serial_region begin
 
@@ -553,7 +553,7 @@ end
 
     end
     # synchronize buffers
-    _block_synchronize()
+    @_block_synchronize()
 end
 
 function apply_adv_fac!(buffer::AbstractArray{mk_float,Ndims},adv_fac::AbstractArray{mk_float,Ndims},endpoints::AbstractArray{mk_float,Ndims},sgn::mk_int) where Ndims
@@ -590,7 +590,7 @@ function apply_adv_fac!(buffer::AbstractArray{mk_float,Ndims},adv_fac::AbstractA
     # synchronize buffers
     # -- this all-to-all block communicate here requires that this function is NOT called from within a parallelised loop
     # -- or from a @serial_region or from an if statment isolating a single rank on a block
-    _block_synchronize()
+    @_block_synchronize()
     #if block_rank[] == 0 # lead process on this shared-memory block
     @serial_region begin
         # now deal with endpoints that are stored across ranks
@@ -654,7 +654,7 @@ function apply_adv_fac!(buffer::AbstractArray{mk_float,Ndims},adv_fac::AbstractA
 
     end
     # synchronize buffers
-    _block_synchronize()
+    @_block_synchronize()
 end
 
 # Special version for pdf_electron with no r-dimension, which has the same number of
@@ -669,7 +669,7 @@ end
     # synchronize buffers
     # -- this all-to-all block communicate here requires that this function is NOT called from within a parallelised loop
     # -- or from a @serial_region or from an if statment isolating a single rank on a block
-    _block_synchronize()
+    @_block_synchronize()
     #if block_rank[] == 0 # lead process on this shared-memory block
     @serial_region begin
 
@@ -732,7 +732,7 @@ end
 
     end
     # synchronize buffers
-    _block_synchronize()
+    @_block_synchronize()
 end
 
 # Special version for pdf_electron with no r-dimension, which has the same number of
@@ -749,7 +749,7 @@ end
     # synchronize buffers
     # -- this all-to-all block communicate here requires that this function is NOT called from within a parallelised loop
     # -- or from a @serial_region or from an if statment isolating a single rank on a block
-    _block_synchronize()
+    @_block_synchronize()
     #if block_rank[] == 0 # lead process on this shared-memory block
     @serial_region begin
         # now deal with endpoints that are stored across ranks
@@ -813,7 +813,7 @@ end
 
     end
     # synchronize buffers
-    _block_synchronize()
+    @_block_synchronize()
 end
 
 """

--- a/moment_kinetics/src/charge_exchange.jl
+++ b/moment_kinetics/src/charge_exchange.jl
@@ -20,7 +20,7 @@ between ions and neutrals
     # nvz = nvpa and identical vz and vpa grids 
 
     if moments.evolve_density
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
         @loop_s is begin
             # apply CX collisions to all ion species
             # for each ion species, obtain affect of charge exchange collisions
@@ -34,7 +34,7 @@ between ions and neutrals
                 vz_spectral, dt; neutrals=false)
         end
     else
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
         @loop_s is begin
             # apply CX collisions to all ion species
             # for each ion species, obtain affect of charge exchange collisions
@@ -66,7 +66,7 @@ between ions and neutrals
     # nvz = nvpa and identical vz and vpa grids
 
     if moments.evolve_density
-        begin_sn_r_z_region()
+        @begin_sn_r_z_region()
         @loop_sn isn begin
             # apply CX collisions to all neutral species
             # for each neutral species, obtain affect of charge exchange collisions
@@ -79,7 +79,7 @@ between ions and neutrals
                 vz, vpa, charge_exchange_frequency, vpa_spectral, dt; neutrals=true)
         end
     else
-        begin_sn_r_z_region()
+        @begin_sn_r_z_region()
         @loop_sn isn begin
             # apply CX collisions to all neutral species
             # for each neutral species, obtain affect of charge exchange collisions
@@ -181,7 +181,7 @@ end
     @boundscheck r.n == size(f_neutral_gav_in,4) || throw(BoundsError(f_neutral_gav_in))
     @boundscheck composition.n_neutral_species == size(f_neutral_gav_in,5) || throw(BoundsError(f_neutral_gav_in))
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
     @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
         # apply CX collisions to all ion species
         # for each ion species, obtain affect of charge exchange collisions
@@ -212,7 +212,7 @@ end
     @boundscheck r.n == size(f_ion_vrvzvzeta_in,5) || throw(BoundsError(f_ion_vrvzvzeta_in))
     @boundscheck composition.n_neutral_species == size(f_ion_vrvzvzeta_in,6) || throw(BoundsError(f_ion_vrvzvzeta_in))
 
-    begin_sn_r_z_vzeta_vr_vz_region()
+    @begin_sn_r_z_vzeta_vr_vz_region()
     @loop_sn_r_z_vzeta_vr_vz isn ir iz ivzeta ivr ivz begin
         # apply CX collisions to all neutral species
         # for each neutral species, obtain affect of charge exchange collisions

--- a/moment_kinetics/src/continuity.jl
+++ b/moment_kinetics/src/continuity.jl
@@ -15,7 +15,7 @@ species
 @timeit global_timer continuity_equation!(
                          dens_out, fvec_in, moments, composition, dt, spectral,
                          ionization, ion_source_settings, num_diss_params) = begin
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     @loop_s_r_z is ir iz begin
         # Use ddens_dz is upwinded using upar
@@ -58,7 +58,7 @@ species
 @timeit global_timer neutral_continuity_equation!(
                          dens_out, fvec_in, moments, composition, dt, spectral,
                          ionization, neutral_source_settings, num_diss_params) = begin
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
 
     @loop_sn_r_z isn ir iz begin
         # Use ddens_dz is upwinded using uz

--- a/moment_kinetics/src/coordinates.jl
+++ b/moment_kinetics/src/coordinates.jl
@@ -346,7 +346,7 @@ function define_coordinate(coord_input::NamedTuple; parallel_io::Bool=false,
         scratch_shared_int2 .= typemin(mk_int)
     end
     if !ignore_MPI
-        _block_synchronize()
+        @_block_synchronize()
     end
     # scratch_2d is an array used for intermediate calculations requiring ngrid x nelement entries
     scratch_2d = allocate_float(coord_input.ngrid, coord_input.nelement_local)

--- a/moment_kinetics/src/debugging.jl
+++ b/moment_kinetics/src/debugging.jl
@@ -38,8 +38,11 @@ macronames = [
     ("debug_shared_array_allocate", 4,
      "Check that allocate_shared() was called from the same place on every process."),
 
-    ("debug_block_synchronize", 4,
-     "Check _block_synchronize() was called from the same place on every process."),
+    ("debug_block_synchronize_quick", 1,
+     "Check _block_synchronize() was called from the same place on every process, with quick check of call site."),
+
+    ("debug_block_synchronize_backtrace", 4,
+     "Check _block_synchronize() was called from the same place on every process, checking the full backtrace of each call."),
 
     ("debug_detect_redundant_block_synchronize", 5,
      "Check if any _block_synchronize() call could have been skipped without resulting "

--- a/moment_kinetics/src/derivatives.jl
+++ b/moment_kinetics/src/derivatives.jl
@@ -35,7 +35,7 @@ function derivative_r!(dfdr::AbstractArray{mk_float,2}, f::AbstractArray{mk_floa
         r_receive_buffer1::AbstractArray{mk_float,1},
         r_receive_buffer2::AbstractArray{mk_float,1}, r_spectral, r)
 
-        begin_z_region()
+        @begin_z_region()
 
 	# differentiate f w.r.t r
 	@loop_z iz begin
@@ -100,7 +100,7 @@ function derivative_r!(dfdr::AbstractArray{mk_float,5}, f::AbstractArray{mk_floa
         r_receive_buffer1::AbstractArray{mk_float,4},
         r_receive_buffer2::AbstractArray{mk_float,4}, r_spectral, r)
 
-        begin_s_z_vperp_vpa_region()
+        @begin_s_z_vperp_vpa_region()
 
 	# differentiate f w.r.t r
 	@loop_s_z_vperp_vpa is iz ivperp ivpa begin
@@ -126,7 +126,7 @@ function derivative_r!(dfdr::AbstractArray{mk_float,6}, f::AbstractArray{mk_floa
         r_receive_buffer1::AbstractArray{mk_float,5},
         r_receive_buffer2::AbstractArray{mk_float,5}, r_spectral, r)
 
-        begin_sn_z_vzeta_vr_vz_region()
+        @begin_sn_z_vzeta_vr_vz_region()
 
 	# differentiate f w.r.t r
 	@loop_sn_z_vzeta_vr_vz isn iz ivzeta ivr ivz begin
@@ -161,7 +161,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,1}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,0},
         z_receive_buffer::AbstractArray{mk_float,0}, z_spectral, z)
 
-    begin_serial_region()
+    @begin_serial_region()
 
     @serial_region begin
         # differentiate f w.r.t z
@@ -188,7 +188,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,2}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,1},
         z_receive_buffer::AbstractArray{mk_float,1}, z_spectral, z)
 
-        begin_r_region()
+        @begin_r_region()
 
 	# differentiate f w.r.t z
 	@loop_r ir begin
@@ -278,7 +278,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,5}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,4},
         z_receive_buffer::AbstractArray{mk_float,4}, z_spectral, z)
 
-        begin_s_r_vperp_vpa_region()
+        @begin_s_r_vperp_vpa_region()
 
 	# differentiate f w.r.t z
 	@loop_s_r_vperp_vpa is ir ivperp ivpa begin
@@ -304,7 +304,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,4}, f::AbstractArray{mk_floa
 	z_send_buffer::AbstractArray{mk_float,3},
 	z_receive_buffer::AbstractArray{mk_float,3}, z_spectral, z)
 
-        begin_r_vperp_vpa_region()
+        @begin_r_vperp_vpa_region()
 
 	# differentiate f w.r.t z
 	@loop_r_vperp_vpa ir ivperp ivpa begin
@@ -330,7 +330,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,6}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,5},
         z_receive_buffer::AbstractArray{mk_float,5}, z_spectral, z)
 
-        begin_sn_r_vzeta_vr_vz_region()
+        @begin_sn_r_vzeta_vr_vz_region()
 
 	# differentiate f w.r.t z
 	@loop_sn_r_vzeta_vr_vz isn ir ivzeta ivr ivz begin
@@ -365,7 +365,7 @@ function second_derivative_r!(d2fdr2::AbstractArray{mk_float,2}, f::AbstractArra
         r_receive_buffer1::AbstractArray{mk_float,1},
         r_receive_buffer2::AbstractArray{mk_float,1}, r_spectral, r)
 
-    begin_z_region()
+    @begin_z_region()
 
     # differentiate f w.r.t r
     @loop_z iz begin
@@ -429,7 +429,7 @@ function second_derivative_r!(d2fdr2::AbstractArray{mk_float,5}, f::AbstractArra
         r_receive_buffer1::AbstractArray{mk_float,4},
         r_receive_buffer2::AbstractArray{mk_float,4}, r_spectral, r)
 
-    begin_s_z_vperp_vpa_region()
+    @begin_s_z_vperp_vpa_region()
 
     # differentiate f w.r.t r
     @loop_s_z_vperp_vpa is iz ivperp ivpa begin
@@ -454,7 +454,7 @@ function second_derivative_r!(d2fdr2::AbstractArray{mk_float,6}, f::AbstractArra
         r_receive_buffer1::AbstractArray{mk_float,5},
         r_receive_buffer2::AbstractArray{mk_float,5}, r_spectral, r)
 
-    begin_sn_z_vzeta_vr_vz_region()
+    @begin_sn_z_vzeta_vr_vz_region()
 
     # differentiate f w.r.t r
     @loop_sn_z_vzeta_vr_vz isn iz ivzeta ivr ivz begin
@@ -488,7 +488,7 @@ function second_derivative_z!(d2fdz2::AbstractArray{mk_float,2}, f::AbstractArra
         z_send_buffer::AbstractArray{mk_float,1},
         z_receive_buffer::AbstractArray{mk_float,1}, z_spectral, z)
 
-    begin_r_region()
+    @begin_r_region()
 
     # differentiate f w.r.t z
     @loop_r ir begin
@@ -551,7 +551,7 @@ function second_derivative_z!(d2fdz2::AbstractArray{mk_float,5}, f::AbstractArra
         z_send_buffer::AbstractArray{mk_float,4},
         z_receive_buffer::AbstractArray{mk_float,4}, z_spectral, z)
 
-    begin_s_r_vperp_vpa_region()
+    @begin_s_r_vperp_vpa_region()
 
     # differentiate f w.r.t z
     @loop_s_r_vperp_vpa is ir ivperp ivpa begin
@@ -576,7 +576,7 @@ function second_derivative_z!(d2fdz2::AbstractArray{mk_float,6}, f::AbstractArra
         z_send_buffer::AbstractArray{mk_float,5},
         z_receive_buffer::AbstractArray{mk_float,5}, z_spectral, z)
 
-    begin_sn_r_vzeta_vr_vz_region()
+    @begin_sn_r_vzeta_vr_vz_region()
 
     # differentiate f w.r.t z
     @loop_sn_r_vzeta_vr_vz isn ir ivzeta ivr ivz begin
@@ -612,7 +612,7 @@ function derivative_r!(dfdr::AbstractArray{mk_float,2}, f::AbstractArray{mk_floa
         r_receive_buffer1::AbstractArray{mk_float,1},
         r_receive_buffer2::AbstractArray{mk_float,1}, r_spectral, r)
 
-    begin_z_region()
+    @begin_z_region()
 
     # differentiate f w.r.t r
     @loop_z iz begin
@@ -686,7 +686,7 @@ function derivative_r!(dfdr::AbstractArray{mk_float,5}, f::AbstractArray{mk_floa
         r_receive_buffer1::AbstractArray{mk_float,4},
         r_receive_buffer2::AbstractArray{mk_float,4}, r_spectral, r)
 
-        begin_s_z_vperp_vpa_region()
+        @begin_s_z_vperp_vpa_region()
 
 	# differentiate f w.r.t r
 	@loop_s_z_vperp_vpa is iz ivperp ivpa begin
@@ -717,7 +717,7 @@ function derivative_r!(dfdr::AbstractArray{mk_float,6}, f::AbstractArray{mk_floa
         r_receive_buffer1::AbstractArray{mk_float,5},
         r_receive_buffer2::AbstractArray{mk_float,5}, r_spectral, r)
 
-        begin_sn_z_vzeta_vr_vz_region()
+        @begin_sn_z_vzeta_vr_vz_region()
 
 	# differentiate f w.r.t r
 	@loop_sn_z_vzeta_vr_vz isn iz ivzeta ivr ivz begin
@@ -757,7 +757,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,2}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,1},
         z_receive_buffer::AbstractArray{mk_float,1}, z_spectral, z)
 
-    begin_r_region()
+    @begin_r_region()
 
     # differentiate f w.r.t z
     @loop_r ir begin
@@ -859,7 +859,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,5}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,4},
         z_receive_buffer::AbstractArray{mk_float,4}, z_spectral, z)
 
-        begin_s_r_vperp_vpa_region()
+        @begin_s_r_vperp_vpa_region()
 
 	# differentiate f w.r.t z
 	@loop_s_r_vperp_vpa is ir ivperp ivpa begin
@@ -890,7 +890,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,4}, f::AbstractArray{mk_floa
 	z_send_buffer::AbstractArray{mk_float,3},
 	z_receive_buffer::AbstractArray{mk_float,3}, z_spectral, z)
 
-    begin_r_vperp_vpa_region()
+    @begin_r_vperp_vpa_region()
 
     # differentiate the pdf f w.r.t z
     @loop_r_vperp_vpa ir ivperp ivpa begin
@@ -921,7 +921,7 @@ function derivative_z!(dfdz::AbstractArray{mk_float,6}, f::AbstractArray{mk_floa
         z_send_buffer::AbstractArray{mk_float,5},
         z_receive_buffer::AbstractArray{mk_float,5}, z_spectral, z)
 
-        begin_sn_r_vzeta_vr_vz_region()
+        @begin_sn_r_vzeta_vr_vz_region()
 
 	# differentiate f w.r.t z
 	@loop_sn_r_vzeta_vr_vz isn ir ivzeta ivr ivz begin

--- a/moment_kinetics/src/electron_vpa_advection.jl
+++ b/moment_kinetics/src/electron_vpa_advection.jl
@@ -20,7 +20,7 @@ calculate the wpa-advection term for the electron kinetic equation
                          pdf_out, pdf_in, density, upar, ppar, moments, advect, vpa,
                          spectral, scratch_dummy, dt, electron_source_settings,
                          ir) = begin
-    begin_z_vperp_region()
+    @begin_z_vperp_region()
 
     adv_fac = advect[1].adv_fac
     speed = advect[1].speed
@@ -131,7 +131,7 @@ function add_electron_vpa_advection_to_Jacobian!(jacobian_matrix, f, dens, upar,
     vpa_Dmat = vpa_spectral.lobatto.Dmat
     vpa_element_scale = vpa.element_scale
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
     @loop_z_vperp_vpa iz ivperp ivpa begin
         if skip_f_electron_bc_points_in_Jacobian(iz, ivperp, ivpa, z, vperp, vpa, z_speed)
             continue

--- a/moment_kinetics/src/electron_z_advection.jl
+++ b/moment_kinetics/src/electron_z_advection.jl
@@ -21,7 +21,7 @@ calculate the z-advection term for the electron kinetic equation = wpa * vthe * 
 @timeit global_timer electron_z_advection!(
                          pdf_out, pdf_in, upar, vth, advect, z, vpa, spectral,
                          scratch_dummy, dt, ir) = begin
-    begin_vperp_vpa_region()
+    @begin_vperp_vpa_region()
 
     adv_fac = advect[1].adv_fac
     speed = advect[1].speed
@@ -29,7 +29,7 @@ calculate the z-advection term for the electron kinetic equation = wpa * vthe * 
     # create a pointer to a scratch_dummy array to store the z-derivative of the electron pdf
     dpdf_dz = @view scratch_dummy.buffer_vpavperpzr_1[:,:,:,ir]
     d2pdf_dz2 = @view scratch_dummy.buffer_vpavperpzr_2[:,:,:,ir]
-    begin_vperp_vpa_region()
+    @begin_vperp_vpa_region()
     # get the updated speed along the z direction using the current pdf
     @views update_electron_speed_z!(advect[1], upar, vth, vpa, ir)
     # update adv_fac -- note that there is no factor of dt here because
@@ -50,7 +50,7 @@ calculate the z-advection term for the electron kinetic equation = wpa * vthe * 
     #    @views second_derivative!(d2pdf_dz2[ivpa,ivperp,:], pdf_in[ivpa,ivperp,:], z, spectral)
     #end
     # calculate the advection term
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
     @loop_z_vperp_vpa iz ivperp ivpa begin
         pdf_out[ivpa,ivperp,iz] += dt * adv_fac[iz,ivpa,ivperp,ir] * dpdf_dz[ivpa,ivperp,iz]
         #pdf_out[ivpa,ivperp,iz] += dt * adv_fac[iz,ivpa,ivperp,ir] * dpdf_dz[ivpa,ivperp,iz] + 0.0001*d2pdf_dz2[ivpa,ivperp,iz]
@@ -101,7 +101,7 @@ function add_electron_z_advection_to_Jacobian!(jacobian_matrix, f, dens, upar, p
     z_Dmat = z_spectral.lobatto.Dmat
     z_element_scale = z.element_scale
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
     @loop_z_vperp_vpa iz ivperp ivpa begin
         if skip_f_electron_bc_points_in_Jacobian(iz, ivperp, ivpa, z, vperp, vpa, z_speed)
             continue

--- a/moment_kinetics/src/em_fields.jl
+++ b/moment_kinetics/src/em_fields.jl
@@ -7,7 +7,7 @@ export update_phi!
 
 using ..type_definitions: mk_float
 using ..array_allocation: allocate_shared_float
-using ..communication: _block_synchronize
+using ..communication: @_block_synchronize
 using ..input_structs
 using ..looping
 using ..moment_kinetics_structs: em_fields_struct
@@ -54,10 +54,10 @@ function update_phi!(fields, fvec, vperp, z, r, composition, collisions, moments
     @boundscheck size(fvec.density,3) == composition.n_ion_species || throw(BoundsError(fvec.density))
     # Update phi using the set of processes that handles the first ion species
     # Means we get at least some parallelism, even though we have to sum
-    # over species, and reduces number of _block_synchronize() calls needed
+    # over species, and reduces number of @_block_synchronize() calls needed
     # when there is only one species.
     
-    begin_serial_region()#(no_synchronize=true)
+    @begin_serial_region()#(true)
 
     dens_e = fvec.electron_density
     # in serial as both s, r and z required locally
@@ -68,9 +68,9 @@ function update_phi!(fields, fvec, vperp, z, r, composition, collisions, moments
         # If composition.electron_physics ==
         # boltzmann_electron_response_with_simple_sheath, all ranks need to read
         # fvec.density at iz=1, so need to synchronize here.
-        # Use _block_synchronize() directly because we stay in a z_s type region, even
+        # Use @_block_synchronize() directly because we stay in a z_s type region, even
         # though synchronization is needed here.
-        _block_synchronize()
+        @_block_synchronize()
     end
     #@loop_r ir begin # radial locations uncoupled so perform boltzmann solve 
                            # for each radial position in parallel if possible 
@@ -80,12 +80,12 @@ function update_phi!(fields, fvec, vperp, z, r, composition, collisions, moments
     jpar_i = @view scratch_dummy.buffer_rs_1[:,:,1]
     N_e = @view scratch_dummy.buffer_rs_2[:,:,1]
     if composition.electron_physics == boltzmann_electron_response
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             N_e .= 1.0
         end
     elseif composition.electron_physics == boltzmann_electron_response_with_simple_sheath
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             # calculate Sum_{i} Z_i n_i u_i = J_||i at z = 0
             jpar_i .= 0.0
@@ -124,7 +124,7 @@ function update_phi!(fields, fvec, vperp, z, r, composition, collisions, moments
         calculate_phi_from_Epar!(fields.phi, fields.Ez, r, z)
     end
     ## can calculate phi at z = L and hence phi_wall(z=L) using jpar_i at z =L if needed
-    _block_synchronize()
+    @_block_synchronize()
 
     ## calculate the electric fields after obtaining phi
     #Er = - d phi / dr 
@@ -177,7 +177,7 @@ end
 function calculate_phi_from_Epar!(phi, Epar, r, z)
     # simple calculation of phi from Epar for now. Assume phi is already set at the
     # lower-ze boundary, e.g. by the kinetic electron boundary condition.
-    begin_serial_region()
+    @begin_serial_region()
 
     dz = z.cell_width
     @serial_region begin

--- a/moment_kinetics/src/energy_equation.jl
+++ b/moment_kinetics/src/energy_equation.jl
@@ -16,7 +16,7 @@ evolve the parallel pressure by solving the energy equation
                          ppar, fvec, moments, collisions, dt, spectral, composition,
                          ion_source_settings, num_diss_params) = begin
 
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     @loop_s_r_z is ir iz begin
         ppar[iz,ir,is] += dt*(-fvec.upar[iz,ir,is]*moments.ion.dppar_dz_upwind[iz,ir,is]
@@ -74,7 +74,7 @@ evolve the neutral parallel pressure by solving the energy equation
                          pz, fvec, moments, collisions, dt, spectral, composition,
                          neutral_source_settings, num_diss_params) = begin
 
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
 
     @loop_sn_r_z isn ir iz begin
         pz[iz,ir,isn] += dt*(-fvec.uz_neutral[iz,ir,isn]*moments.neutral.dpz_dz_upwind[iz,ir,isn]

--- a/moment_kinetics/src/external_sources.jl
+++ b/moment_kinetics/src/external_sources.jl
@@ -514,7 +514,7 @@ Initialize the arrays `moments.ion.external_source_amplitude`,
 """
 function initialize_external_source_amplitude!(moments, external_source_settings, vperp,
                                                vzeta, vr, n_neutral_species)
-    begin_r_z_region()
+    @begin_r_z_region()
 
     ion_source_settings = external_source_settings.ion
     # The electron loop must be in the same as the ion loop so that each electron source
@@ -735,7 +735,7 @@ Initialize the arrays `moments.ion.external_source_controller_integral` and
 """
 function initialize_external_source_controller_integral!(
              moments, external_source_settings, n_neutral_species)
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin
         ion_source_settings = external_source_settings.ion
         for index ∈ eachindex(ion_source_settings)
@@ -798,7 +798,7 @@ Add external source term to the ion kinetic equation.
     vpa_grid = vpa.grid
     vperp_grid = vperp.grid
     if source_type in ("Maxwellian","energy","density_midpoint_control","density_profile_control","temperature_midpoint_control")
-        begin_s_r_z_vperp_region()
+        @begin_s_r_z_vperp_region()
         if moments.evolve_ppar && moments.evolve_upar && moments.evolve_density
             vth = moments.ion.vth
             density = fvec.density
@@ -877,7 +877,7 @@ Add external source term to the ion kinetic equation.
             end
         end
     elseif source_type == "alphas" || source_type == "alphas-with-losses"
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
         source_v0 = ion_source.source_v0
         if !(source_v0 > 1.0e-8)
             error("source_v0=$source_v0 < 1.0e-8")
@@ -934,7 +934,7 @@ Add external source term to the ion kinetic equation.
                   * "evolve_upar=$(moments.evolve_upar), evolve_ppar=$(moments.evolve_ppar)")
         end
     elseif source_type == "beam" || source_type == "beam-with-losses"
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
         source_vpa0 = ion_source.source_vpa0
         source_vperp0 = ion_source.source_vperp0
         if !(source_vpa0 > 1.0e-8)
@@ -1033,7 +1033,7 @@ Note that this function operates on a single point in `r`, given by `ir`, and `p
 @timeit global_timer external_electron_source!(
                          pdf_out, pdf_in, electron_density, electron_upar, moments,
                          composition, electron_source, index, vperp, vpa, dt, ir) = begin
-    begin_z_vperp_region()
+    @begin_z_vperp_region()
 
     me_over_mi = composition.me_over_mi
 
@@ -1118,7 +1118,7 @@ function add_external_electron_source_to_Jacobian!(jacobian_matrix, f, moments, 
     vpa_grid = vpa.grid
     v_size = vperp.n * vpa.n
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
     if electron_source.source_type == "energy" && include === :all
         @loop_z_vperp_vpa iz ivperp ivpa begin
             if skip_f_electron_bc_points_in_Jacobian(iz, ivperp, ivpa, z, vperp, vpa,
@@ -1277,7 +1277,7 @@ Add external source term to the neutral kinetic equation.
 @timeit global_timer external_neutral_source!(
                          pdf, fvec, moments, neutral_source, index, vzeta, vr, vz,
                          dt) = begin
-    begin_sn_r_z_vzeta_vr_region()
+    @begin_sn_r_z_vzeta_vr_region()
 
     @views source_amplitude = moments.neutral.external_source_amplitude[:, :, index]
     source_T = neutral_source.source_T
@@ -1387,7 +1387,7 @@ source amplitude.
 """
 @timeit global_timer external_ion_source_controller!(
                          fvec_in, moments, ion_source_settings, index, dt) = begin
-    begin_r_z_region()
+    @begin_r_z_region()
 
     is = 1
     ion_moments = moments.ion
@@ -1423,7 +1423,7 @@ source amplitude.
             end
         end
     elseif ion_source_settings.source_type == "density_midpoint_control"
-        begin_serial_region()
+        @begin_serial_region()
 
         # controller_amplitude error is a shared memory Vector of length 1
         controller_amplitude = ion_source_settings.PI_controller_amplitude
@@ -1452,7 +1452,7 @@ source amplitude.
                           comm_inter_block[])
         end
 
-        begin_r_z_region()
+        @begin_r_z_region()
 
         amplitude = controller_amplitude[1]
         @loop_r_z ir iz begin
@@ -1473,7 +1473,7 @@ source amplitude.
             end
         end
     elseif ion_source_settings.source_type == "temperature_midpoint_control"
-        begin_serial_region()
+        @begin_serial_region()
         ion_moments.temp .= 2 .* ppar ./ density
         # controller_amplitude error is a shared memory Vector of length 1
         controller_amplitude = ion_source_settings.PI_controller_amplitude
@@ -1502,7 +1502,7 @@ source amplitude.
                           comm_inter_block[])
         end
 
-        begin_r_z_region()
+        @begin_r_z_region()
 
         amplitude = controller_amplitude[1]
         @loop_r_z ir iz begin
@@ -1532,7 +1532,7 @@ source amplitude.
         #    end
         #end
     elseif ion_source_settings.source_type == "density_profile_control"
-        begin_r_z_region()
+        @begin_r_z_region()
 
         target = ion_source_settings.PI_density_target
         P = ion_source_settings.PI_density_controller_P
@@ -1600,7 +1600,7 @@ up to date.
 """
 @timeit global_timer external_electron_source_controller!(
                          fvec_in, moments, electron_source_settings, index, dt) = begin
-    begin_r_z_region()
+    @begin_r_z_region()
 
     is = 1
     electron_moments = moments.electron
@@ -1680,7 +1680,7 @@ source amplitude.
 @timeit global_timer external_neutral_source_controller!(
                          fvec_in, moments, neutral_source_settings, index, r, z,
                          dt) = begin
-    begin_r_z_region()
+    @begin_r_z_region()
 
     is = 1
     neutral_moments = moments.neutral
@@ -1714,7 +1714,7 @@ source amplitude.
             end
         end
     elseif neutral_source_settings.source_type == "density_midpoint_control"
-        begin_serial_region()
+        @begin_serial_region()
 
         # controller_amplitude error is a shared memory Vector of length 1
         controller_amplitude = neutral_source_settings.PI_controller_amplitude
@@ -1744,7 +1744,7 @@ source amplitude.
                           comm_inter_block[])
         end
 
-        begin_r_z_region()
+        @begin_r_z_region()
 
         amplitude = controller_amplitude[1]
         @loop_r_z ir iz begin
@@ -1765,7 +1765,7 @@ source amplitude.
             end
         end
     elseif neutral_source_settings.source_type == "density_profile_control"
-        begin_r_z_region()
+        @begin_r_z_region()
 
         density = fvec_in.density_neutral
         target = neutral_source_settings.PI_density_target
@@ -1791,7 +1791,7 @@ source amplitude.
             end
         end
     elseif neutral_source_settings.source_type == "recycling"
-        begin_serial_region()
+        @begin_serial_region()
         target_flux = 0.0
         @boundscheck size(fvec_in.density, 3) == 1
         @boundscheck size(fvec_in.density_neutral, 3) == 1
@@ -1819,7 +1819,7 @@ source amplitude.
         target_flux = MPI.Bcast(target_flux, 0, comm_block[])
 
         # No need to synchronize as MPI.Bcast() synchronized already
-        begin_r_z_region(no_synchronize=true)
+        @begin_r_z_region(true)
 
         amplitude = neutral_moments.external_source_amplitude
         profile = neutral_source_settings.controller_source_profile

--- a/moment_kinetics/src/file_io.jl
+++ b/moment_kinetics/src/file_io.jl
@@ -387,7 +387,7 @@ function setup_io_input(input_dict, timestepping_section, warn_unexpected::Bool;
         if global_rank[] == 0
             mkpath(io_settings["output_dir"])
         end
-        _block_synchronize()
+        @_block_synchronize()
     end
 
     return io_input_struct(; (Symbol(k) => v for (k,v) ∈ io_settings)...)
@@ -439,7 +439,7 @@ function setup_file_io(io_input, boundary_distributions, vz, vr, vzeta, vpa, vpe
                        external_source_settings, input_dict, restart_time_index,
                        previous_runs_info, time_for_setup, t_params, nl_solver_params)
 
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin
         # Only read/write from first process in each 'block'
 
@@ -487,7 +487,7 @@ function setup_electron_io(io_input, vpa, vperp, z, r, composition, collisions,
                            evolve_density, evolve_upar, evolve_ppar,
                            external_source_settings, t_params, input_dict,
                            restart_time_index, previous_runs_info, prefix_label)
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin
         # Only read/write from first process in each 'block'
 
@@ -3720,7 +3720,7 @@ function debug_dump(vz::coordinate, vr::coordinate, vzeta::coordinate, vpa::coor
     global debug_output_file
 
     # Only read/write from first process in each 'block'
-    _block_synchronize()
+    @_block_synchronize()
     @serial_region begin
         if debug_output_file === nothing
             # Open the file the first time`debug_dump()` is called
@@ -3879,7 +3879,7 @@ function debug_dump(vz::coordinate, vr::coordinate, vzeta::coordinate, vpa::coor
 
     debug_output_counter[] += 1
 
-    _block_synchronize()
+    @_block_synchronize()
 
     return nothing
 end

--- a/moment_kinetics/src/fokker_planck_calculus.jl
+++ b/moment_kinetics/src/fokker_planck_calculus.jl
@@ -305,7 +305,7 @@ function init_Rosenbluth_potential_integration_weights!(G0_weights,G1_weights,H0
     end
 
     # precalculated weights, integrating over Lagrange polynomials
-    begin_vperp_vpa_region()
+    @begin_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         #limits where checks required to determine which divergence-safe grid is needed
         igrid_vpa, ielement_vpa, ielement_vpa_low, ielement_vpa_hi, igrid_vperp, ielement_vperp, ielement_vperp_low, ielement_vperp_hi = get_element_limit_indices(ivpa,ivperp,vpa,vperp)
@@ -409,7 +409,7 @@ function init_Rosenbluth_potential_boundary_integration_weights!(G0_weights,
 
     # precalculate weights, integrating over Lagrange polynomials
     # first compute weights along lower vpa boundary
-    begin_vperp_region()
+    @begin_vperp_region()
     ivpa = 1 # lower_vpa_boundary
     @loop_vperp ivperp begin
         #limits where checks required to determine which divergence-safe grid is needed
@@ -478,7 +478,7 @@ function init_Rosenbluth_potential_boundary_integration_weights!(G0_weights,
                 igrid_vpa, igrid_vperp, vpa_val, vperp_val)
     end
     # finally compute weight along upper vperp boundary
-    begin_vpa_region()
+    @begin_vpa_region()
     ivperp = vperp.n # upper_vperp_boundary
     @loop_vpa ivpa begin
         #limits where checks required to determine which divergence-safe grid is needed
@@ -513,7 +513,7 @@ function init_Rosenbluth_potential_boundary_integration_weights!(G0_weights,
                 igrid_vpa, igrid_vperp, vpa_val, vperp_val)
     end
     # return the parallelisation status to serial
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin 
         if global_rank[] == 0 && print_to_screen
             println("finished (boundary) weights calculation   ", Dates.format(now(), dateformat"H:MM:SS"))
@@ -1113,7 +1113,7 @@ of `vpa_vperp_boundary_data`. Used in testing.
 """
 function assign_exact_boundary_data!(func_data::vpa_vperp_boundary_data,
                                         func_exact,vpa,vperp)
-    begin_anyv_region()
+    @begin_anyv_region()
     nvpa = vpa.n
     nvperp = vperp.n
     @anyv_serial_region begin
@@ -1175,7 +1175,7 @@ function calculate_boundary_data!(func_data::vpa_vperp_boundary_data,
                                   weight::MPISharedArray{mk_float,4},func_input,vpa,vperp)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
         func_data.lower_boundary_vpa[ivperp] = 0.0
         func_data.upper_boundary_vpa[ivperp] = 0.0
@@ -1187,7 +1187,7 @@ function calculate_boundary_data!(func_data::vpa_vperp_boundary_data,
         end
     end
     #for ivpa in 1:nvpa
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
         func_data.upper_boundary_vperp[ivpa] = 0.0
         for ivperpp in 1:nvperp
@@ -1210,7 +1210,7 @@ function calculate_boundary_data!(func_data::vpa_vperp_boundary_data,
                                   func_input,vpa,vperp)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
         func_data.lower_boundary_vpa[ivperp] = 0.0
         func_data.upper_boundary_vpa[ivperp] = 0.0
@@ -1222,7 +1222,7 @@ function calculate_boundary_data!(func_data::vpa_vperp_boundary_data,
         end
     end
     #for ivpa in 1:nvpa
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
         func_data.upper_boundary_vperp[ivpa] = 0.0
         for ivperpp in 1:nvperp
@@ -1248,18 +1248,18 @@ function calculate_rosenbluth_potential_boundary_data!(rpbd::rosenbluth_potentia
     dfdvpa = fkpl.dfdvpa
     d2fdvperpdvpa = fkpl.d2fdvperpdvpa
     #for ivpa in 1:vpa.n
-    begin_anyv_vpa_region()
+    @begin_anyv_vpa_region()
     @loop_vpa ivpa begin
         @views derivative!(dfdvperp[ivpa,:], pdf[ivpa,:], vperp, vperp_spectral)
     end
-    begin_anyv_vperp_region()
+    @begin_anyv_vperp_region()
     @loop_vperp ivperp begin
     #for ivperp in 1:vperp.n
         @views derivative!(dfdvpa[:,ivperp], pdf[:,ivperp], vpa, vpa_spectral)
         @views derivative!(d2fdvperpdvpa[:,ivperp], dfdvperp[:,ivperp], vpa, vpa_spectral)
     end
     # ensure data is synchronized
-    _anyv_subblock_synchronize()
+    @_anyv_subblock_synchronize()
     # carry out the numerical integration 
     calculate_boundary_data!(rpbd.H_data,fkpl.H0_weights,pdf,vpa,vperp)
     calculate_boundary_data!(rpbd.dHdvpa_data,fkpl.H0_weights,dfdvpa,vpa,vperp)
@@ -1579,12 +1579,12 @@ function calculate_boundary_data_multipole_H!(func_data::vpa_vperp_boundary_data
                                              Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_H(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_H(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_H(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1597,12 +1597,12 @@ end
 function calculate_boundary_data_multipole_dHdvpa!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_dHdvpa(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_dHdvpa(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_dHdvpa(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1615,12 +1615,12 @@ end
 function calculate_boundary_data_multipole_dHdvperp!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_dHdvperp(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_dHdvperp(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_dHdvperp(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1633,12 +1633,12 @@ end
 function calculate_boundary_data_multipole_G!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_G(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_G(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_G(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1651,12 +1651,12 @@ end
 function calculate_boundary_data_multipole_dGdvperp!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_dGdvperp(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_dGdvperp(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_dGdvperp(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1669,12 +1669,12 @@ end
 function calculate_boundary_data_multipole_d2Gdvperp2!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_d2Gdvperp2(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_d2Gdvperp2(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_d2Gdvperp2(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1687,12 +1687,12 @@ end
 function calculate_boundary_data_multipole_d2Gdvperpdvpa!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_d2Gdvperpdvpa(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_d2Gdvperpdvpa(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_d2Gdvperpdvpa(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1705,12 +1705,12 @@ end
 function calculate_boundary_data_multipole_d2Gdvpa2!(func_data::vpa_vperp_boundary_data,vpa,vperp,Inn_vec)
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region(no_synchronize=true)
+    @begin_anyv_vperp_region(true)
     @loop_vperp ivperp begin
                 func_data.lower_boundary_vpa[ivperp] = multipole_d2Gdvpa2(vpa.grid[1],vperp.grid[ivperp],Inn_vec)
                 func_data.upper_boundary_vpa[ivperp] = multipole_d2Gdvpa2(vpa.grid[nvpa],vperp.grid[ivperp],Inn_vec)
     end
-    begin_anyv_vpa_region(no_synchronize=true)
+    @begin_anyv_vpa_region(true)
     @loop_vpa ivpa begin
                 func_data.upper_boundary_vperp[ivpa] = multipole_d2Gdvpa2(vpa.grid[ivpa],vperp.grid[nvperp],Inn_vec)
     end
@@ -1734,7 +1734,7 @@ function calculate_rosenbluth_potential_boundary_data_multipole!(rpbd::rosenblut
         I06, I16, I26 = 0.0, 0.0, 0.0
         I08 = 0.0
         
-        begin_anyv_region()
+        @begin_anyv_region()
         @anyv_serial_region begin
            I00 = integrate_over_vspace(@view(pdf[:,:]), vpa.grid, 0, vpa.wgts, vperp.grid, 0, vperp.wgts)
            I10 = integrate_over_vspace(@view(pdf[:,:]), vpa.grid, 1, vpa.wgts, vperp.grid, 0, vperp.wgts)
@@ -1776,7 +1776,7 @@ function calculate_rosenbluth_potential_boundary_data_multipole!(rpbd::rosenblut
             MPI.Bcast!(Inn_vec, 0, comm_anyv_subblock[])
         end
         # ensure data is synchronized
-        _anyv_subblock_synchronize()
+        @_anyv_subblock_synchronize()
         # evaluate the multipole formulae 
         calculate_boundary_data_multipole_H!(rpbd.H_data,vpa,vperp,Inn_vec)
         calculate_boundary_data_multipole_dHdvpa!(rpbd.dHdvpa_data,vpa,vperp,Inn_vec)
@@ -1808,7 +1808,7 @@ function calculate_rosenbluth_potential_boundary_data_delta_f_multipole!(rpbd::r
     mass = 1.0
     dens, upar, vth = 0.0, 0.0, 0.0
     # first, compute the moments and delta f
-    begin_anyv_region()
+    @begin_anyv_region()
     @anyv_serial_region begin
       dens =  get_density(pdf, vpa, vperp)
       upar = get_upar(pdf, vpa, vperp, dens)
@@ -1827,7 +1827,7 @@ function calculate_rosenbluth_potential_boundary_data_delta_f_multipole!(rpbd::r
     end
     (dens, upar, vth) = param_vec
     # ensure data is synchronized
-    _anyv_subblock_synchronize()
+    @_anyv_subblock_synchronize()
     # now pass the delta f to the multipole function
     calculate_rosenbluth_potential_boundary_data_multipole!(rpbd,dummy_vpavperp,
       vpa,vperp,vpa_spectral,vperp_spectral,
@@ -1835,7 +1835,7 @@ function calculate_rosenbluth_potential_boundary_data_delta_f_multipole!(rpbd::r
     # now add on the contributions from the Maxwellian
     nvpa = vpa.n
     nvperp = vperp.n
-    begin_anyv_vperp_region()
+    @begin_anyv_vperp_region()
     @loop_vperp ivperp begin
                 rpbd.H_data.lower_boundary_vpa[ivperp] += H_Maxwellian(dens,upar,vth,vpa,vperp,1,ivperp)
                 rpbd.H_data.upper_boundary_vpa[ivperp] += H_Maxwellian(dens,upar,vth,vpa,vperp,nvpa,ivperp)
@@ -1850,7 +1850,7 @@ function calculate_rosenbluth_potential_boundary_data_delta_f_multipole!(rpbd::r
                 rpbd.d2Gdvperp2_data.lower_boundary_vpa[ivperp] += d2Gdvperp2_Maxwellian(dens,upar,vth,vpa,vperp,1,ivperp)
                 rpbd.d2Gdvperp2_data.upper_boundary_vpa[ivperp] += d2Gdvperp2_Maxwellian(dens,upar,vth,vpa,vperp,nvpa,ivperp)
     end
-    begin_anyv_vpa_region()
+    @begin_anyv_vpa_region()
     @loop_vpa ivpa begin
                 rpbd.H_data.upper_boundary_vperp[ivpa] += H_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,nvperp)
                 rpbd.dHdvpa_data.upper_boundary_vperp[ivpa] += dHdvpa_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,nvperp)
@@ -1860,23 +1860,23 @@ function calculate_rosenbluth_potential_boundary_data_delta_f_multipole!(rpbd::r
                 rpbd.d2Gdvperp2_data.upper_boundary_vperp[ivpa] += d2Gdvperp2_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,nvperp)
     end
     if calculate_GG
-       begin_anyv_vperp_region()
+       @begin_anyv_vperp_region()
        @loop_vperp ivperp begin
                    rpbd.G_data.lower_boundary_vpa[ivperp] += G_Maxwellian(dens,upar,vth,vpa,vperp,1,ivperp)
                    rpbd.G_data.upper_boundary_vpa[ivperp] += G_Maxwellian(dens,upar,vth,vpa,vperp,nvpa,ivperp)
        end
-       begin_anyv_vpa_region()
+       @begin_anyv_vpa_region()
        @loop_vpa ivpa begin
                    rpbd.G_data.upper_boundary_vperp[ivpa] += G_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,nvperp)
        end
     end
     if calculate_dGdvperp
-       begin_anyv_vperp_region()
+       @begin_anyv_vperp_region()
        @loop_vperp ivperp begin
                    rpbd.dGdvperp_data.lower_boundary_vpa[ivperp] += dGdvperp_Maxwellian(dens,upar,vth,vpa,vperp,1,ivperp)
                    rpbd.dGdvperp_data.upper_boundary_vpa[ivperp] += dGdvperp_Maxwellian(dens,upar,vth,vpa,vperp,nvpa,ivperp)
        end
-       begin_anyv_vpa_region()
+       @begin_anyv_vpa_region()
        @loop_vpa ivpa begin
                    rpbd.dGdvperp_data.upper_boundary_vperp[ivpa] += dGdvperp_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,nvperp)
        end
@@ -2553,7 +2553,7 @@ function assemble_explicit_collision_operator_rhs_serial!(rhsvpavperp,pdfs,d2Gsp
     d2Gspdvperp2,dHspdvpa,dHspdvperp,ms,msp,nussp,
     vpa,vperp,YY_arrays::YY_collision_operator_arrays)
     @inbounds begin
-        begin_anyv_region()
+        @begin_anyv_region()
         @anyv_serial_region begin
             # assemble RHS of collision operator
             rhsc = vec(rhsvpavperp)
@@ -2623,7 +2623,7 @@ function assemble_explicit_collision_operator_rhs_parallel!(rhsvpavperp,pdfs,d2G
     d2Gspdvperp2,dHspdvpa,dHspdvperp,ms,msp,nussp,
     vpa,vperp,YY_arrays::YY_collision_operator_arrays)
     # assemble RHS of collision operator
-    begin_anyv_vperp_vpa_region()
+    @begin_anyv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         rhsvpavperp[ivpa,ivperp] = 0.0
     end
@@ -2720,7 +2720,7 @@ function assemble_explicit_collision_operator_rhs_parallel_analytical_inputs!(rh
     d2Gspdvperp2,dHspdvpa,dHspdvperp,ms,msp,nussp,
     vpa,vperp,YY_arrays::YY_collision_operator_arrays)
     # assemble RHS of collision operator
-    begin_anyv_vperp_vpa_region()
+    @begin_anyv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         rhsvpavperp[ivpa,ivperp] = 0.0
     end
@@ -2964,7 +2964,7 @@ function calculate_rosenbluth_potentials_via_elliptic_solve!(GG,HH,dHdvpa,dHdvpe
               or boundary_data_option='$direct_integration'")
     end
     # carry out the elliptic solves required
-    begin_anyv_vperp_vpa_region()
+    @begin_anyv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         S_dummy[ivpa,ivperp] = -(4.0/sqrt(pi))*ffsp_in[ivpa,ivperp]
     end
@@ -2973,7 +2973,7 @@ function calculate_rosenbluth_potentials_via_elliptic_solve!(GG,HH,dHdvpa,dHdvpe
     # The solves run on ranks 0, 1 and 2 of the subblock respectively, but modulo the size
     # of the subblock (to ensure that the ranks doing work are never outside the
     # subblock, if the size of the subblock is less than 3).
-    begin_anyv_region()
+    @begin_anyv_region()
     if anyv_subblock_rank[] == 0 % anyv_subblock_size[]
         elliptic_solve!(HH, S_dummy, rpbd.H_data, lu_obj_LP, MM2D_sparse, rhsvpavperp,
                         vpa, vperp)
@@ -2987,7 +2987,7 @@ function calculate_rosenbluth_potentials_via_elliptic_solve!(GG,HH,dHdvpa,dHdvpe
                         rhsvpavperp_copy2, vpa, vperp)
     end
     
-    begin_anyv_vperp_vpa_region()
+    @begin_anyv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         S_dummy[ivpa,ivperp] = 2.0*HH[ivpa,ivperp]
     end
@@ -2999,7 +2999,7 @@ function calculate_rosenbluth_potentials_via_elliptic_solve!(GG,HH,dHdvpa,dHdvpe
     # ranks in the subblock if both conditions calculate_GG and calculate_dGdvperp are
     # false; at least 3 ranks if only one of the conditions is true; and at least 4 ranks
     # if both conditions are true).
-    begin_anyv_region()
+    @begin_anyv_region()
     if calculate_GG
         if anyv_subblock_rank[] == 2 % anyv_subblock_size[]
             elliptic_solve!(GG, S_dummy, rpbd.G_data, lu_obj_LP, MM2D_sparse,
@@ -3022,12 +3022,12 @@ function calculate_rosenbluth_potentials_via_elliptic_solve!(GG,HH,dHdvpa,dHdvpe
     end
     
     if algebraic_solve_for_d2Gdvperp2
-        begin_anyv_vperp_vpa_region()
+        @begin_anyv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             S_dummy[ivpa,ivperp] = 2.0*HH[ivpa,ivperp] - d2Gdvpa2[ivpa,ivperp]
             Q_dummy[ivpa,ivperp] = -dGdvperp[ivpa,ivperp]
         end
-        begin_anyv_region()
+        @begin_anyv_region()
         @anyv_serial_region begin
             # use the algebraic solve function to find
             # d2Gdvperp2 = 2H - d2Gdvpa2 - (1/vperp)dGdvperp
@@ -3038,13 +3038,13 @@ function calculate_rosenbluth_potentials_via_elliptic_solve!(GG,HH,dHdvpa,dHdvpe
         end
     else
         # solve a weak-form PDE for d2Gdvperp2
-        begin_anyv_vperp_vpa_region()
+        @begin_anyv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             #S_dummy[ivpa,ivperp] = 2.0*HH[ivpa,ivperp] # <- this is already the value of
                                                         #    S_dummy calculated above
             Q_dummy[ivpa,ivperp] = 2.0*d2Gdvpa2[ivpa,ivperp]
         end
-        begin_anyv_region()
+        @begin_anyv_region()
         @anyv_serial_region begin
             elliptic_solve!(d2Gdvperp2, S_dummy, Q_dummy, rpbd.d2Gdvperp2_data, lu_obj_LB,
                             KPperp2D_sparse, MMparMNperp2D_sparse, rhsvpavperp, vpa,
@@ -3072,11 +3072,11 @@ function calculate_rosenbluth_potentials_via_direct_integration!(GG,HH,dHdvpa,dH
     H2_weights = fkpl_arrays.H2_weights
     H3_weights = fkpl_arrays.H3_weights
     # first compute the derivatives of fs' (the integration weights assume d fs' dvpa and d fs' dvperp are known)
-    begin_anyv_vperp_region()
+    @begin_anyv_vperp_region()
     @loop_vperp ivperp begin
         @views derivative!(dfdvpa[:,ivperp], ffsp_in[:,ivperp], vpa, vpa_spectral)
     end
-    begin_anyv_vpa_region()
+    @begin_anyv_vpa_region()
     @loop_vpa ivpa begin
         @views derivative!(dfdvperp[ivpa,:], ffsp_in[ivpa,:], vperp, vperp_spectral)
         @views derivative!(d2fdvperpdvpa[ivpa,:], dfdvpa[ivpa,:], vperp, vperp_spectral)
@@ -3105,7 +3105,7 @@ function calculate_rosenbluth_integrals!(GG,d2Gspdvpa2,dGspdvperp,d2Gspdvperpdvp
                                         fsp,dfspdvpa,dfspdvperp,d2fspdvperpdvpa,
                                         G0_weights,G1_weights,H0_weights,H1_weights,H2_weights,H3_weights,
                                         nvpa,nvperp)
-    begin_anyv_vperp_vpa_region()
+    @begin_anyv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         GG[ivpa,ivperp] = 0.0
         d2Gspdvpa2[ivpa,ivperp] = 0.0
@@ -3146,7 +3146,7 @@ function enforce_vpavperp_BCs!(pdf,vpa,vperp,vpa_spectral,vperp_spectral)
     # vpa boundary conditions
     # zero at infinity
     if vpa.bc == "zero"
-        begin_anyv_vperp_region()
+        @begin_anyv_vperp_region()
         @loop_vperp ivperp begin
             pdf[1,ivperp] = 0.0
             pdf[nvpa,ivperp] = 0.0
@@ -3156,7 +3156,7 @@ function enforce_vpavperp_BCs!(pdf,vpa,vperp,vpa_spectral,vperp_spectral)
     # zero boundary condition at infinity
     # set regularity condition d F / d vperp = 0 at vperp = 0
     # adjust F(vperp = 0) so that d F / d vperp = 0 at vperp = 0
-    begin_anyv_vpa_region()
+    @begin_anyv_vpa_region()
     if vperp.bc in ("zero", "zero-impose-regularity")
         @loop_vpa ivpa begin
             pdf[ivpa,nvperp] = 0.0
@@ -3188,7 +3188,7 @@ two reference speeds.
 """
 function interpolate_2D_vspace!(pdf_out,pdf_in,vpa,vperp,scalefac)
     
-    begin_anyv_vperp_vpa_region()
+    @begin_anyv_vperp_vpa_region()
     # loop over points in the output interpolated dataset
     @loop_vperp ivperp begin
         vperp_val = vperp.grid[ivperp]*scalefac
@@ -3245,13 +3245,13 @@ end
 #    newgrid_vperp = vperp.scratch .= scalefac .* vperp.grid
 #    newgrid_vpa = vpa.scratch .= scalefac .* vpa.grid
 #
-#    begin_anyv_vpa_region()
+#    @begin_anyv_vpa_region()
 #    @loop_vpa ivpa begin
 #        @views interpolate_to_grid_1d!(pdf_buffer[ivpa,:], newgrid_vperp,
 #                                       pdf_in[ivpa,:], vperp, vperp_spectral)
 #    end
 #
-#    begin_anyv_vperp_region()
+#    @begin_anyv_vperp_region()
 #    @loop_vperp ivperp begin
 #        @views interpolate_to_grid_1d!(pdf_out[:,ivperp], newgrid_vpa,
 #                                       pdf_buffer[:,ivperp], vpa, vpa_spectral)

--- a/moment_kinetics/src/force_balance.jl
+++ b/moment_kinetics/src/force_balance.jl
@@ -18,7 +18,7 @@ to update the parallel particle flux dens*upar for each species
                          spectral, composition, geometry, ion_source_settings,
                          num_diss_params) = begin
 
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     # account for momentum flux contribution to force balance
     density = fvec.density
@@ -78,7 +78,7 @@ end
                          spectral, composition, geometry, neutral_source_settings,
                          num_diss_params) = begin
 
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
 
     # account for momentum flux contribution to force balance
     density = fvec.density_neutral

--- a/moment_kinetics/src/gyroaverages.jl
+++ b/moment_kinetics/src/gyroaverages.jl
@@ -16,7 +16,7 @@ using ..lagrange_polynomials: lagrange_poly
 using ..input_structs: gyrokinetic_ions
 using ..looping
 using ..timer_utils
-using ..communication: MPISharedArray, comm_block, _block_synchronize
+using ..communication: MPISharedArray, comm_block, @_block_synchronize
 
 struct gyro_operators
     # matrix for applying a gyroaverage to a function F(r,vpa,vperp) at fixed r, with R = r - rhovec and rhovec = b x v / Omega
@@ -58,7 +58,7 @@ function init_gyro_operators(vperp,z,r,gyrophase,geometry,composition;print_info
        # init the matrix!
        # the first two indices are to be summed over
        # the other indices are the "field" positions of the resulting gyroaveraged quantity
-       begin_serial_region()
+       @begin_serial_region()
        @serial_region begin
            zlist = allocate_float(gyrophase.n)
            rlist = allocate_float(gyrophase.n)
@@ -159,7 +159,7 @@ function init_gyro_operators(vperp,z,r,gyrophase,geometry,composition;print_info
         end
            
         # Broadcast the values in gyroloopsizes across the shared-memory block
-        _block_synchronize()
+        @_block_synchronize()
         # initialise the arrays containing the indexing information
         # use the fact that the first index cannot be larger than the size of z.n*r.n
         # and accept that we are storing undefined values in exchange for storing the useful
@@ -187,7 +187,7 @@ function init_gyro_operators(vperp,z,r,gyrophase,geometry,composition;print_info
                 end
             end
         end
-        _block_synchronize()
+        @_block_synchronize()
         if print_info
             println("Finished: init_gyro_operators")
         end
@@ -269,7 +269,7 @@ and filling the result into an array of shape (vperp,z,r,s)
     izpgyroindex = gyro.izpgyroindex
     irpgyroindex = gyro.irpgyroindex
     
-    begin_s_r_z_vperp_region()
+    @begin_s_r_z_vperp_region()
     @loop_s_r_z_vperp is ir iz ivperp begin
         nsum = gyroloopsizes[ivperp,iz,ir,is]
         @views izplist = izpgyroindex[1:nsum,ivperp,iz,ir,is]
@@ -311,7 +311,7 @@ and filling the result into an of the same shape
     izpgyroindex = gyro.izpgyroindex
     irpgyroindex = gyro.irpgyroindex
     
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
     @loop_s_r_z_vperp is ir iz ivperp begin
         nsum = gyroloopsizes[ivperp,iz,ir,is]
         @views izplist = izpgyroindex[1:nsum,ivperp,iz,ir,is]

--- a/moment_kinetics/src/ionization.jl
+++ b/moment_kinetics/src/ionization.jl
@@ -24,7 +24,7 @@ using ..timer_utils
     @boundscheck r.n == size(f_out,4) || throw(BoundsError(f_out))
     @boundscheck composition.n_ion_species == size(f_out,5) || throw(BoundsError(f_out))
     
-    begin_r_z_region()
+    @begin_r_z_region()
 
     if moments.evolve_density
         # For now, assume species index `is` corresponds to the neutral
@@ -117,7 +117,7 @@ end
     @boundscheck composition.n_neutral_species == size(f_neutral_out,6) || throw(BoundsError(f_neutral_out))
 
     if !moments.evolve_density
-        begin_sn_r_z_vz_region()
+        @begin_sn_r_z_vz_region()
 
         ionization = collisions.reactions.ionization_frequency
         @loop_sn isn begin
@@ -152,7 +152,7 @@ end
     
     ionization_frequency = collisions.reactions.ionization_frequency
     
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     # ion ionization rate =   < f_n > n_e R_ion
     # neutral "ionization" (depopulation) rate =   -  f_n  n_e R_ion
@@ -186,7 +186,7 @@ end
     # neutral "ionization" (depopulation) rate =   -  f_n  n_e R_ion
     #NB: used quasineutrality to replace electron density n_e with ion density
     #NEEDS GENERALISATION TO n_ion_species > 1 (missing species charge: Sum_i Z_i n_i = n_e)
-    begin_sn_r_z_vzeta_vr_vz_region()
+    @begin_sn_r_z_vzeta_vr_vz_region()
     @loop_sn isn begin
         for is ∈ 1:composition.n_ion_species
             @loop_r_z_vzeta_vr_vz ir iz ivzeta ivr ivz begin

--- a/moment_kinetics/src/krook_collisions.jl
+++ b/moment_kinetics/src/krook_collisions.jl
@@ -76,7 +76,7 @@ Currently Krook collisions
 @timeit global_timer krook_collisions!(
                          pdf_out, fvec_in, moments, composition, collisions, vperp, vpa,
                          dt) = begin
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     if vperp.n > 1 && (moments.evolve_density || moments.evolve_upar || moments.evolve_ppar)
         error("Krook collisions not implemented for 2V moment-kinetic cases yet")
@@ -171,7 +171,7 @@ Note that this function operates on a single point in `r`, so `pdf_out`, `pdf_in
 @timeit global_timer electron_krook_collisions!(
                          pdf_out, pdf_in, dens_in, upar_in, upar_ion_in, vth_in,
                          collisions, vperp, vpa, dt) = begin
-    begin_z_region()
+    @begin_z_region()
 
     # For now, electrons are always fully moment-kinetic
     evolve_density = true
@@ -336,7 +336,7 @@ function add_electron_krook_collisions_to_Jacobian!(jacobian_matrix, f, dens, up
 
     using_reference_parameters = (collisions.krook.frequency_option == "reference_parameters")
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
     @loop_z_vperp_vpa iz ivperp ivpa begin
         if skip_f_electron_bc_points_in_Jacobian(iz, ivperp, ivpa, z, vperp, vpa, z_speed)
             continue

--- a/moment_kinetics/src/load_data.jl
+++ b/moment_kinetics/src/load_data.jl
@@ -641,7 +641,7 @@ function reload_evolving_fields!(pdf, moments, fields, boundary_distributions,
     electron_dt_before_last_fail = Ref(Inf)
     previous_runs_info = nothing
     restart_electron_physics = nothing
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin
         fid = open_readonly_output_file(restart_prefix_iblock[1], "dfns";
                                         iblock=restart_prefix_iblock[2])
@@ -1081,7 +1081,7 @@ function reload_electron_data!(pdf, moments, t_params, restart_prefix_iblock, ti
     code_time = 0.0
     pdf_electron_converged = false
     previous_runs_info = nothing
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin
         fid = open_readonly_output_file(restart_prefix_iblock[1], "initial_electron";
                                         iblock=restart_prefix_iblock[2])
@@ -4447,7 +4447,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
                            vperp=nvperp, vpa=nvpa, vzeta=run_info.vzeta.n,
                            vr=run_info.vr.n, vz=run_info.vz.n)
         for it ∈ 1:nt, is ∈ 1:nspecies
-            begin_serial_region()
+            @begin_serial_region()
             # Only need some struct with a 'speed' variable
             advect = (speed=@view(speed[:,:,:,:,is,it]),)
             # Only need Er
@@ -4551,7 +4551,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
         end
 
         for it ∈ 1:nt
-            begin_serial_region()
+            @begin_serial_region()
             # Only need some struct with a 'speed' variable
             advect = [(speed=@view(speed[:,:,:,:,is,it]),) for is ∈ 1:nspecies]
             # Only need Ez
@@ -4609,7 +4609,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
                            vr=(run_info.vr === nothing ? 1 : run_info.vr.n),
                            vz=(run_info.vz === nothing ? 1 : run_info.vz.n))
         for it ∈ 1:nt
-            begin_serial_region()
+            @begin_serial_region()
             # Only need some struct with a 'speed' variable
             advect = (speed=@view(speed[:,:,:,:,it]),)
             for ir ∈ 1:run_info.r.n
@@ -4683,7 +4683,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
                            vr=(run_info.vr === nothing ? 1 : run_info.vr.n),
                            vz=(run_info.vz === nothing ? 1 : run_info.vz.n))
         for it ∈ 1:nt
-            begin_serial_region()
+            @begin_serial_region()
             # Only need some struct with a 'speed' variable
             advect = (speed=@view(speed[:,:,:,:,it]),)
             moments = (electron=(vth=vth[:,:,it],
@@ -4721,7 +4721,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
                            vperp=run_info.vperp.n, vpa=run_info.vpa.n, vzeta=nvzeta,
                            vr=nvr, vz=nvz)
         for it ∈ 1:nt, isn ∈ 1:nspecies
-            begin_serial_region()
+            @begin_serial_region()
             # Only need some struct with a 'speed' variable
             advect = (speed=@view(speed[:,:,:,:,:,isn,it]),)
             @views update_speed_neutral_z!(advect, uz[:,:,:,it], vth[:,:,:,it],
@@ -4815,7 +4815,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
                            vperp=run_info.vperp.n, vpa=run_info.vpa.n, vzeta=nvzeta,
                            vr=nvr, vz=nvz)
         for it ∈ 1:nt
-            begin_serial_region()
+            @begin_serial_region()
             # Only need some struct with a 'speed' variable
             advect = [(speed=@view(speed[:,:,:,:,:,isn,it]),) for isn ∈ 1:nspecies]
             # Don't actually use `fields` at the moment
@@ -5000,7 +5000,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
         nt = size(speed, 6)
         nspecies = size(speed, 5)
         variable = allocate_float(nt)
-        begin_serial_region()
+        @begin_serial_region()
         for it ∈ 1:nt
             min_CFL = Inf
             for is ∈ 1:nspecies
@@ -5016,7 +5016,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
         nt = size(speed, 6)
         nspecies = size(speed, 5)
         variable = allocate_float(nt)
-        begin_serial_region()
+        @begin_serial_region()
         for it ∈ 1:nt
             min_CFL = Inf
             for is ∈ 1:nspecies
@@ -5032,7 +5032,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
                              normalize_advection_speed_shape=false)
         nt = size(speed, 5)
         variable = allocate_float(nt)
-        begin_serial_region()
+        @begin_serial_region()
         for it ∈ 1:nt
             min_CFL = get_minimum_CFL_z(@view(speed[:,:,:,:,it]), run_info.z)
             variable[it] = min_CFL
@@ -5044,7 +5044,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
         speed = get_variable(run_info, "electron_vpa_advect_speed")
         nt = size(speed, 5)
         variable = allocate_float(nt)
-        begin_serial_region()
+        @begin_serial_region()
         for it ∈ 1:nt
             min_CFL = get_minimum_CFL_vpa(@view(speed[:,:,:,:,it]), run_info.vpa)
             variable[it] = min_CFL
@@ -5058,7 +5058,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
         nt = size(speed, 7)
         nspecies = size(speed, 6)
         variable = allocate_float(nt)
-        begin_serial_region()
+        @begin_serial_region()
         for it ∈ 1:nt
             min_CFL = Inf
             for isn ∈ 1:nspecies
@@ -5074,7 +5074,7 @@ function get_variable(run_info, variable_name; normalize_advection_speed_shape=t
         nt = size(speed, 7)
         nspecies = size(speed, 6)
         variable = allocate_float(nt)
-        begin_serial_region()
+        @begin_serial_region()
         for it ∈ 1:nt
             min_CFL = Inf
             for isn ∈ 1:nspecies

--- a/moment_kinetics/src/manufactured_solns.jl
+++ b/moment_kinetics/src/manufactured_solns.jl
@@ -82,7 +82,7 @@ end
         # Time independent, so store arrays instead of functions
 
         Source_i_array = allocate_shared_float(vpa_coord.n,vperp_coord.n,z_coord.n,r_coord.n)
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
         #println("here loop thing ", looping.loop_ranges[].s)
         @loop_s is begin
             if is == 1
@@ -94,7 +94,7 @@ end
 
         if composition.n_neutral_species > 0
             Source_n_array = allocate_shared_float(vz_coord.n,vr_coord.n,vzeta_coord.n,z_coord.n,r_coord.n)
-            begin_sn_r_z_region()
+            @begin_sn_r_z_region()
             @loop_sn isn begin
                 if isn == 1
                     @loop_r_z_vzeta_vr_vz ir iz ivzeta ivr ivz begin

--- a/moment_kinetics/src/maxwell_diffusion.jl
+++ b/moment_kinetics/src/maxwell_diffusion.jl
@@ -95,7 +95,7 @@ to act as the diffusion operator.
     # the current distribution) using the moments of the distribution (so that the 
     # operator itself conserves the moments), and then this result will be the one 
     # whose second derivative will be added to the RHS (i.e. subtracted from the current)
-    begin_s_r_z_vperp_region()
+    @begin_s_r_z_vperp_region()
 
     # In what follows, there are eight combinations of booleans (though not all have been
     # fully implemented yet). In line with moment kinetics, the Maxwellian is normalised
@@ -206,7 +206,7 @@ to act as the diffusion operator.
     # the current distribution) using the moments of the distribution (so that the 
     # operator itself conserves the moments), and then this result will be the one 
     # whose second derivative will be added to the RHS (i.e. subtracted from the current pdf)
-    begin_sn_r_z_vzeta_vr_region()
+    @begin_sn_r_z_vzeta_vr_region()
 
 
     if moments.evolve_ppar && moments.evolve_upar

--- a/moment_kinetics/src/moment_constraints.jl
+++ b/moment_kinetics/src/moment_constraints.jl
@@ -6,7 +6,6 @@ function.
 module moment_constraints
 
 using ..boundary_conditions: skip_f_electron_bc_points_in_Jacobian
-using ..communication: _block_synchronize
 using ..looping
 using ..timer_utils
 using ..type_definitions: mk_float
@@ -95,7 +94,7 @@ end
     A = moments.electron.constraints_A_coefficient
     B = moments.electron.constraints_B_coefficient
     C = moments.electron.constraints_C_coefficient
-    begin_r_z_region()
+    @begin_r_z_region()
     @loop_r_z ir iz begin
         A[iz,ir], B[iz,ir], C[iz,ir] =
             hard_force_moment_constraints!(@view(f[:,:,iz,ir]), moments, vpa)
@@ -106,7 +105,7 @@ end
     A = moments.ion.constraints_A_coefficient
     B = moments.ion.constraints_B_coefficient
     C = moments.ion.constraints_C_coefficient
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
     @loop_s_r_z is ir iz begin
         A[iz,ir,is], B[iz,ir,is], C[iz,ir,is] =
             hard_force_moment_constraints!(@view(f[:,:,iz,ir,is]), moments, vpa)
@@ -171,7 +170,7 @@ end
     A = moments.neutral.constraints_A_coefficient
     B = moments.neutral.constraints_B_coefficient
     C = moments.neutral.constraints_C_coefficient
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
     @loop_sn_r_z isn ir iz begin
         A[iz,ir,isn], B[iz,ir,isn], C[iz,ir,isn] =
             hard_force_moment_constraints_neutral!(@view(f[:,:,:,iz,ir,is]), moments, vz)
@@ -256,7 +255,7 @@ timesteps that do not guarantee accurate time evolution.
 """
 @timeit global_timer electron_implicit_constraint_forcing!(
                          f_out, f_in, constraint_forcing_rate, vpa, dt, ir) = begin
-    begin_z_region()
+    @begin_z_region()
     vpa_grid = vpa.grid
     @loop_z iz begin
         @views zeroth_moment = integrate_over_vspace(f_in[:,1,iz], vpa.wgts)
@@ -297,7 +296,7 @@ function add_electron_implicit_constraint_forcing_to_Jacobian!(
     vpa_wgts = vpa.wgts
     v_size = vperp.n * vpa.n
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
     @loop_z_vperp_vpa iz ivperp ivpa begin
         if skip_f_electron_bc_points_in_Jacobian(iz, ivperp, ivpa, z, vperp, vpa, z_speed)
             continue

--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -92,7 +92,7 @@ using .file_io: write_all_moments_data_to_binary, write_all_dfns_data_to_binary,
                 write_final_timing_data_to_binary
 using .command_line_options: get_options
 using .communication
-using .communication: _block_synchronize
+using .communication: @_block_synchronize
 using .debugging
 using .external_sources
 using .input_structs
@@ -312,14 +312,14 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
                                     composition, geometry, r, z, vpa, vperp, vzeta, vr,
                                     vz)
 
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             @. moments.electron.temp = composition.me_over_mi * moments.electron.vth^2
             @. moments.electron.ppar = 0.5 * moments.electron.dens * moments.electron.temp
         end
         if composition.electron_physics ∈ (kinetic_electrons,
                                            kinetic_electrons_with_temperature_equation)
-            begin_r_z_vperp_vpa_region()
+            @begin_r_z_vperp_vpa_region()
             @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
                 pdf.electron.pdf_before_ion_timestep[ivpa,ivperp,iz,ir] =
                     pdf.electron.norm[ivpa,ivperp,iz,ir]
@@ -331,7 +331,7 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
         initialize_external_source_amplitude!(moments, external_source_settings, vperp,
                                               vzeta, vr, composition.n_neutral_species)
 
-        _block_synchronize()
+        @_block_synchronize()
     end
 
     # Broadcast code_time from the root process of each shared-memory block (on which it
@@ -386,7 +386,7 @@ parallel loop ranges, and are only used by the tests in `debug_test/`.
         io_dfns = nothing
     end
 
-    begin_s_r_z_vperp_region()
+    @begin_s_r_z_vperp_region()
 
     return pdf, scratch, scratch_implicit, scratch_electron, t_params, vz, vr,
            vzeta, vpa, vperp, gyrophase, z, r, moments, fields, spectral_objects,
@@ -406,7 +406,7 @@ function cleanup_moment_kinetics!(ascii_io, io_moments, io_dfns)
         debug_detect_redundant_is_active[] = false
     end
 
-    begin_serial_region()
+    @begin_serial_region()
 
     # finish i/o
     finish_file_io(ascii_io, io_moments, io_dfns)

--- a/moment_kinetics/src/neutral_r_advection.jl
+++ b/moment_kinetics/src/neutral_r_advection.jl
@@ -18,7 +18,7 @@ do a single stage time advance in r (potentially as part of a multi-stage RK sch
                          f_out, fvec_in, advect, r, z, vzeta, vr, vz, dt, r_spectral,
                          composition, geometry, scratch_dummy) = begin
     
-    begin_sn_z_vzeta_vr_vz_region()
+    @begin_sn_z_vzeta_vr_vz_region()
     
     @loop_sn isn begin
         # get the updated speed along the r direction using the current f

--- a/moment_kinetics/src/neutral_vz_advection.jl
+++ b/moment_kinetics/src/neutral_vz_advection.jl
@@ -23,7 +23,7 @@ begin
         return nothing
     end
 
-    begin_sn_r_z_vzeta_vr_region()
+    @begin_sn_r_z_vzeta_vr_region()
 
     # calculate the advection speed corresponding to current f
     update_speed_neutral_vz!(advect, fields, fvec_in, moments, vz, vr, vzeta, z, r,
@@ -52,7 +52,7 @@ function update_speed_neutral_vz!(advect, fields, fvec, moments, vz, vr, vzeta, 
         update_speed_default_neutral!(advect, fields, fvec, moments, vz, z, r,
                                       composition, collisions, neutral_source_settings)
     elseif vz.advection.option == "constant"
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             # Not usually used - just run in serial
             # dvpa/dt = constant
@@ -61,7 +61,7 @@ function update_speed_neutral_vz!(advect, fields, fvec, moments, vz, vr, vzeta, 
             end
         end
     elseif vpa.advection.option == "linear"
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             # Not usually used - just run in serial
             # dvpa/dt = constant ⋅ (vpa + L_vpa/2)

--- a/moment_kinetics/src/neutral_z_advection.jl
+++ b/moment_kinetics/src/neutral_z_advection.jl
@@ -18,7 +18,7 @@ do a single stage time advance (potentially as part of a multi-stage RK scheme)
                          f_out, fvec_in, moments, advect, r, z, vzeta, vr, vz, dt, t,
                          spectral, composition, scratch_dummy) = begin
 
-    begin_sn_r_vzeta_vr_vz_region()
+    @begin_sn_r_vzeta_vr_vz_region()
 
     @loop_sn isn begin
         # get the updated speed along the z direction using the current f

--- a/moment_kinetics/src/nonlinear_solvers.jl
+++ b/moment_kinetics/src/nonlinear_solvers.jl
@@ -138,7 +138,7 @@ function setup_nonlinear_solve(active, input_dict, coords, outer_coords=(); defa
         V_ppar = allocate_shared_float(coords.z.n, linear_restart+1)
         V_pdf = allocate_shared_float(reverse(coord_sizes)..., linear_restart+1)
 
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             H .= 0.0
             c .= 0.0
@@ -158,7 +158,7 @@ function setup_nonlinear_solve(active, input_dict, coords, outer_coords=(); defa
         g = allocate_shared_float(linear_restart + 1)
         V = allocate_shared_float(reverse(coord_sizes)..., linear_restart+1)
 
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             H .= 0.0
             c .= 0.0
@@ -567,7 +567,7 @@ end
                                rtol, atol, x) = begin
     z = coords.z
 
-    begin_z_region()
+    @begin_z_region()
 
     local_norm = 0.0
     if z.irank < z.nrank - 1
@@ -584,7 +584,7 @@ end
         end
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_norm = Ref(local_norm)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_norm, +, comm_block[]) # global_norm is the norm_square for the block
 
@@ -592,7 +592,7 @@ end
         @timeit_debug global_timer "MPI.Allreduce! comm_inter_block" MPI.Allreduce!(global_norm, +, comm_inter_block[]) # global_norm is the norm_square for the whole grid
         global_norm[] = sqrt(global_norm[] / z.n_global)
     end
-    _block_synchronize()
+    @_block_synchronize()
     @timeit_debug global_timer "MPI.Bcast! comm_block" MPI.Bcast!(global_norm, comm_block[]; root=0)
 
     return global_norm[]
@@ -629,7 +629,7 @@ end
         zend = z.n + 1
     end
 
-    begin_z_region()
+    @begin_z_region()
 
     ppar_local_norm_square = 0.0
     @loop_z iz begin
@@ -639,7 +639,7 @@ end
         ppar_local_norm_square += (ppar_residual[iz] / (rtol * abs(x_ppar[iz]) + atol))^2
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_norm_ppar = Ref(ppar_local_norm_square) # global_norm_ppar is the norm_square for ppar in the block
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_norm_ppar, +, comm_block[])
 
@@ -648,7 +648,7 @@ end
         global_norm_ppar[] = global_norm_ppar[] / z.n_global
     end
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
 
     pdf_local_norm_square = 0.0
     @loop_z iz begin
@@ -660,7 +660,7 @@ end
         end
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_norm = Ref(pdf_local_norm_square)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_norm, +, comm_block[]) # global_norm is the norm_square for the block
 
@@ -670,7 +670,7 @@ end
 
         global_norm[] = sqrt(mean((global_norm_ppar[], global_norm[])))
     end
-    _block_synchronize()
+    @_block_synchronize()
 
     @timeit_debug global_timer "MPI.Bcast! comm_block" MPI.Bcast!(global_norm, comm_block[]; root=0)
 
@@ -686,7 +686,7 @@ end
     vperp = coords.vperp
     vpa = coords.vpa
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     local_norm = 0.0
     if r.irank < r.nrank - 1
@@ -708,7 +708,7 @@ end
         end
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_norm = Ref(local_norm)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_norm, +, comm_block[]) # global_norm is the norm_square for the block
 
@@ -716,7 +716,7 @@ end
         @timeit_debug global_timer "MPI.Allreduce! comm_inter_block" MPI.Allreduce!(global_norm, +, comm_inter_block[]) # global_norm is the norm_square for the whole grid
         global_norm[] = sqrt(global_norm[] / (n_ion_species * r.n_global * z.n_global * vperp.n_global * vpa.n_global))
     end
-    _block_synchronize()
+    @_block_synchronize()
     @timeit_debug global_timer "MPI.Bcast! comm_block" MPI.Bcast!(global_norm, comm_block[]; root=0)
 
     return global_norm[]
@@ -728,7 +728,7 @@ end
 
     z = coords.z
 
-    begin_z_region()
+    @begin_z_region()
 
     z = coords.z
 
@@ -747,7 +747,7 @@ end
         end
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_dot = Ref(local_dot)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_dot, +, comm_block[]) # global_dot is the dot for the block
 
@@ -790,7 +790,7 @@ end
         zend = z.n + 1
     end
 
-    begin_z_region()
+    @begin_z_region()
 
     ppar_local_dot = 0.0
     @loop_z iz begin
@@ -800,7 +800,7 @@ end
         ppar_local_dot += v_ppar[iz] * w_ppar[iz] / (rtol * abs(x_ppar[iz]) + atol)^2
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     ppar_global_dot = Ref(ppar_local_dot)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(ppar_global_dot, +, comm_block[]) # ppar_global_dot is the ppar_dot for the block
 
@@ -809,7 +809,7 @@ end
         ppar_global_dot[] = ppar_global_dot[] / z.n_global
     end
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
 
     pdf_local_dot = 0.0
     @loop_z_vperp_vpa iz ivperp ivpa begin
@@ -819,7 +819,7 @@ end
         pdf_local_dot += v_pdf[ivpa,ivperp,iz] * w_pdf[ivpa,ivperp,iz] / (rtol * abs(x_pdf[ivpa,ivperp,iz]) + atol)^2
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_dot = Ref(pdf_local_dot)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_dot, +, comm_block[]) # global_dot is the dot for the block
 
@@ -842,7 +842,7 @@ end
     vperp = coords.vperp
     vpa = coords.vpa
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     local_dot = 0.0
     if r.irank < r.nrank - 1
@@ -863,7 +863,7 @@ end
         local_dot += v[ivpa,ivperp,iz,ir,is] * w[ivpa,ivperp,iz,ir,is] / (rtol * abs(x[ivpa,ivperp,iz,ir,is]) + atol)^2
     end
 
-    _block_synchronize()
+    @_block_synchronize()
     global_dot = Ref(local_dot)
     @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_dot, +, comm_block[]) # global_dot is the dot for the block
 
@@ -881,7 +881,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:z}, func, result::AbstractArray{mk_float, 1}) = begin
 
-    begin_z_region()
+    @begin_z_region()
 
     @loop_z iz begin
         result[iz] = func()
@@ -892,7 +892,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:z}, func, result::AbstractArray{mk_float, 1}, x1) = begin
 
-    begin_z_region()
+    @begin_z_region()
 
     @loop_z iz begin
         result[iz] = func(x1[iz])
@@ -903,7 +903,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:z}, func, result::AbstractArray{mk_float, 1}, x1, x2) = begin
 
-    begin_z_region()
+    @begin_z_region()
 
     if isa(x2, AbstractArray)
         @loop_z iz begin
@@ -920,7 +920,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:z}, func, result::AbstractArray{mk_float, 1}, x1, x2, x3) = begin
 
-    begin_z_region()
+    @begin_z_region()
 
     if isa(x3, AbstractArray)
         @loop_z iz begin
@@ -989,13 +989,13 @@ end
 
     result_ppar, result_pdf = result
 
-    begin_z_region()
+    @begin_z_region()
 
     @loop_z iz begin
         result_ppar[iz] = func()
     end
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
 
     @loop_z_vperp_vpa iz ivperp ivpa begin
         result_pdf[ivpa,ivperp,iz] = func()
@@ -1010,13 +1010,13 @@ end
     result_ppar, result_pdf = result
     x1_ppar, x1_pdf = x1
 
-    begin_z_region()
+    @begin_z_region()
 
     @loop_z iz begin
         result_ppar[iz] = func(x1_ppar[iz])
     end
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
 
     @loop_z_vperp_vpa iz ivperp ivpa begin
         result_pdf[ivpa,ivperp,iz] = func(x1_pdf[ivpa,ivperp,iz])
@@ -1033,25 +1033,25 @@ end
 
     if isa(x2, Tuple)
         x2_ppar, x2_pdf = x2
-        begin_z_region()
+        @begin_z_region()
 
         @loop_z iz begin
             result_ppar[iz] = func(x1_ppar[iz], x2_ppar[iz])
         end
 
-        begin_z_vperp_vpa_region()
+        @begin_z_vperp_vpa_region()
 
         @loop_z_vperp_vpa iz ivperp ivpa begin
             result_pdf[ivpa,ivperp,iz] = func(x1_pdf[ivpa,ivperp,iz], x2_pdf[ivpa,ivperp,iz])
         end
     else
-        begin_z_region()
+        @begin_z_region()
 
         @loop_z iz begin
             result_ppar[iz] = func(x1_ppar[iz], x2)
         end
 
-        begin_z_vperp_vpa_region()
+        @begin_z_vperp_vpa_region()
 
         @loop_z_vperp_vpa iz ivperp ivpa begin
             result_pdf[ivpa,ivperp,iz] = func(x1_pdf[ivpa,ivperp,iz], x2)
@@ -1070,25 +1070,25 @@ end
 
     if isa(x3, Tuple)
         x3_ppar, x3_pdf = x3
-        begin_z_region()
+        @begin_z_region()
 
         @loop_z iz begin
             result_ppar[iz] = func(x1_ppar[iz], x2_ppar[iz], x3_ppar[iz])
         end
 
-        begin_z_vperp_vpa_region()
+        @begin_z_vperp_vpa_region()
 
         @loop_z_vperp_vpa iz ivperp ivpa begin
             result_pdf[ivpa,ivperp,iz] = func(x1_pdf[ivpa,ivperp,iz], x2_pdf[ivpa,ivperp,iz], x3_pdf[ivpa,ivperp,iz])
         end
     else
-        begin_z_region()
+        @begin_z_region()
 
         @loop_z iz begin
             result_ppar[iz] = func(x1_ppar[iz], x2_ppar[iz], x3)
         end
 
-        begin_z_vperp_vpa_region()
+        @begin_z_vperp_vpa_region()
 
         @loop_z_vperp_vpa iz ivperp ivpa begin
             result_pdf[ivpa,ivperp,iz] = func(x1_pdf[ivpa,ivperp,iz], x2_pdf[ivpa,ivperp,iz], x3)
@@ -1101,7 +1101,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:srzvperpvpa}, func, result::AbstractArray{mk_float, 5}) = begin
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
         result[ivpa,ivperp,iz,ir,is] = func()
@@ -1112,7 +1112,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:srzvperpvpa}, func, result::AbstractArray{mk_float, 5}, x1) = begin
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
         result[ivpa,ivperp,iz,ir,is] = func(x1[ivpa,ivperp,iz,ir,is])
@@ -1123,7 +1123,7 @@ end
 @timeit_debug global_timer parallel_map(
                   ::Val{:srzvperpvpa}, func, result::AbstractArray{mk_float, 5}, x1, x2) = begin
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     if isa(x2, AbstractArray)
         @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
@@ -1141,7 +1141,7 @@ end
                   ::Val{:srzvperpvpa}, func, result::AbstractArray{mk_float, 5}, x1, x2,
                   x3) = begin
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     if isa(x3, AbstractArray)
         @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
@@ -1159,7 +1159,7 @@ end
 @timeit_debug global_timer parallel_delta_x_calc(
                   ::Val{:z}, delta_x::AbstractArray{mk_float, 1}, V, y) = begin
 
-    begin_z_region()
+    @begin_z_region()
 
     ny = length(y)
     @loop_z iz begin
@@ -1193,7 +1193,7 @@ end
 
     ny = length(y)
 
-    begin_z_region()
+    @begin_z_region()
 
     @loop_z iz begin
         for iy ∈ 1:ny
@@ -1201,7 +1201,7 @@ end
         end
     end
 
-    begin_z_vperp_vpa_region()
+    @begin_z_vperp_vpa_region()
 
     @loop_z_vperp_vpa iz ivperp ivpa begin
         for iy ∈ 1:ny
@@ -1215,7 +1215,7 @@ end
 @timeit_debug global_timer parallel_delta_x_calc(
                   ::Val{:srzvperpvpa}, delta_x::AbstractArray{mk_float, 5}, V, y) = begin
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     ny = length(y)
     @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
@@ -1296,7 +1296,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
     if serial_solve
         g[1] = beta
     else
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             g[1] = beta
         end
@@ -1328,7 +1328,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                 if serial_solve
                     H[j,i] = w_dot_Vj
                 else
-                    begin_serial_region()
+                    @begin_serial_region()
                     @serial_region begin
                         H[j,i] = w_dot_Vj
                     end
@@ -1339,7 +1339,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
             if serial_solve
                 H[i+1,i] = norm_w
             else
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     H[i+1,i] = norm_w
                 end
@@ -1360,7 +1360,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                 g[i+1] = -s[i] * g[i]
                 g[i] = c[i] * g[i]
             else
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     for j ∈ 1:i-1
                         gamma = c[j] * H[j,i] + s[j] * H[j+1,i]
@@ -1375,7 +1375,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                     g[i+1] = -s[i] * g[i]
                     g[i] = c[i] * g[i]
                 end
-                _block_synchronize()
+                @_block_synchronize()
             end
             residual = abs(g[i+1])
 

--- a/moment_kinetics/src/numerical_dissipation.jl
+++ b/moment_kinetics/src/numerical_dissipation.jl
@@ -139,7 +139,7 @@ vpa_boundary_buffer_damping_rate = 0.1
         vpa_inds = flatten((1:nbuffer, vpa.n-nbuffer+1:vpa.n))
     end
 
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     if moments.evolve_upar && moments.evolve_ppar
         @loop_s_r_z is ir iz begin
@@ -238,7 +238,7 @@ vpa_boundary_buffer_diffusion_coefficient = 0.1
         vpa_inds = flatten((1:nbuffer, vpa.n-nbuffer+1:vpa.n))
     end
 
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     @loop_s_r_z is ir iz begin
         # Calculate second derivative
@@ -260,7 +260,7 @@ the boundaries, so this should be an OK thing to force.
 Note: not currently used.
 """
 @timeit global_timer vpa_boundary_force_decreasing!(f_out, vpa) = begin
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
 
     ngrid = vpa.ngrid
     n = vpa.n
@@ -301,7 +301,7 @@ vpa_dissipation_coefficient = 0.1
         return nothing
     end
 
-    begin_s_r_z_vperp_region()
+    @begin_s_r_z_vperp_region()
 
     # if T_spectral <: Bool
     #     # Scale diffusion coefficient like square of grid spacing, so convergence will
@@ -358,7 +358,7 @@ vperp_dissipation_coefficient = 0.1
 @timeit global_timer vperp_dissipation!(
                          f_out, f_in, vperp, spectral, dt, diffusion_coefficient) = begin
     
-    begin_s_r_z_vpa_region()
+    @begin_s_r_z_vpa_region()
 
     if diffusion_coefficient <= 0.0 || vperp.n == 1
         return nothing
@@ -396,7 +396,7 @@ on internal or external element boundaries
         return nothing
     end
 
-    begin_s_r_vperp_vpa_region()
+    @begin_s_r_vperp_vpa_region()
 
     # calculate d^2 f / d z^2 using distributed memory compatible routines
     second_derivative_z!(scratch_dummy.buffer_vpavperpzrs_1, f_in,
@@ -437,7 +437,7 @@ on internal or external element boundaries
         return nothing
     end
 
-    begin_s_z_vperp_vpa_region()
+    @begin_s_z_vperp_vpa_region()
 
     # calculate d^2 f / d r^2 using distributed memory compatible routines
     second_derivative_r!(scratch_dummy.buffer_vpavperpzrs_1, f_in,
@@ -471,7 +471,7 @@ vz_dissipation_coefficient = 0.1
         return nothing
     end
 
-    begin_sn_r_z_vzeta_vr_region()
+    @begin_sn_r_z_vzeta_vr_region()
 
     @loop_sn_r_z_vzeta_vr isn ir iz ivzeta ivr begin
         @views second_derivative!(vz.scratch, f_in[:,ivr,ivzeta,iz,ir,isn], vz, spectral)
@@ -505,7 +505,7 @@ on internal or external element boundaries
         return nothing
     end
 
-    begin_sn_r_vzeta_vr_vz_region()
+    @begin_sn_r_vzeta_vr_vz_region()
 
     # calculate d^2 f / d z^2  using distributed memory compatible routines
     second_derivative_z!(scratch_dummy.buffer_vzvrvzetazrsn_1, f_in,
@@ -546,7 +546,7 @@ on internal or external element boundaries
         return nothing
     end
 
-    begin_sn_z_vzeta_vr_vz_region()
+    @begin_sn_z_vzeta_vr_vz_region()
 
     # calculate d^2 f/ d r^2 using distributed memory compatible routines
     second_derivative_r!(scratch_dummy.buffer_vzvrvzetazrsn_1, f_in,

--- a/moment_kinetics/src/r_advection.jl
+++ b/moment_kinetics/src/r_advection.jl
@@ -18,7 +18,7 @@ do a single stage time advance (potentially as part of a multi-stage RK scheme)
                          f_out, fvec_in, moments, fields, advect, r, z, vperp, vpa, dt,
                          r_spectral, composition, geometry, scratch_dummy) = begin
 
-    begin_s_z_vperp_vpa_region()
+    @begin_s_z_vperp_vpa_region()
 
     @loop_s is begin
         # get the updated speed along the r direction using the current f

--- a/moment_kinetics/src/runge_kutta.jl
+++ b/moment_kinetics/src/runge_kutta.jl
@@ -553,7 +553,7 @@ function rk_update_loop_low_storage!(rk_coefs, rk_coefs_implicit,
                                      old_implicit, first_implicit; output=new)
     @boundscheck length(rk_coefs) == 3
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
     if rk_coefs_implicit === nothing
         @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
             output[ivpa,ivperp,iz,ir,is] = rk_coefs[1]*first[ivpa,ivperp,iz,ir,is] +
@@ -577,7 +577,7 @@ function rk_update_loop!(rk_coefs, rk_coefs_implicit,
                          var_arrays_implicit; output=var_arrays[N]) where N
     @boundscheck length(rk_coefs) ≥ N
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
     if rk_coefs_implicit === nothing
         @loop_s_r_z_vperp_vpa is ir iz ivperp ivpa begin
             output[ivpa,ivperp,iz,ir,is] =
@@ -602,7 +602,7 @@ function rk_update_loop_low_storage!(rk_coefs, rk_coefs_implicit,
                                      old_implicit, first_implicit; output=new)
     @boundscheck length(rk_coefs) == 3
 
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
     if rk_coefs_implicit === nothing
         @loop_s_r_z is ir iz begin
             output[iz,ir,is] = rk_coefs[1]*first[iz,ir,is] +
@@ -626,7 +626,7 @@ function rk_update_loop!(rk_coefs, rk_coefs_implicit,
                          var_arrays_implicit; output=var_arrays[N]) where N
     @boundscheck length(rk_coefs) ≥ N
 
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
     if rk_coefs_implicit === nothing
         @loop_s_r_z is ir iz begin
             output[iz,ir,is] = sum(rk_coefs[i] * var_arrays[i][iz,ir,is] for i ∈ 1:N)
@@ -649,7 +649,7 @@ function rk_update_loop_low_storage!(rk_coefs, rk_coefs_implicit,
                                      old_implicit, first_implicit; output=new)
     @boundscheck length(rk_coefs) == 3
 
-    begin_r_z_vperp_vpa_region()
+    @begin_r_z_vperp_vpa_region()
     if rk_coefs_implicit === nothing
         @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
             output[ivpa,ivperp,iz,ir] = rk_coefs[1]*first[ivpa,ivperp,iz,ir] +
@@ -673,7 +673,7 @@ function rk_update_loop!(rk_coefs, rk_coefs_implicit,
                          var_arrays_implicit; output=var_arrays[N]) where N
     @boundscheck length(rk_coefs) ≥ N
 
-    begin_r_z_vperp_vpa_region()
+    @begin_r_z_vperp_vpa_region()
     if rk_coefs_implicit === nothing
         @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
             output[ivpa,ivperp,iz,ir] =
@@ -699,7 +699,7 @@ function rk_update_loop_low_storage!(rk_coefs, rk_coefs_implicit,
                                      old_implicit, first_implicit; output=new)
     @boundscheck length(rk_coefs) == 3
 
-    begin_r_z_region()
+    @begin_r_z_region()
     if rk_coefs_implicit === nothing
         @loop_r_z ir iz begin
             output[iz,ir] = rk_coefs[1]*first[iz,ir] +
@@ -724,7 +724,7 @@ function rk_update_loop!(rk_coefs, rk_coefs_implicit,
                          output=var_arrays[N]) where N
     @boundscheck length(rk_coefs) ≥ N
 
-    begin_r_z_region()
+    @begin_r_z_region()
     if rk_coefs_implicit === nothing
         @loop_r_z ir iz begin
             output[iz,ir] = sum(rk_coefs[i] * var_arrays[i][iz,ir] for i ∈ 1:N)
@@ -749,7 +749,7 @@ function rk_update_loop_neutrals_low_storage!(rk_coefs, rk_coefs_implicit,
                                               output=new)
     @boundscheck length(rk_coefs) == 3
 
-    begin_sn_r_z_vzeta_vr_vz_region()
+    @begin_sn_r_z_vzeta_vr_vz_region()
     if rk_coefs_implicit === nothing
         @loop_sn_r_z_vzeta_vr_vz isn ir iz ivzeta ivr ivz begin
             output[ivz,ivr,ivzeta,iz,ir,isn] = rk_coefs[1]*first[ivz,ivr,ivzeta,iz,ir,isn] +
@@ -773,7 +773,7 @@ function rk_update_loop_neutrals!(rk_coefs, rk_coefs_implicit,
                                   var_arrays_implicit; output=var_arrays[N]) where N
     @boundscheck length(rk_coefs) ≥ N
 
-    begin_sn_r_z_vzeta_vr_vz_region()
+    @begin_sn_r_z_vzeta_vr_vz_region()
     if rk_coefs_implicit === nothing
         @loop_sn_r_z_vzeta_vr_vz isn ir iz ivzeta ivr ivz begin
             output[ivz,ivr,ivzeta,iz,ir,isn] =
@@ -800,7 +800,7 @@ function rk_update_loop_neutrals_low_storage!(rk_coefs, rk_coefs_implicit,
                                               output=new)
     @boundscheck length(rk_coefs) == 3
 
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
     if rk_coefs_implicit === nothing
         @loop_sn_r_z isn ir iz begin
             output[iz,ir,isn] = rk_coefs[1]*first[iz,ir,isn] +
@@ -824,7 +824,7 @@ function rk_update_loop_neutrals!(rk_coefs, rk_coefs_implicit,
                                   var_arrays_implicit; output=var_arrays[N]) where N
     @boundscheck length(rk_coefs) ≥ N
 
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
     if rk_coefs_implicit === nothing
         @loop_sn_r_z isn ir iz begin
             output[iz,ir,isn] = sum(rk_coefs[i] * var_arrays[i][iz,ir,isn] for i ∈ 1:N)

--- a/moment_kinetics/src/source_terms.jl
+++ b/moment_kinetics/src/source_terms.jl
@@ -17,7 +17,7 @@ flow and/or pressure, and use them to update the pdf
                          pdf_out, fvec_in, moments, vpa, z, r, dt, spectral, composition,
                          collisions, ion_source_settings) = begin
 
-    begin_s_r_z_vperp_vpa_region()
+    @begin_s_r_z_vperp_vpa_region()
 
     #n_species = size(pdf_out,3)
     if moments.evolve_ppar
@@ -152,7 +152,7 @@ flow and/or pressure, and use them to update the pdf
                          pdf_out, fvec_in, moments, vpa, z, r, dt, spectral, composition,
                          collisions, neutral_source_settings) = begin
 
-    begin_sn_r_z_vzeta_vr_vz_region()
+    @begin_sn_r_z_vzeta_vr_vz_region()
 
     #n_species = size(pdf_out,3)
     if moments.evolve_ppar
@@ -284,7 +284,7 @@ advance the dfn with an arbitrary source function
         Source_i = manufactured_source_list.Source_i_array
         Source_n = manufactured_source_list.Source_n_array
 
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
 
         @loop_s is begin
             @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
@@ -293,7 +293,7 @@ advance the dfn with an arbitrary source function
         end
 
         if composition.n_neutral_species > 0
-            begin_sn_r_z_region()
+            @begin_sn_r_z_region()
             @loop_sn isn begin
                 @loop_r_z_vzeta_vr_vz ir iz ivzeta ivr ivz begin
                     pdf_neutral_out[ivz,ivr,ivzeta,iz,ir,isn] += dt*Source_n[ivz,ivr,ivzeta,iz,ir]
@@ -305,7 +305,7 @@ advance the dfn with an arbitrary source function
         Source_i_func = manufactured_source_list.Source_i_func
         Source_n_func = manufactured_source_list.Source_n_func
 
-        begin_s_r_z_region()
+        @begin_s_r_z_region()
 
         @loop_s is begin
             @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
@@ -314,7 +314,7 @@ advance the dfn with an arbitrary source function
         end
 
         if composition.n_neutral_species > 0
-            begin_sn_r_z_region()
+            @begin_sn_r_z_region()
             @loop_sn isn begin
                 @loop_r_z_vzeta_vr_vz ir iz ivzeta ivr ivz begin
                     pdf_neutral_out[ivz,ivr,ivzeta,iz,ir,isn] += dt*Source_n_func(vz.grid[ivz],vr.grid[ivr],vzeta.grid[ivzeta],z.grid[iz],r.grid[ir],t)

--- a/moment_kinetics/src/velocity_grid_transforms.jl
+++ b/moment_kinetics/src/velocity_grid_transforms.jl
@@ -26,7 +26,7 @@ using ..timer_utils
     @boundscheck r.n == size(f_out, 4) || throw(BoundsError(f_out))
     @boundscheck composition.n_neutral_species == size(f_out, 5) || throw(BoundsError(f_out))
 
-    begin_sn_r_z_region()
+    @begin_sn_r_z_region()
     @loop_sn_r_z isn ir iz begin
         bzed = geometry.bzed[iz,ir]
         bzeta = geometry.bzeta[iz,ir]
@@ -82,7 +82,7 @@ end
     @boundscheck r.n == size(f_out, 5) || throw(BoundsError(f_out))
     @boundscheck composition.n_ion_species == size(f_out, 6) || throw(BoundsError(f_out))
     
-    begin_s_r_z_region()
+    @begin_s_r_z_region()
     @loop_s_r_z is ir iz begin
         bzed = geometry.bzed[iz,ir]
         bzeta = geometry.bzeta[iz,ir]

--- a/moment_kinetics/src/vpa_advection.jl
+++ b/moment_kinetics/src/vpa_advection.jl
@@ -29,7 +29,7 @@ using SparseArrays
                          vpa_spectral, composition, collisions, ion_source_settings,
                          geometry) = begin
 
-    begin_s_r_z_vperp_region()
+    @begin_s_r_z_vperp_region()
 
     # only have a parallel acceleration term for neutrals if using the peculiar velocity
     # wpar = vpar - upar as a variable; i.e., d(wpar)/dt /=0 for neutrals even though d(vpar)/dt = 0.
@@ -72,7 +72,7 @@ end
                                       z_spectral,
                                       num_diss_params.ion.moment_dissipation_coefficient)
 
-    begin_s_r_z_vperp_region()
+    @begin_s_r_z_vperp_region()
 
     coords = (vpa=vpa,)
     vpa_bc = vpa.bc
@@ -335,7 +335,7 @@ function update_speed_vpa!(advect, fields, fvec, moments, vpa, vperp, z, r, comp
         update_speed_default!(advect, fields, fvec, moments, vpa, vperp, z, r, composition,
                               collisions, ion_source_settings, t, geometry)
     elseif vpa.advection.option == "constant"
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             # Not usually used - just run in serial
             # dvpa/dt = constant
@@ -344,7 +344,7 @@ function update_speed_vpa!(advect, fields, fvec, moments, vpa, vperp, z, r, comp
             end
         end
     elseif vpa.advection.option == "linear"
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             # Not usually used - just run in serial
             # dvpa/dt = constant ⋅ (vpa + L_vpa/2)

--- a/moment_kinetics/src/vperp_advection.jl
+++ b/moment_kinetics/src/vperp_advection.jl
@@ -20,7 +20,7 @@ using ..r_advection: update_speed_r!
     update_z_r_speeds!(z_advect, r_advect, fvec_in, moments, fields,
                             geometry, vpa, vperp, z, r, t)
     
-    begin_s_r_z_vpa_region()
+    @begin_s_r_z_vpa_region()
     @loop_s is begin
         # get the updated speed along the vperp direction using the current f
         @views update_speed_vperp!(vperp_advect[is], vpa, vperp, z, r, z_advect[is], r_advect[is], geometry)
@@ -74,7 +74,7 @@ function update_z_r_speeds!(z_advect, r_advect, fvec_in, moments, fields,
     if update_z_speed
     # make sure z speed is physical despite
     # 0D nature of simulation
-        begin_s_r_vperp_vpa_region()
+        @begin_s_r_vperp_vpa_region()
         @loop_s is begin
             # get the updated speed along the z direction using the current f
             @views update_speed_z!(z_advect[is], fvec_in.upar[:,:,is],
@@ -87,7 +87,7 @@ function update_z_r_speeds!(z_advect, r_advect, fvec_in, moments, fields,
     if update_r_speed
     # make sure r speed is physical despite
     # 0D nature of simulation
-        begin_s_z_vperp_vpa_region()
+        @begin_s_z_vperp_vpa_region()
         @loop_s is begin
             # get the updated speed along the r direction using the current f
             update_speed_r!(r_advect[is], fvec_in.upar[:,:,is],

--- a/moment_kinetics/src/z_advection.jl
+++ b/moment_kinetics/src/z_advection.jl
@@ -18,7 +18,7 @@ do a single stage time advance (potentially as part of a multi-stage RK scheme)
                          f_out, fvec_in, moments, fields, advect, z, vpa, vperp, r, dt, t,
                          spectral, composition, geometry, scratch_dummy) = begin
 
-    begin_s_r_vperp_vpa_region()
+    @begin_s_r_vperp_vpa_region()
 
     @loop_s is begin
         # get the updated speed along the z direction using the current f

--- a/moment_kinetics/test/fokker_planck_tests.jl
+++ b/moment_kinetics/test/fokker_planck_tests.jl
@@ -102,7 +102,7 @@ function runtests()
             # scale factor for change of reference speed
             scalefac = cref_ion/cref_electron
 
-            begin_serial_region()
+            @begin_serial_region()
             @serial_region begin
                 @loop_vperp_vpa ivperp ivpa begin
                     Fe[ivpa,ivperp] = F_Maxwellian(dense,upare,vthe,vpa,vperp,ivpa,ivperp)
@@ -112,7 +112,7 @@ function runtests()
                 end
             end
 
-            begin_s_r_z_anyv_region()
+            @begin_s_r_z_anyv_region()
             interpolate_2D_vspace!(Fe_interp_ion_units,Fe,vpa,vperp,scalefac)
             #println("Fe",Fe)
             #println("Fe interp",Fe_interp_ion_units)
@@ -122,7 +122,7 @@ function runtests()
             #println("Fi interp", Fi_interp_electron_units)
             #println("Fi exact",Fi_exact_electron_units)
 
-            begin_serial_region()
+            @begin_serial_region()
             # check the result
             @serial_region begin
                 # for electron data on ion grids
@@ -151,7 +151,7 @@ function runtests()
             vpa, vpa_spectral, vperp, vperp_spectral = create_grids(ngrid,nelement_vpa,nelement_vperp,
                                                                         Lvpa=2.0,Lvperp=1.0)
             nc_global = vpa.n*vperp.n
-            begin_serial_region()
+            @begin_serial_region()
             fkpl_arrays = init_fokker_planck_collisions_weak_form(vpa,vperp,vpa_spectral,vperp_spectral,
                                                                   precompute_weights=false, print_to_screen=print_to_screen)
             KKpar2D_with_BC_terms_sparse = fkpl_arrays.KKpar2D_with_BC_terms_sparse
@@ -215,7 +215,7 @@ function runtests()
                 nelement_vperp = 4
                 vpa, vpa_spectral, vperp, vperp_spectral = create_grids(ngrid,nelement_vpa,nelement_vperp,
                                                                             Lvpa=12.0,Lvperp=6.0)
-                begin_serial_region()
+                @begin_serial_region()
                 if boundary_data_option == direct_integration
                     precompute_weights = true
                 else
@@ -252,7 +252,7 @@ function runtests()
                 dHdvperp_M_err = allocate_float(vpa.n,vperp.n)
 
                 dens, upar, vth = 1.0, 1.0, 1.0
-                begin_serial_region()
+                @begin_serial_region()
                 for ivperp in 1:vperp.n
                     for ivpa in 1:vpa.n
                         F_M[ivpa,ivperp] = F_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
@@ -268,7 +268,7 @@ function runtests()
                 end
                 rpbd_exact = allocate_rosenbluth_potential_boundary_data(vpa,vperp)
                 # use known test function to provide exact data
-                begin_s_r_z_anyv_region()
+                @begin_s_r_z_anyv_region()
                 calculate_rosenbluth_potential_boundary_data_exact!(rpbd_exact,
                       H_M_exact,dHdvpa_M_exact,dHdvperp_M_exact,G_M_exact,
                       dGdvperp_M_exact,d2Gdvperp2_M_exact,
@@ -283,8 +283,8 @@ function runtests()
                      boundary_data_option=boundary_data_option)
                 # extract C[Fs,Fs'] result
                 # and Rosenbluth potentials for testing
-                begin_s_r_z_anyv_region()
-                begin_anyv_vperp_vpa_region()
+                @begin_s_r_z_anyv_region()
+                @begin_anyv_vperp_vpa_region()
                 @loop_vperp_vpa ivperp ivpa begin
                     G_M_num[ivpa,ivperp] = fkpl_arrays.GG[ivpa,ivperp]
                     H_M_num[ivpa,ivperp] = fkpl_arrays.HH[ivpa,ivperp]
@@ -295,7 +295,7 @@ function runtests()
                     d2Gdvpa2_M_num[ivpa,ivperp] = fkpl_arrays.d2Gdvpa2[ivpa,ivperp]
                     d2Gdvperpdvpa_M_num[ivpa,ivperp] = fkpl_arrays.d2Gdvperpdvpa[ivpa,ivperp]
                 end
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     # test the boundary data
                     max_H_boundary_data_err, max_dHdvpa_boundary_data_err,
@@ -401,7 +401,7 @@ function runtests()
             nelement_vperp = 4
             vpa, vpa_spectral, vperp, vperp_spectral = create_grids(ngrid,nelement_vpa,nelement_vperp,
                                                                         Lvpa=12.0,Lvperp=6.0)
-            begin_serial_region()
+            @begin_serial_region()
             fkpl_arrays = init_fokker_planck_collisions_weak_form(vpa,vperp,vpa_spectral,vperp_spectral,
                                                                   precompute_weights=true, print_to_screen=print_to_screen)
 
@@ -429,7 +429,7 @@ function runtests()
                 ms = 1.0
                 msp = 1.0
                 nussp = 1.0
-                begin_serial_region()
+                @begin_serial_region()
                 for ivperp in 1:vperp.n
                     for ivpa in 1:vpa.n
                         Fs_M[ivpa,ivperp] = F_Maxwellian(denss,upars,vths,vpa,vperp,ivpa,ivperp)
@@ -439,7 +439,7 @@ function runtests()
                                                                         nussp,vpa,vperp,ivpa,ivperp)
                     end
                 end
-                begin_s_r_z_anyv_region()
+                @begin_s_r_z_anyv_region()
                 fokker_planck_collision_operator_weak_form!(Fs_M,F_M,ms,msp,nussp,
                                                  fkpl_arrays,
                                                  vperp, vpa, vperp_spectral, vpa_spectral,
@@ -455,12 +455,12 @@ function runtests()
                     conserving_corrections!(fkpl_arrays.CC,Fs_M,vpa,vperp,dummy_array)
                 end
                 # extract C[Fs,Fs'] result
-                begin_s_r_z_anyv_region()
-                begin_anyv_vperp_vpa_region()
+                @begin_s_r_z_anyv_region()
+                @begin_anyv_vperp_vpa_region()
                 @loop_vperp_vpa ivperp ivpa begin
                     C_M_num[ivpa,ivperp] = fkpl_arrays.CC[ivpa,ivperp]
                 end
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     C_M_max, C_M_L2 = print_test_data(C_M_exact,C_M_num,C_M_err,"C_M",vpa,vperp,dummy_array,print_to_screen=print_to_screen)
                     if test_self_operator && !test_numerical_conserving_terms && !use_Maxwellian_Rosenbluth_coefficients && !use_Maxwellian_field_particle_distribution
@@ -558,7 +558,7 @@ function runtests()
             nelement_vperp = 8
             vpa, vpa_spectral, vperp, vperp_spectral = create_grids(ngrid,nelement_vpa,nelement_vperp,
                                                                         Lvpa=12.0,Lvperp=6.0)
-            begin_serial_region()
+            @begin_serial_region()
             fkpl_arrays = init_fokker_planck_collisions_weak_form(vpa,vperp,vpa_spectral,vperp_spectral,
                                                                   precompute_weights=true, print_to_screen=print_to_screen)
 
@@ -586,7 +586,7 @@ function runtests()
                 nsprime = size(msp,1)
                 nuref = 1.0
 
-                begin_serial_region()
+                @begin_serial_region()
                 for ivperp in 1:vperp.n
                     for ivpa in 1:vpa.n
                         Fs_M[ivpa,ivperp] = F_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
@@ -605,7 +605,7 @@ function runtests()
                         end
                     end
                 end
-                begin_s_r_z_anyv_region()
+                @begin_s_r_z_anyv_region()
                 @views fokker_planck_collision_operator_weak_form_Maxwellian_Fsp!(Fs_M[:,:],
                                      nuref,mref,Zref,msp,Zsp,denssp,uparsp,vthsp,
                                      fkpl_arrays,vperp,vpa,vperp_spectral,vpa_spectral)
@@ -616,12 +616,12 @@ function runtests()
                     density_conserving_correction!(fkpl_arrays.CC,Fs_M,vpa,vperp,dummy_array)
                 end
                 # extract C[Fs,Fs'] result
-                begin_s_r_z_anyv_region()
-                begin_anyv_vperp_vpa_region()
+                @begin_s_r_z_anyv_region()
+                @begin_anyv_vperp_vpa_region()
                 @loop_vperp_vpa ivperp ivpa begin
                     C_M_num[ivpa,ivperp] = fkpl_arrays.CC[ivpa,ivperp]
                 end
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     C_M_max, C_M_L2 = print_test_data(C_M_exact,C_M_num,C_M_err,"C_M",vpa,vperp,dummy_array,print_to_screen=print_to_screen)
                     atol_max = 7.0e-2
@@ -655,7 +655,7 @@ function runtests()
             nelement_vperp = 4
             vpa, vpa_spectral, vperp, vperp_spectral = create_grids(ngrid,nelement_vpa,nelement_vperp,
                                                                         Lvpa=12.0,Lvperp=6.0)
-            begin_serial_region()
+            @begin_serial_region()
             fkpl_arrays = init_fokker_planck_collisions_direct_integration(vperp,vpa,precompute_weights=true,print_to_screen=print_to_screen)
             dummy_array = allocate_float(vpa.n,vperp.n)
             F_M = allocate_float(vpa.n,vperp.n)
@@ -685,7 +685,7 @@ function runtests()
             dHdvperp_M_err = allocate_float(vpa.n,vperp.n)
 
             dens, upar, vth = 1.0, 1.0, 1.0
-            begin_serial_region()
+            @begin_serial_region()
             for ivperp in 1:vperp.n
                 for ivpa in 1:vpa.n
                     F_M[ivpa,ivperp] = F_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
@@ -700,11 +700,11 @@ function runtests()
                 end
             end
             # calculate the potentials numerically
-            begin_s_r_z_anyv_region()
+            @begin_s_r_z_anyv_region()
             calculate_rosenbluth_potentials_via_direct_integration!(G_M_num,H_M_num,dHdvpa_M_num,dHdvperp_M_num,
              d2Gdvpa2_M_num,dGdvperp_M_num,d2Gdvperpdvpa_M_num,d2Gdvperp2_M_num,F_M,
              vpa,vperp,vpa_spectral,vperp_spectral,fkpl_arrays)
-            begin_serial_region()
+            @begin_serial_region()
             @serial_region begin
                 # test the integration
                 # to recalculate absolute tolerances atol, set print_to_screen = true

--- a/moment_kinetics/test/gyroaverage_tests.jl
+++ b/moment_kinetics/test/gyroaverage_tests.jl
@@ -186,7 +186,7 @@ function gyroaverage_test(absolute_error; rhostar=0.1, pitch=0.5, ngrid=5, kr=2,
         gphi = allocate_shared_float(vperp.n,z.n,r.n,composition.n_ion_species)
         gphi_exact = allocate_float(vperp.n,z.n,r.n,composition.n_ion_species)
         gphi_err = allocate_float(vperp.n,z.n,r.n)
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin 
             fill_test_arrays!(phi,gphi_exact,vperp,z,r,geometry,composition,kz,kr,phasez,phaser)
         end
@@ -195,7 +195,7 @@ function gyroaverage_test(absolute_error; rhostar=0.1, pitch=0.5, ngrid=5, kr=2,
         gyroaverage_field!(gphi,phi,gyro,vperp,z,r,composition)
         
         # compute errors
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             @. gphi_err = abs(gphi - gphi_exact)
             if print_test_results
@@ -219,14 +219,14 @@ function gyroaverage_test(absolute_error; rhostar=0.1, pitch=0.5, ngrid=5, kr=2,
         gpdf = allocate_shared_float(vpa.n,vperp.n,z.n,r.n,n_ion_species)
         gpdf_exact = allocate_float(vpa.n,vperp.n,z.n,r.n,n_ion_species)
         gpdf_err = allocate_float(vpa.n,vperp.n,z.n,r.n,n_ion_species)
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             fill_pdf_test_arrays!(pdf,gpdf_exact,vpa,vperp,z,r,composition,geometry,kz,kr,phasez,phaser)
         end
         
         gyroaverage_pdf!(gpdf,pdf,gyro,vpa,vperp,z,r,composition)
         # compute errors
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             @. gpdf_err = abs(gpdf - gpdf_exact)
             if print_test_results

--- a/moment_kinetics/test/nonlinear_solver_tests.jl
+++ b/moment_kinetics/test/nonlinear_solver_tests.jl
@@ -72,7 +72,7 @@ function linear_test()
             if serial_solve
                 residual .= A * x - b
             else
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     residual .= A * x - b
                 end
@@ -102,7 +102,7 @@ function linear_test()
             v = allocate_shared_float(n)
             w = allocate_shared_float(n)
 
-            begin_serial_region()
+            @begin_serial_region()
             @serial_region begin
                 x .= 0.0
                 residual .= 0.0
@@ -130,7 +130,7 @@ function linear_test()
 
             @test isapprox(x, x_direct; atol=100.0*atol)
         else
-            begin_serial_region()
+            @begin_serial_region()
             @serial_region begin
                 x_direct = A \ b
 
@@ -195,7 +195,7 @@ function nonlinear_test()
                 D = abs(x[i])^2.5
                 residual[i] = D * (x[i-1] - 2.0 * x[i]) - b[i]
             else
-                begin_serial_region()
+                @begin_serial_region()
                 @serial_region begin
                     i = 1
                     D = abs(x[i])^2.5
@@ -236,7 +236,7 @@ function nonlinear_test()
             v .= 0.0
             w .= 0.0
         else
-            begin_serial_region()
+            @begin_serial_region()
             @serial_region begin
                 x .= 1.0
                 residual .= 0.0
@@ -265,7 +265,7 @@ function nonlinear_test()
         if serial_solve
             @test isapprox(residual, zeros(n); atol=4.0*atol)
         else
-            begin_serial_region()
+            @begin_serial_region()
             @serial_region begin
                 @test isapprox(residual, zeros(n); atol=4.0*atol)
             end

--- a/test_scripts/2D_FEM_assembly_test.jl
+++ b/test_scripts/2D_FEM_assembly_test.jl
@@ -125,7 +125,7 @@ end
                                        r=1, z=1, vperp=vperp.n, vpa=vpa.n,
                                        vzeta=1, vr=1, vz=1)
         nc_global = vpa.n*vperp.n
-        begin_serial_region()
+        @begin_serial_region()
         start_init_time = now()
         if boundary_data_option == direct_integration
             precompute_weights = true
@@ -251,7 +251,7 @@ end
         end
         rpbd_exact = allocate_rosenbluth_potential_boundary_data(vpa,vperp)
 
-        begin_s_r_z_anyv_region()
+        @begin_s_r_z_anyv_region()
 
         # use known test function to provide exact data
         calculate_rosenbluth_potential_boundary_data_exact!(rpbd_exact,
@@ -284,8 +284,8 @@ end
              algebraic_solve_for_d2Gdvperp2=false,calculate_GG=true,calculate_dGdvperp=true,boundary_data_option=boundary_data_option)
         # extract C[Fs,Fs'] result
         # and Rosenbluth potentials for testing
-        begin_s_r_z_anyv_region()
-        begin_anyv_vperp_vpa_region()
+        @begin_s_r_z_anyv_region()
+        @begin_anyv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             C_M_num[ivpa,ivperp] = fkpl_arrays.CC[ivpa,ivperp]
             G_M_num[ivpa,ivperp] = fkpl_arrays.GG[ivpa,ivperp]
@@ -300,7 +300,7 @@ end
         
         init_time = Dates.value(finish_init_time - start_init_time)
         calculate_time = Dates.value(now() - finish_init_time)
-        begin_serial_region()
+        @begin_serial_region()
         fkerr = allocate_error_data()
         @serial_region begin
             println("finished C calculation   ", Dates.format(now(), dateformat"H:MM:SS"))

--- a/test_scripts/fkpl_direct_integration_test.jl
+++ b/test_scripts/fkpl_direct_integration_test.jl
@@ -182,7 +182,7 @@ function test_Lagrange_Rosenbluth_potentials(ngrid,nelement; standalone=true)
     fokkerplanck_arrays = init_fokker_planck_collisions_direct_integration(vperp,vpa; precompute_weights=true)
     fka = fokkerplanck_arrays
 
-    begin_s_r_z_anyv_region()
+    @begin_s_r_z_anyv_region()
 
     # calculate the potentials by direct integration
     calculate_rosenbluth_potentials_via_direct_integration!(fka.GG,fka.HH,fka.dHdvpa,fka.dHdvperp,
@@ -190,7 +190,7 @@ function test_Lagrange_Rosenbluth_potentials(ngrid,nelement; standalone=true)
              vpa,vperp,vpa_spectral,vperp_spectral,fka)
             
     # error analysis of distribution function
-    begin_serial_region()
+    @begin_serial_region()
     @serial_region begin
         println("finished integration   ", Dates.format(now(), dateformat"H:MM:SS"))
         @. dfsdvpa_err = abs(fka.dfdvpa - dfsdvpa_Maxwell)
@@ -333,7 +333,7 @@ function test_Lagrange_Rosenbluth_potentials(ngrid,nelement; standalone=true)
         end
         
     end
-    _block_synchronize()
+    @_block_synchronize()
     if standalone 
         finalize_comms!()
     end

--- a/test_scripts/gyroaverage_test.jl
+++ b/test_scripts/gyroaverage_test.jl
@@ -148,7 +148,7 @@ function gyroaverage_test(;rhostar=0.1, pitch=0.5, ngrid=5, kr=2, kz=2, phaser=0
         gphi = allocate_shared_float(vperp.n,z.n,r.n)
         gphi_exact = allocate_float(vperp.n,z.n,r.n)
         gphi_err = allocate_float(vperp.n,z.n,r.n)
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin 
             fill_test_arrays!(phi,gphi_exact,vperp,z,r,geometry,kz,kr,phasez,phaser)
         end
@@ -157,7 +157,7 @@ function gyroaverage_test(;rhostar=0.1, pitch=0.5, ngrid=5, kr=2, kz=2, phaser=0
         gyroaverage_field!(gphi,phi,gyro,vperp,z,r,composition)
         
         # compute errors
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             @. gphi_err = abs(gphi - gphi_exact)
             println("Test gyroaverage_field!()")
@@ -189,14 +189,14 @@ function gyroaverage_test(;rhostar=0.1, pitch=0.5, ngrid=5, kr=2, kz=2, phaser=0
         gpdf = allocate_shared_float(nvpa,vperp.n,z.n,r.n,n_ion_species)
         gpdf_exact = allocate_float(nvpa,vperp.n,z.n,r.n,n_ion_species)
         gpdf_err = allocate_float(nvpa,vperp.n,z.n,r.n,n_ion_species)
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             fill_pdf_test_arrays!(pdf,gpdf_exact,vpa,vperp,z,r,composition,geometry,kz,kr,phasez,phaser)
         end
         
         gyroaverage_pdf!(gpdf,pdf,gyro,vpa,vperp,z,r,composition)
         # compute errors
-        begin_serial_region()
+        @begin_serial_region()
         @serial_region begin
             @. gpdf_err = abs(gpdf - gpdf_exact)
             println("Test gyroaverage_pdf!()")

--- a/util/MKJacobianUtils.jl
+++ b/util/MKJacobianUtils.jl
@@ -185,7 +185,7 @@ function get_electron_Jacobian_matrix(run_directory; restart_time_index=1,
     buffer_2 = @view scratch_dummy.buffer_rs_2[ir,1]
     buffer_3 = @view scratch_dummy.buffer_rs_3[ir,1]
     buffer_4 = @view scratch_dummy.buffer_rs_4[ir,1]
-    begin_z_region()
+    @begin_z_region()
     @loop_z iz begin
         third_moment[iz] = 0.5 * qpar[iz] / ppar[iz] / vth[iz]
     end
@@ -205,7 +205,7 @@ function get_electron_Jacobian_matrix(run_directory; restart_time_index=1,
 
         z_speed = @view z_advect[1].speed[:,:,:,ir]
         dpdf_dz = @view scratch_dummy.buffer_vpavperpzr_1[:,:,:,ir]
-        begin_vperp_vpa_region()
+        @begin_vperp_vpa_region()
         update_electron_speed_z!(z_advect[1], upar, vth, vpa.grid, ir)
         @loop_vperp_vpa ivperp ivpa begin
             @views z_advect[1].adv_fac[:,ivpa,ivperp,ir] = -z_speed[:,ivpa,ivperp]


### PR DESCRIPTION
Making `@_block_synchronize()` and `@begin_*_region()` into macros allows a quicker debug check for consistency of synchronization calls, as macros can capture the file/line where they were called.

The capture of file/line by a macro is done at compile time, so the code runs much quicker than when using the full stack trace, which needs to be re-checked every call. Not using the full stack trace is slightly less comprehensive, as there is the potential that a synchronization call could be made inconsistently if, e.g., two (or more) different functions call some function that then calls `@begin_*_region()`. This is probably a rare case though, and anyway if a run has got into an inconsistent state it is almost certain that there will soon be an inconsistent call that the quicker debug check would catch. The full stack trace is very slow, so when some inconsistency only happens a fairly long way into a run, it can become painful to debug using that check - the case that motivated me to make this PR was that when writing output, there was a bug that sent different processes into different branches after output was written, but this only happened several thousand steps into the run.

If this change causes errors in some code that I haven't managed to update in this PR, the required update is to replace `_block_synchronize()` with `@_block_synchronize()`, and replace `begin_*_region()` with `@begin_*_region()`.