### PR TITLE
Support subnamelists in one version of set_defaults_and_check_section!()

### DIFF
--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -927,8 +927,13 @@ function set_defaults_and_check_section!(options::OptionsDict, section_name::Str
         # `Base.get()` defined above.
         if isa(default_value, AbstractDict)
             # handle the case that the default_value is itself a dictionary from a subnamelist
+            if !(key in keys(section))
+                # create the subsection if it doesn't already exist
+                section[key] = OptionsDict()
+            end
+            subsection = section[key]
             for (sub_key, sub_default_value) in default_value
-                section[key][sub_key] = get(section[key], sub_key, sub_default_value)
+                subsection[sub_key] = get(subsection, sub_key, sub_default_value)
             end
         else
             section[key] = get(section, key, default_value)

--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -925,7 +925,14 @@ function set_defaults_and_check_section!(options::OptionsDict, section_name::Str
         key = String(key_sym)
         # Use `Base.get()` here to take advantage of our `Enum`-handling method of
         # `Base.get()` defined above.
-        section[key] = get(section, key, default_value)
+        if isa(default_value, AbstractDict)
+            # handle the case that the default_value is itself a dictionary from a subnamelist
+            for (sub_key, sub_default_value) in default_value
+                section[key][sub_key] = get(section[key], sub_key, sub_default_value)
+            end
+        else
+            section[key] = get(section, key, default_value)
+        end
     end
 
     _check_for_nothing(section, section_name)


### PR DESCRIPTION
This PR aims to update the version of `set_defaults_and_check_section!()` that returns a dictionary so that subnamelists can be supported in the TOML. Note that another version of  `set_defaults_and_check_section!()` at https://github.com/mabarnes/moment_kinetics/blob/322412d04710ab868aed0580dd8b22ac21b42bbc/moment_kinetics/src/input_structs.jl#L989-L1016 is not updated.

 - [ ] Consider if possible to use https://github.com/mabarnes/moment_kinetics/blob/322412d04710ab868aed0580dd8b22ac21b42bbc/moment_kinetics/src/utils.jl#L313-L329 or https://github.com/mabarnes/moment_kinetics/blob/322412d04710ab868aed0580dd8b22ac21b42bbc/moment_kinetics/src/utils.jl#L336-L345 to reduce code duplication.
 - [ ] Consider if possible or desirable to extend this support to https://github.com/mabarnes/moment_kinetics/blob/322412d04710ab868aed0580dd8b22ac21b42bbc/moment_kinetics/src/input_structs.jl#L989-L1016.