### PR TITLE
Refactor inputs for implicit FP collisions: remove subnamelists

### DIFF
--- a/examples/fokker-planck/fokker-planck-relaxation-implicit.toml
+++ b/examples/fokker-planck/fokker-planck-relaxation-implicit.toml
@@ -74,7 +74,7 @@ boundary_data_option="multipole_expansion"
 #boundary_data_option="delta_f_multipole"
 #boundary_data_option="direct_integration"
 
-[fokker_planck_collisions.nonlinear_solver]
+[fokker_planck_collisions_nonlinear_solver]
 rtol = 0.0
 atol = 1.0e-10
 nonlinear_max_iterations = 50

--- a/moment_kinetics/src/fokker_planck.jl
+++ b/moment_kinetics/src/fokker_planck.jl
@@ -913,8 +913,7 @@ function setup_fp_nl_solve(implicit_ion_fp_collisions::Bool,
         input_dict,
         coords; serial_solve=false, anyv_region=true,
         section_name = section_name,
-        default_atol=default_atol, default_rtol=default_rtol,
-        preconditioner_type=Val(:lu))
+        default_atol=default_atol, default_rtol=default_rtol)
 end
 
 function implicit_ion_fokker_planck_self_collisions!(pdf_out, pdf_in, dSdt, 

--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -947,13 +947,8 @@ function set_defaults_and_check_section!(options::OptionsDict, section_name::Str
         # `Base.get()` defined above.
         if isa(default_value, AbstractDict)
             # handle the case that the default_value is itself a dictionary from a subnamelist
-            if !(key in keys(section))
-                # create the subsection if it doesn't already exist
-                section[key] = OptionsDict()
-            end
-            subsection = section[key]
             for (sub_key, sub_default_value) in default_value
-                subsection[sub_key] = get(subsection, sub_key, sub_default_value)
+                section[key][sub_key] = get(section[key], sub_key, sub_default_value)
             end
         else
             section[key] = get(section, key, default_value)

--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -945,14 +945,7 @@ function set_defaults_and_check_section!(options::OptionsDict, section_name::Str
         key = String(key_sym)
         # Use `Base.get()` here to take advantage of our `Enum`-handling method of
         # `Base.get()` defined above.
-        if isa(default_value, AbstractDict)
-            # handle the case that the default_value is itself a dictionary from a subnamelist
-            for (sub_key, sub_default_value) in default_value
-                section[key][sub_key] = get(section[key], sub_key, sub_default_value)
-            end
-        else
-            section[key] = get(section, key, default_value)
-        end
+        section[key] = get(section, key, default_value)
     end
 
     _check_for_nothing(section, section_name)

--- a/moment_kinetics/src/input_structs.jl
+++ b/moment_kinetics/src/input_structs.jl
@@ -586,8 +586,6 @@ Base.@kwdef struct fkpl_collisions_input
     # kept here because charge number different from 1
     # is not supported for other physics features
     Zi::mk_float
-    # OptionsDict for nonlinear solver
-    nonlinear_solver::OptionsDict
 end
 
 """

--- a/moment_kinetics/src/moment_kinetics_input.jl
+++ b/moment_kinetics/src/moment_kinetics_input.jl
@@ -438,8 +438,7 @@ function mk_input(input_dict=OptionsDict(); save_inputs_to_txt=false, ignore_MPI
     end
     
     # check input (and initialized coordinate structs) to catch errors/unsupported options
-    check_input(io, io_immutable.output_dir, timestepping_section["nstep"],
-                timestepping_section["dt"], r, z, vpa, vperp, composition,
+    check_input(io, io_immutable.output_dir, timestepping_section, r, z, vpa, vperp, composition,
                 species_immutable, evolve_moments, num_diss_params, save_inputs_to_txt,
                 collisions)
 
@@ -460,8 +459,10 @@ end
 """
 check various input options to ensure they are all valid/consistent
 """
-function check_input(io, output_dir, nstep, dt, r, z, vpa, vperp, composition, species,
+function check_input(io, output_dir, timestepping_section, r, z, vpa, vperp, composition, species,
                      evolve_moments, num_diss_params, save_inputs_to_txt, collisions)
+    nstep = timestepping_section["nstep"]
+    dt = timestepping_section["dt"]
     # copy the input file to the output directory to be saved
     if save_inputs_to_txt && global_rank[] == 0
         cp(joinpath(@__DIR__, "moment_kinetics_input.jl"), joinpath(output_dir, "moment_kinetics_input.jl"), force=true)
@@ -484,6 +485,18 @@ function check_input(io, output_dir, nstep, dt, r, z, vpa, vperp, composition, s
             error("ERROR: you are using \n      vpa.discretization='"*vpa.discretization*
               "' \n      vperp.discretization='"*vperp.discretization*"' \n      with the ion self-collision operator \n"*
               "ERROR: you should use \n       vpa.discretization='gausslegendre_pseudospectral' \n       vperp.discretization='gausslegendre_pseudospectral'")
+        end
+        if (timestepping_section["kinetic_ion_solver"] == implicit_ion_fp_collisions) && (vperp.bc == "zero-impose-regularity")
+            errorstring = (
+                """ERROR: you are using
+
+                    vperp.bc = "$(vperp.bc)"
+                    kinetic_ion_solver="$(implicit_ion_fp_collisions)"
+
+                Only vperp.bc = "none" or vperp.bc = "zero" are currently
+                supported for kinetic_ion_solver="$(implicit_ion_fp_collisions)".
+                """)
+            error(errorstring)
         end
     end
 end

--- a/moment_kinetics/src/nonlinear_solvers.jl
+++ b/moment_kinetics/src/nonlinear_solvers.jl
@@ -87,12 +87,13 @@ layout of the variable to be solved (i.e. fastest-varying first).
 The nonlinear solver will be called inside a loop over `outer_coords`, so we might need
 for example a preconditioner object for each point in that outer loop.
 """
-function setup_nonlinear_solve(active, input_dict, coords, outer_coords=(); default_rtol=1.0e-5,
+function setup_nonlinear_solve(active, input_dict, coords, outer_coords=();
+                               section_name="nonlinear_solver", default_rtol=1.0e-5,
                                default_atol=1.0e-12, serial_solve=false, anyv_region=false,
                                electron_ppar_pdf_solve=false,
                                preconditioner_type=Val(:none), warn_unexpected=false)
     nl_solver_section = set_defaults_and_check_section!(
-        input_dict, "nonlinear_solver", warn_unexpected;
+        input_dict, section_name, warn_unexpected;
         rtol=default_rtol,
         atol=default_atol,
         nonlinear_max_iterations=20,

--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -821,7 +821,7 @@ function setup_time_advance!(pdf, fields, vz, vr, vzeta, vpa, vperp, z, r, gyrop
               * "time")
     end
     nl_solver_ion_fp_collisions = setup_fp_nl_solve(t_params.use_implicit_ion_fp_collisions,
-                                                    collisions.fkpl, (vperp=vperp, vpa=vpa))
+                                                    input_dict, (vperp=vperp, vpa=vpa))
 
     nl_solver_params = (electron_conduction=electron_conduction_nl_solve_parameters,
                         electron_advance=nl_solver_electron_advance_params,

--- a/moment_kinetics/test/fokker_planck_tests.jl
+++ b/moment_kinetics/test/fokker_planck_tests.jl
@@ -314,12 +314,9 @@ function backward_Euler_fokker_planck_self_collisions_test(;
     implicit_ion_fp_collisions = true
     coords = (vperp=vperp,vpa=vpa)
     spectral = (vperp_spectral=vperp_spectral, vpa_spectral=vpa_spectral)
-    # initialise instance of fkpl_collisions_input() to get default nonlinear solver values
-    # no need to supply any "fokker_planck_collisions" options as we use lower-level functions
-    # below which do not otherwise use the data in the fkpl struct.
     fkpl = setup_fkpl_collisions_input(OptionsDict(), true)
     nl_solver_params = setup_fp_nl_solve(implicit_ion_fp_collisions,
-                                        fkpl, coords)
+                                        OptionsDict(), coords)
 
     for it in 1:ntime
         @begin_s_r_z_anyv_region()

--- a/moment_kinetics/test/fokker_planck_time_evolution_tests.jl
+++ b/moment_kinetics/test/fokker_planck_time_evolution_tests.jl
@@ -591,23 +591,22 @@ function runtests()
             expected_zero,
              1.0e-14, 1.0e-14; vperp=OptionsDict("bc" => vperp_bc))
         end
-        @testset "Gauss Legendre no (explicitly) enforced boundary conditions" begin
+        @testset "Gauss Legendre no (explicitly) enforced boundary conditions: explicit timestepping" begin
             run_name = "gausslegendre_pseudospectral_none_bc"
             vperp_bc = "none"
             vpa_bc = "none"
             run_test(test_input_gauss_legendre, expected_none_bc, 1.0e-14, 1.0e-14;
                      vperp=OptionsDict("bc" => vperp_bc), vpa=OptionsDict("bc" => vpa_bc))
         end
-        @testset "Gauss Legendre no (explicitly) enforced boundary conditions" begin
+        @testset "Gauss Legendre no (explicitly) enforced boundary conditions: IMEX timestepping" begin
             run_name = "gausslegendre_pseudospectral_none_bc"
             vperp_bc = "none"
             vpa_bc = "none"
             run_test(test_input_gauss_legendre, expected_none_bc, 5.0e-12, 5.0e-12;
                      vperp=OptionsDict("bc" => vperp_bc), vpa=OptionsDict("bc" => vpa_bc),
-                     fokker_planck_collisions=OptionsDict("nonlinear_solver" =>
-                                                               OptionsDict("rtol" => 0.0,
+                     fokker_planck_collisions_nonlinear_solver=OptionsDict("rtol" => 0.0,
                                                                            "atol" => 1.0e-14,
-                                                                           "nonlinear_max_iterations" => 20,),),
+                                                                           "nonlinear_max_iterations" => 20,),
                      timestepping=OptionsDict("kinetic_ion_solver" => "implicit_ion_fp_collisions",
                                               "type" => "PareschiRusso3(4,3,3)",))
         end

--- a/moment_kinetics/test/fokker_planck_time_evolution_tests.jl
+++ b/moment_kinetics/test/fokker_planck_time_evolution_tests.jl
@@ -581,7 +581,7 @@ function runtests()
             run_name = "gausslegendre_pseudospectral"
             vperp_bc = "zero-impose-regularity"
             run_test(test_input_gauss_legendre,
-             expected_zero_impose_regularity, 1.0e-14, 1.0e-14;
+             expected_zero_impose_regularity, 1.0e-14, 2.0e-14;
              vperp=OptionsDict("bc" => vperp_bc))
         end
         @testset "Gauss Legendre no enforced regularity condition at vperp = 0" begin

--- a/test_scripts/ImplicitCollisionsTest.jl
+++ b/test_scripts/ImplicitCollisionsTest.jl
@@ -176,7 +176,7 @@ function test_implicit_collisions(; vth0=0.5,vperp0=1.0,vpa0=0.0, ngrid=3,neleme
                                                                                         "nonlinear_max_iterations" => nonlinear_max_iterations),)
     fkpl = setup_fkpl_collisions_input(input_toml, true)
     nl_solver_params = setup_fp_nl_solve(implicit_ion_fp_collisions,
-                                        fkpl, coords)
+                                        input_toml, coords)
 
     #println(nl_solver_params.preconditioners)
     for it in 1:ntime
@@ -358,7 +358,7 @@ function test_implicit_collisions_wrapper(; vth0=0.5,vperp0=1.0,vpa0=0.0, ngrid=
     coords = (vperp=vperp,vpa=vpa)
     spectral_objects = (vperp_spectral=vperp_spectral, vpa_spectral=vpa_spectral)
     nl_solver_params = setup_fp_nl_solve(implicit_ion_fp_collisions,
-                                         collisions.fkpl, coords)
+                                         input_toml, coords)
 
     #println(nl_solver_params.preconditioners)
     for it in 1:ntime

--- a/test_scripts/ImplicitCollisionsTest.jl
+++ b/test_scripts/ImplicitCollisionsTest.jl
@@ -171,9 +171,9 @@ function test_implicit_collisions(; vth0=0.5,vperp0=1.0,vpa0=0.0, ngrid=3,neleme
     implicit_ion_fp_collisions = true
     coords = (vperp=vperp,vpa=vpa)
     spectral = (vperp_spectral=vperp_spectral, vpa_spectral=vpa_spectral)
-    input_toml = OptionsDict("fokker_planck_collisions" => OptionsDict("nonlinear_solver" => OptionsDict("rtol" => rtol,
-                                                                                                         "atol" => atol,
-                                                                                                         "nonlinear_max_iterations" => nonlinear_max_iterations),))
+    input_toml = OptionsDict("fokker_planck_collisions_nonlinear_solver" => OptionsDict("rtol" => rtol,
+                                                                                        "atol" => atol,
+                                                                                        "nonlinear_max_iterations" => nonlinear_max_iterations),)
     fkpl = setup_fkpl_collisions_input(input_toml, true)
     nl_solver_params = setup_fp_nl_solve(implicit_ion_fp_collisions,
                                         fkpl, coords)
@@ -291,11 +291,10 @@ function test_implicit_collisions_wrapper(; vth0=0.5,vperp0=1.0,vpa0=0.0, ngrid=
                                                                         "frequency_option" => "manual",
                                                                         "self_collisions" => true,
                                                                         "use_conserving_corrections" => test_numerical_conserving_terms,
-                                                                        "boundary_data_option" => boundary_data_option,
-                                                                        "nonlinear_solver" => OptionsDict("rtol" => rtol,
-                                                                                                          "atol" => atol,
-                                                                                                          "nonlinear_max_iterations" => nonlinear_max_iterations),
-                                                                        )
+                                                                        "boundary_data_option" => boundary_data_option,),
+                            "fokker_planck_collisions_nonlinear_solver" => OptionsDict("rtol" => rtol,
+                                                                                       "atol" => atol,
+                                                                                       "nonlinear_max_iterations" => nonlinear_max_iterations),
                             )
     #println(options_to_TOML(input_toml))
     collisions = (fkpl = setup_fkpl_collisions_input(input_toml, true), krook=nothing)

--- a/util/precompile_run.jl
+++ b/util/precompile_run.jl
@@ -93,9 +93,9 @@ collisions_input4 = recursive_merge(wall_bc_cheb_input, OptionsDict("composition
                                                                     "vpa" => OptionsDict("discretization" => "gausslegendre_pseudospectral"),
                                                                    ))
 collisions_input5 = recursive_merge(wall_bc_cheb_input, OptionsDict("composition" => OptionsDict("n_neutral_species" => 0),
-                                                                    "fokker_planck_collisions" => OptionsDict("use_fokker_planck" => true, "self_collisions" => true, "boundary_data_option" => "multipole_expansion",
-                                                                                                              "nonlinear_solver" => OptionsDict("rtol" => 0.0,
-                                                                                                                                               "atol" => 1.0e-14)),
+                                                                    "fokker_planck_collisions" => OptionsDict("use_fokker_planck" => true, "self_collisions" => true, "boundary_data_option" => "multipole_expansion"),
+                                                                    "fokker_planck_collisions_nonlinear_solver" => OptionsDict("rtol" => 0.0,
+                                                                                                                               "atol" => 1.0e-14),
                                                                     "timestepping"=> OptionsDict("kinetic_ion_solver" => "implicit_ion_fp_collisions",
                                                                                                  "type" => "PareschiRusso3(4,3,3)",),
                                                                     "vperp" => OptionsDict("discretization" => "gausslegendre_pseudospectral"),


### PR DESCRIPTION
This PR should address comments from @johnomotani regarding consistency of the inputs for nonlinear solvers for implicit FP collisions with the overall input checking scheme.

Here I make the nonlinear solver input for Fokker-Planck collisions take the form
```
[fokker_planck_collisions_nonlinear_solver]
rtol = 0.0
atol = 1.0e-10
nonlinear_max_iterations = 50
```
I.e., this is a standalone namelist that is read once by `setup_nonlinear_solve()` by passing the main `input_dict` (directly from the TOML) through a wrapper where Fokker-Planck specific defaults can be specified.