### PR TITLE
Add option in timestepping section to print out density or temperatur…

### DIFF
--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -94,6 +94,7 @@ struct time_info{Terrorsum <: Real, T_debug_output, T_electron, Trkimp, Timpzero
     write_after_fixed_step_count::Bool
     error_sum_zero::Terrorsum
     split_operators::Bool
+    print_nT_live::Bool
     steady_state_residual::Bool
     converged_residual_value::mk_float
     use_manufactured_solns_for_advance::Bool

--- a/moment_kinetics/src/moment_kinetics_input.jl
+++ b/moment_kinetics/src/moment_kinetics_input.jl
@@ -150,6 +150,7 @@ function mk_input(input_dict=OptionsDict(); save_inputs_to_txt=false, ignore_MPI
         exact_output_times=false,
         type="SSPRK4",
         split_operators=false,
+        print_nT_live=false,
         steady_state_residual=false,
         converged_residual_value=-1.0,
         rtol=1.0e-5,
@@ -235,6 +236,7 @@ function mk_input(input_dict=OptionsDict(); save_inputs_to_txt=false, ignore_MPI
     electron_timestepping_section = copy(electron_timestepping_section)
     electron_timestepping_section["atol_upar"] = NaN
     electron_timestepping_section["steady_state_residual"] = true
+    electron_timestepping_section["print_nT_live"] = false
     if !(0.0 < electron_timestepping_section["step_update_prefactor"] < 1.0)
         error("[electron_timestepping] step_update_prefactor="
               * "$(electron_timestepping_section["step_update_prefactor"]) must be between "

--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -2025,6 +2025,14 @@ function  time_advance!(pdf, scratch, scratch_implicit, scratch_electron, t_para
                               rpad(string(t_params.moments_output_counter[]), 4), "  ",
                               "t = ", rpad(string(round(t_params.t[], sigdigits=6)), 7), "  ",
                               "nstep = ", rpad(string(t_params.step_counter[]), 7), "  ")
+                        if t_params.print_nT_live
+                            midpoint = Int64(round(size(moments.ion.dens)[1]/2))
+                            print("midpoint density: ", 
+                            rpad(string(round(moments.ion.dens[midpoint,1,1], sigdigits = 4)), 7))
+                            print("   midpoint temperature: ", 
+                            rpad(string(round(moments.ion.ppar[midpoint,1,1]*2/(
+                            moments.ion.dens[midpoint,1,1]), sigdigits = 4)), 7), "\n")
+                        end
                         if t_params.adaptive
                             print("nfail = ", rpad(string(t_params.failure_counter[]), 7), "  ",
                                   "dt = ", rpad(string(t_params.dt_before_output[]), 7), "  ")
@@ -2115,14 +2123,6 @@ function  time_advance!(pdf, scratch, scratch_implicit, scratch_electron, t_para
                                 "t = ", rpad(string(round(t_params.t[], sigdigits=6)), 7), "  ",
                                 "nstep = ", rpad(string(t_params.step_counter[]), 7), "  ",
                                 Dates.format(now(), dateformat"H:MM:SS"))
-                        if t_params.print_nT_live
-                            midpoint = Int64(round(size(moments.ion.dens)[1]/2))
-                            print("midpoint density: ", 
-                            rpad(string(round(moments.ion.dens[midpoint,1,1], sigdigits = 4)), 7))
-                            print("   midpoint temperature: ", 
-                            rpad(string(round(moments.ion.ppar[midpoint,1,1]*2/(
-                            moments.ion.dens[midpoint,1,1]), sigdigits = 4)), 7), "\n")
-                        end
                         flush(stdout)
                     end
                 end

--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -553,7 +553,8 @@ function setup_time_info(t_input, n_variables, code_time, dt_reload,
                      mk_float(cap_factor_ion_dt), mk_int(max_pseudotimesteps),
                      mk_float(max_pseudotime), include_wall_bc_in_preconditioner,
                      t_input["write_after_fixed_step_count"], error_sum_zero,
-                     t_input["split_operators"], t_input["steady_state_residual"],
+                     t_input["split_operators"], t_input["print_nT_live"], 
+                     t_input["steady_state_residual"], 
                      mk_float(t_input["converged_residual_value"]),
                      manufactured_solns_input.use_for_advance, t_input["stopfile_name"],
                      debug_io, electron_t_params)
@@ -2114,6 +2115,14 @@ function  time_advance!(pdf, scratch, scratch_implicit, scratch_electron, t_para
                                 "t = ", rpad(string(round(t_params.t[], sigdigits=6)), 7), "  ",
                                 "nstep = ", rpad(string(t_params.step_counter[]), 7), "  ",
                                 Dates.format(now(), dateformat"H:MM:SS"))
+                        if t_params.print_nT_live
+                            midpoint = Int64(round(size(moments.ion.dens)[1]/2))
+                            print("midpoint density: ", 
+                            rpad(string(round(moments.ion.dens[midpoint,1,1], sigdigits = 4)), 7))
+                            print("   midpoint temperature: ", 
+                            rpad(string(round(moments.ion.ppar[midpoint,1,1]*2/(
+                            moments.ion.dens[midpoint,1,1]), sigdigits = 4)), 7), "\n")
+                        end
                         flush(stdout)
                     end
                 end


### PR DESCRIPTION
…e at midpoint (electron steps not supported yet), which can be useful when gauging effectiveness of PI controllers - you can essentially 'see' the graphs of density and temperature motion without having to use makie_post_processing