### PR TITLE
Add debug IO outputs in `electron_kinetic_equation_euler_update!()`

### DIFF
--- a/moment_kinetics/src/file_io.jl
+++ b/moment_kinetics/src/file_io.jl
@@ -1166,19 +1166,28 @@ function define_dynamic_moment_variables!(fid, n_ion_species, n_neutral_species,
             dynamic, "failure_counter", mk_int; parallel_io=parallel_io,
             description="cumulative number of timestep failures for the run")
 
+        dynamic_keys = collect(keys(dynamic))
         for failure_var ∈ keys(t_params.failure_caused_by)
-            create_dynamic_variable!(
-                dynamic, "failure_caused_by_$failure_var", mk_int;
-                parallel_io=parallel_io,
-                description="cumulative count of how many times $failure_var caused a "
-                            * "timestep failure for the run")
+            # Only write these variables if they were created in the output file, because
+            # sometimes (e.g. for debug_io=true) they are not needed.
+            if failure_var ∈ dynamic_keys
+                create_dynamic_variable!(
+                    dynamic, "failure_caused_by_$failure_var", mk_int;
+                    parallel_io=parallel_io,
+                    description="cumulative count of how many times $failure_var caused "
+                                * "a timestep failure for the run")
+            end
         end
         for limit_var ∈ keys(t_params.limit_caused_by)
-            create_dynamic_variable!(
-                dynamic, "limit_caused_by_$limit_var", mk_int;
-                parallel_io=parallel_io,
-                description="cumulative count of how many times $limit_var limited the "
-                            * "timestep for the run")
+            # Only write these variables if they were created in the output file, because
+            # sometimes (e.g. for debug_io=true) they are not needed.
+            if limit_var ∈ dynamic_keys
+                create_dynamic_variable!(
+                    dynamic, "limit_caused_by_$limit_var", mk_int;
+                    parallel_io=parallel_io,
+                    description="cumulative count of how many times $limit_var limited "
+                                * "the timestep for the run")
+            end
         end
 
         io_dt_before_last_fail = create_dynamic_variable!(
@@ -3136,13 +3145,22 @@ function write_electron_moments_data_to_binary(scratch, moments, t_params, elect
                                   electron_t_params.previous_dt[], t_idx, parallel_io)
             append_to_dynamic_var(io_moments.electron_failure_counter,
                                   electron_t_params.failure_counter[], t_idx, parallel_io)
+            dynamic_keys = collect(keys(dynamic))
             for (k,v) ∈ pairs(electron_t_params.failure_caused_by)
-                io_var = dynamic["electron_failure_caused_by_$k"]
-                append_to_dynamic_var(io_var, v, t_idx, parallel_io; only_root=true)
+                # Only write these variables if they were created in the output file,
+                # because sometimes (e.g. for debug_io=true) they are not needed.
+                if k ∈ dynamic_keys
+                    io_var = dynamic["electron_failure_caused_by_$k"]
+                    append_to_dynamic_var(io_var, v, t_idx, parallel_io; only_root=true)
+                end
             end
             for (k,v) ∈ pairs(electron_t_params.limit_caused_by)
-                io_var = dynamic["electron_limit_caused_by_$k"]
-                append_to_dynamic_var(io_var, v, t_idx, parallel_io; only_root=true)
+                # Only write these variables if they were created in the output file,
+                # because sometimes (e.g. for debug_io=true) they are not needed.
+                if k ∈ dynamic_keys
+                    io_var = dynamic["electron_limit_caused_by_$k"]
+                    append_to_dynamic_var(io_var, v, t_idx, parallel_io; only_root=true)
+                end
             end
             append_to_dynamic_var(io_moments.electron_dt_before_last_fail,
                                   electron_t_params.dt_before_last_fail[], t_idx,

--- a/moment_kinetics/src/file_io.jl
+++ b/moment_kinetics/src/file_io.jl
@@ -3323,7 +3323,7 @@ binary output file
         # add the distribution function data at this time slice to the output file
         write_ion_dfns_data_to_binary(scratch, t_params, n_ion_species, io_dfns, t_idx, r,
                                       z, vperp, vpa)
-        if t_params.kinetic_electron_solver == implicit_time_evolving || scratch_electron !== nothing
+        if t_params.kinetic_electron_solver ∈ (implicit_time_evolving, explicit_time_evolving) || scratch_electron !== nothing
             write_electron_dfns_data_to_binary(scratch, scratch_electron, t_params,
                                                io_dfns, t_idx, r, z, vperp, vpa)
         end
@@ -3406,7 +3406,7 @@ function write_electron_dfns_data_to_binary(scratch, scratch_electron, t_params,
         parallel_io = io_dfns.io_input.parallel_io
 
         if io_dfns.f_electron !== nothing
-            if t_params.kinetic_electron_solver == implicit_time_evolving || scratch_electron === nothing
+            if t_params.kinetic_electron_solver ∈ (implicit_time_evolving, explicit_time_evolving) || scratch_electron === nothing
                 n_rk_stages = t_params.n_rk_stages
                 this_scratch = scratch
             elseif t_params.electron === nothing

--- a/moment_kinetics/src/initial_conditions.jl
+++ b/moment_kinetics/src/initial_conditions.jl
@@ -538,25 +538,6 @@ function initialize_pdf!(pdf, moments, boundary_distributions, composition, r, z
         end
     end
 
-    # @serial_region begin
-    #     @loop_r ir begin
-    #         # this is the initial guess for the electron pdf
-    #         # it will be iteratively updated to satisfy the time-independent
-    #         # electron kinetic equation
-    #         @views init_electron_pdf_over_density!(pdf.electron.norm[:,:,:,ir], moments.electron.dens[:,ir],
-    #             moments.electron.upar[:,ir], moments.electron.vth[:,ir], z, vpa, vperp)
-    #     end
-    #     # now that we have our initial guess for the electron pdf, we iterate
-    #     # using the time-independent electron kinetic equation to find a self-consistent
-    #     # solution for the electron pdf
-    #     max_electron_pdf_iterations = 100
-    #     @views update_electron_pdf!(pdf.electron.norm, moments.electron.dens, moments.electron.vth, moments.electron.ppar, 
-    #                                 moments.electron.ddens_dz, moments.electron.dppar_dz, moments.electron.dqpar_dz, moments.electron.dvth_dz,
-    #                                 max_electron_pdf_iterations, z, vpa, z_spectral, vpa_spectral, scratch_dummy)
-    # end
-
-
-
     return nothing
 end
 
@@ -568,8 +549,10 @@ function initialize_electron_pdf!(scratch, scratch_electron, pdf, moments, field
                                   nl_solver_params, t_params, t_input, io_input,
                                   input_dict; skip_electron_solve)
 
-    # now that the initial electron pdf is given, the electron parallel heat flux should be updated
-    # if using kinetic electrons
+    if t_input["skip_electron_initial_solve"]
+        skip_electron_solve = true
+    end
+
     if composition.electron_physics ∈ (kinetic_electrons,
                                        kinetic_electrons_with_temperature_equation)
         @begin_serial_region()

--- a/moment_kinetics/src/moment_kinetics_input.jl
+++ b/moment_kinetics/src/moment_kinetics_input.jl
@@ -238,6 +238,7 @@ function mk_input(input_dict=OptionsDict(); save_inputs_to_txt=false, ignore_MPI
         max_pseudotime=1.0e-2,
         include_wall_bc_in_preconditioner=false,
         no_restart=false,
+        skip_electron_initial_solve=false,
         debug_io=false,
        )
     if electron_timestepping_section["nwrite"] < 0

--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -3661,14 +3661,23 @@ implementation), a call needs to be made with `dt` scaled by some coefficient.
     end
 
     if advance.electron_pdf
-        electron_t_params = (dt=Ref(dt),)
         for ir ∈ 1:r.n
+            if t_params.debug_io !== nothing && ir == 1
+                # Probably do not want to write separate debug output for every r-index
+                # even in 2D, as this would create very large output files, so pick a
+                # single r-index for debug output. This might not be the most useful
+                # r-index for 2D simulations!
+                this_debug_io = t_params.debug_io
+            else
+                this_debug_io = nothing
+            end
             @views electron_kinetic_equation_euler_update!(
-                       fvec_out.pdf_electron[:,:,:,ir], fvec_out.electron_ppar[:,ir],
-                       fvec_in.pdf_electron[:,:,:,ir], fvec_in.electron_ppar[:,ir],
-                       moments, z, vperp, vpa, z_spectral, vpa_spectral, z_advect,
-                       vpa_advect, scratch_dummy, collisions, composition,
-                       external_source_settings, num_diss_params, electron_t_params, ir)
+                       fvec_out, fvec_in.pdf_electron[:,:,:,ir],
+                       fvec_in.electron_ppar[:,ir], moments, z, vperp, vpa, z_spectral,
+                       vpa_spectral, z_advect, vpa_advect, scratch_dummy, collisions,
+                       composition, external_source_settings, num_diss_params,
+                       t_params, ir; debug_io=this_debug_io, fields=fields,
+                       r=r, vzeta=vzeta, vr=vr, vz=vz, istage=istage)
         end
         write_debug_IO("electron_kinetic_equation_euler_update!")
     end

--- a/moment_kinetics/test/jacobian_matrix_tests.jl
+++ b/moment_kinetics/test/jacobian_matrix_tests.jl
@@ -3415,10 +3415,10 @@ function test_electron_kinetic_equation(test_input; rtol=(5.0e2*epsilon)^2)
                 residual_p[iz] = ppar[iz]
             end
             electron_kinetic_equation_euler_update!(
-                residual_f, residual_p, this_f, this_p, moments, z, vperp, vpa,
-                z_spectral, vpa_spectral, z_advect, vpa_advect, scratch_dummy, collisions,
-                composition, external_source_settings, num_diss_params, t_params.electron,
-                ir; evolve_ppar=true, ion_dt=ion_dt)
+                (pdf_electron=residual_f, electron_ppar=residual_p), this_f, this_p,
+                moments, z, vperp, vpa, z_spectral, vpa_spectral, z_advect, vpa_advect,
+                scratch_dummy, collisions, composition, external_source_settings,
+                num_diss_params, t_params.electron, ir; evolve_ppar=true, ion_dt=ion_dt)
             # Now
             #   residual = f_electron_old + dt*RHS(f_electron_newvar)
             # so update to desired residual


### PR DESCRIPTION
Currently can only be used with `kinetic_electron_solver=explicit_time_evolving` because we need to pass the `scratch_pdf` struct containing also the ion/neutral variables in in order to write the output file.