### PR TITLE
Convert 'anyv' parallelisation to 'anysv'

### DIFF
--- a/docs/src/developing.md
+++ b/docs/src/developing.md
@@ -231,8 +231,8 @@ that share an anysv subblock are all part of the `comm_anysv_subblock[]`
 communicator (which is a subset of the processes in the full block, whose
 communicator is `comm_block[]`).
 
-See also notes on debugging the 'anyv' parallelisation: [Collision operator and
-'anysv' region](@ref).
+See also notes on debugging the 'anysv' parallelisation: [Collision operator
+and 'anysv' region](@ref).
 
 ## Bounds checking
 

--- a/moment_kinetics/debug_test/README.md
+++ b/moment_kinetics/debug_test/README.md
@@ -23,20 +23,20 @@ something like
 julia --project --check-bounds=yes --compiled-modules=no debug_test/runtests.jl --debug 99
 ```
 
-Collision operator and 'anyv' region
+Collision operator and 'anysv' region
 ------------------------------------
 
 The collision operator uses a slightly hacky special set of functions for
-shared memory parallelism, to allow the outer loop over species and spatial
-dimensions to be parallelised, but also inner loops over `vperp`, `vpa` or
-`vperp` and `vpa` to be parallelised - changing the type of inner-loop
-parallelism within the outer loop. This happens within an 'anyv' region, which
-is started with the `begin_s_r_z_anyv_region()` function. The debug checks
-within an 'anyv' region only check for correctness on the sub-block
-communicator that parallelises over velocity space, so if there were errors due
-to incorrect species or spatial parallelism they would not (might not?) be
-detected. These errors should be unlikely as the collision operator only writes
-to a single species at a single spatial point.
+shared memory parallelism, to allow the outer loop over spatial dimensions to
+be parallelised, but also inner loops over `s`, `vperp`, `vpa` or combinations
+to be parallelised - changing the type of inner-loop parallelism within the
+outer loop. This happens within an 'anysv' region, which is started with the
+`begin_r_z_anysv_region()` function. The debug checks within an 'anysv' region
+only check for correctness on the sub-block communicator that parallelises over
+velocity space, so if there were errors due to incorrect species or spatial
+parallelism they would not (might not?) be detected. These errors should be
+unlikely as the collision operator only writes to a single species at a single
+spatial point.
 
 Finding race conditions
 -----------------------

--- a/moment_kinetics/debug_test/runtest_template.jl
+++ b/moment_kinetics/debug_test/runtest_template.jl
@@ -2,7 +2,7 @@ using moment_kinetics: setup_moment_kinetics, cleanup_moment_kinetics!
 using moment_kinetics.time_advance: time_advance!
 using moment_kinetics.communication
 using moment_kinetics.looping: all_dimensions, dimension_combinations,
-                               anyv_dimension_combinations
+                               anysv_dimension_combinations
 using moment_kinetics.type_definitions: OptionsDict
 using moment_kinetics.Glob
 using moment_kinetics.Primes
@@ -52,7 +52,7 @@ function runtests(; restart=false)
     # Only need to test dimension combinations that are actually used for parallel loops
     # in some part of the code
     dimension_combinations_to_test = [c for c in tuple(dimension_combinations...,
-                                                       anyv_dimension_combinations...)
+                                                       anysv_dimension_combinations...)
                                       if dimension_combination_is_used(c)]
 
     @testset "$test_type" begin
@@ -69,7 +69,7 @@ function runtests(; restart=false)
                 continue
             end
 
-            if :anyv ∈ debug_loop_type
+            if :anysv ∈ debug_loop_type
                 dims_to_test = debug_loop_type[2:end]
             else
                 dims_to_test = debug_loop_type

--- a/moment_kinetics/src/communication.jl
+++ b/moment_kinetics/src/communication.jl
@@ -973,10 +973,10 @@ debugging routines need to be updated.
             end
         end
 
-        # Also check 'anyv' arrays, as these are synchronized by this call.
+        # Also check 'anysv' arrays, as these are synchronized by this call.
         # `missing` passed as the call_site argument here indicates that the check of
         # call_site has already been done.
-        _anyv_subblock_synchronize(missing)
+        _anysv_subblock_synchronize(missing)
 
         MPI.Barrier(comm_block[])
     end

--- a/moment_kinetics/src/communication.jl
+++ b/moment_kinetics/src/communication.jl
@@ -14,12 +14,12 @@ module communication
 
 export allocate_shared, block_rank, block_size, n_blocks, comm_block, comm_inter_block,
        iblock_index, comm_world, finalize_comms!, initialize_comms!, global_rank,
-       MPISharedArray, global_size, comm_anyv_subblock, anyv_subblock_rank,
-       anyv_subblock_size, anyv_isubblock_index, anyv_nsubblocks_per_block
+       MPISharedArray, global_size, comm_anysv_subblock, anysv_subblock_rank,
+       anysv_subblock_size, anysv_isubblock_index, anysv_nsubblocks_per_block
 export setup_distributed_memory_MPI
 export setup_distributed_memory_MPI_for_weights_precomputation
 export setup_serial_MPI
-export @_block_synchronize, @_anyv_subblock_synchronize
+export @_block_synchronize, @_anysv_subblock_synchronize
 
 using LinearAlgebra
 using MPI
@@ -58,18 +58,18 @@ MPI.jl delete the communicator.
 const comm_inter_block = Ref(MPI.COMM_NULL)
 
 """
-Communicator for the local velocity-space subset of a shared-memory block in a 'anyv'
+Communicator for the local velocity-space subset of a shared-memory block in a 'anysv'
 region
 
-The 'anyv' region is used to parallelise the collision operator. See
-[`moment_kinetics.looping.get_best_anyv_split`](@ref).
+The 'anysv' region is used to parallelise the collision operator. See
+[`moment_kinetics.looping.get_best_anysv_split`](@ref).
 
 Must use a `Ref{MPI.Comm}` to allow a non-const `MPI.Comm` to be stored. Need to actually
 assign to this and not just copy a pointer into the `.val` member because otherwise the
 `MPI.Comm` object created by `MPI.Comm_split()` would be deleted, which probably makes
 MPI.jl delete the communicator.
 """
-const comm_anyv_subblock = Ref(MPI.COMM_NULL)
+const comm_anysv_subblock = Ref(MPI.COMM_NULL)
 
 # Use Ref for these variables so that they can be made `const` (so have a definite
 # type), but contain a value assigned at run-time.
@@ -95,19 +95,19 @@ const block_size = Ref{mk_int}()
 
 """
 """
-const anyv_subblock_rank = Ref{mk_int}()
+const anysv_subblock_rank = Ref{mk_int}()
 
 """
 """
-const anyv_subblock_size = Ref{mk_int}()
+const anysv_subblock_size = Ref{mk_int}()
 
 """
 """
-const anyv_isubblock_index = Ref{Union{mk_int,Nothing}}()
+const anysv_isubblock_index = Ref{Union{mk_int,Nothing}}()
 
 """
 """
-const anyv_nsubblocks_per_block = Ref{mk_int}()
+const anysv_nsubblocks_per_block = Ref{mk_int}()
 
 """
 """
@@ -561,11 +561,11 @@ end
     # instances, so their is_read and is_written members can be checked and
     # reset by _block_synchronize()
     const global_debugmpisharedarray_store = Vector{DebugMPISharedArray}(undef, 0)
-    # 'anyv' regions require a separate array store, because within an anyv region,
+    # 'anysv' regions require a separate array store, because within an anysv region,
     # processes in the same shared memory block may still not be synchronized if they are
-    # in different anyv sub-blocks, so debug checks within an anyv region should only
-    # consider the anyv-specific arrays.
-    const global_anyv_debugmpisharedarray_store = Vector{DebugMPISharedArray}(undef, 0)
+    # in different anysv sub-blocks, so debug checks within an anysv region should only
+    # consider the anysv-specific arrays.
+    const global_anysv_debugmpisharedarray_store = Vector{DebugMPISharedArray}(undef, 0)
 end
 
 """
@@ -684,8 +684,8 @@ function allocate_shared(T, dims; comm=nothing, maybe_debug=true)
         # If @debug_shared_array is active, create DebugMPISharedArray instead of Array
         if maybe_debug
             debug_array = DebugMPISharedArray(array, comm)
-            if comm == comm_anyv_subblock[]
-                push!(global_anyv_debugmpisharedarray_store, debug_array)
+            if comm == comm_anysv_subblock[]
+                push!(global_anysv_debugmpisharedarray_store, debug_array)
             else
                 push!(global_debugmpisharedarray_store, debug_array)
             end
@@ -820,8 +820,8 @@ end
     Can be added when debugging to help pin down where an error occurs.
     """
     function debug_check_shared_memory(; comm=comm_block[], kwargs...)
-        if comm == comm_anyv_subblock[]
-            for array ∈ global_anyv_debugmpisharedarray_store
+        if comm == comm_anysv_subblock[]
+            for array ∈ global_anysv_debugmpisharedarray_store
                 debug_check_shared_array(array; comm=comm, kwargs...)
             end
         else
@@ -983,39 +983,39 @@ debugging routines need to be updated.
 end
 
 """
-Call an MPI Barrier for all processors in an 'anyv' sub-block.
+Call an MPI Barrier for all processors in an 'anysv' sub-block.
 
-The 'anyv' region is used to parallelise the collision operator. See
-[`moment_kinetics.looping.get_best_anyv_split`](@ref).
+The 'anysv' region is used to parallelise the collision operator. See
+[`moment_kinetics.looping.get_best_anysv_split`](@ref).
 
 Used to synchronise processors that are working on the same shared-memory array(s)
 between operations, to avoid race conditions. Should be even cheaper than
 [`@_block_synchronize`](@ref) because it only requires communication on a smaller
 communicator.
 
-Note: `_anyv_subblock_synchronize()` may be called different numbers of times on different
+Note: `_anysv_subblock_synchronize()` may be called different numbers of times on different
 sub-blocks, depending on how the species and spatial dimensions are split up.
 `@debug_detect_redundant_block_synchronize` is not implemented (yet?) for
-`_anyv_subblock_synchronize()`.
+`_anysv_subblock_synchronize()`.
 """
-macro _anyv_subblock_synchronize()
+macro _anysv_subblock_synchronize()
     id_hash = @debug_block_synchronize_quick_ifelse(
                    hash(string(@__FILE__, @__LINE__)),
                    nothing
                   )
-    return :( _anyv_subblock_synchronize($id_hash) )
+    return :( _anysv_subblock_synchronize($id_hash) )
 end
 
 """
-Internal function called by `anyv` synchronization macros.
+Internal function called by `anysv` synchronization macros.
 """
-function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
-    if comm_anyv_subblock[] == MPI.COMM_NULL
+function _anysv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
+    if comm_anysv_subblock[] == MPI.COMM_NULL
         # No synchronization to do for a null communicator
         return nothing
     end
 
-    MPI.Barrier(comm_anyv_subblock[])
+    MPI.Barrier(comm_anysv_subblock[])
 
     @debug_block_synchronize_backtrace begin
         st = stacktrace()
@@ -1028,12 +1028,12 @@ function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
         signaturestring = string([string(s.file, s.line) for s ∈ st]...)
 
         hash = sha256(signaturestring)
-        all_hashes = reshape(MPI.Allgather(hash, comm_anyv_subblock[]), length(hash),
-                             MPI.Comm_size(comm_anyv_subblock[]))
+        all_hashes = reshape(MPI.Allgather(hash, comm_anysv_subblock[]), length(hash),
+                             MPI.Comm_size(comm_anysv_subblock[]))
         for i ∈ 1:block_size[]
             h = all_hashes[:, i]
             if h != hash
-                error("_anyv_subblock_synchronize() called inconsistently\n",
+                error("_anysv_subblock_synchronize() called inconsistently\n",
                       "rank $(block_rank[]) called from:\n",
                       stackstring)
             end
@@ -1048,9 +1048,9 @@ function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
         # If call_site===missing, then this function was called from inside
         # _block_synchronize(), and the call site was already checked there.
         if call_site !== missing
-            all_hashes = MPI.Allgather(call_site, comm_anyv_subblock[])
+            all_hashes = MPI.Allgather(call_site, comm_anysv_subblock[])
             if !all(h -> h == all_hashes[1], all_hashes)
-                error("_anyv_subblock_synchronize() called inconsistently")
+                error("_anysv_subblock_synchronize() called inconsistently")
             end
         end
     end
@@ -1063,9 +1063,9 @@ function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
         # * If an element is written to, only the rank that writes to it should read it.
         #
         @debug_detect_redundant_block_synchronize previous_was_unnecessary = true
-        for array ∈ global_anyv_debugmpisharedarray_store
+        for array ∈ global_anysv_debugmpisharedarray_store
 
-            debug_check_shared_array(array; comm=comm_anyv_subblock[])
+            debug_check_shared_array(array; comm=comm_anysv_subblock[])
 
             @debug_detect_redundant_block_synchronize begin
                 # debug_detect_redundant_is_active[] is set to true at the beginning of
@@ -1077,7 +1077,7 @@ function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
                 if debug_detect_redundant_is_active[]
 
                     if !debug_check_shared_array(array; check_redundant=true,
-                                                 comm_anyv_subblock)
+                                                 comm_anysv_subblock)
                         # If there was a failure for at least one array, the previous
                         # _block_synchronize was necessary - if the previous call was not
                         # there, for this array array.is_read and array.is_written would
@@ -1107,7 +1107,7 @@ function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
                 # Check the previous call was unnecessary on all processes, not just
                 # this one
                 previous_was_unnecessary = MPI.Allreduce(previous_was_unnecessary,
-                                                         MPI.Op(&, Bool), comm_anyv_subblock[])
+                                                         MPI.Op(&, Bool), comm_anysv_subblock[])
 
                 if (previous_was_unnecessary && global_size[] > 1)
                     # The intention of this debug block is to detect when calls to
@@ -1134,7 +1134,7 @@ function _anyv_subblock_synchronize(call_site::Union{Nothing,Missing,UInt64})
             end
         end
 
-        MPI.Barrier(comm_anyv_subblock[])
+        MPI.Barrier(comm_anysv_subblock[])
     end
 end
 
@@ -1177,7 +1177,7 @@ end
 """
 function free_shared_arrays()
     @debug_shared_array resize!(global_debugmpisharedarray_store, 0)
-    @debug_shared_array resize!(global_anyv_debugmpisharedarray_store, 0)
+    @debug_shared_array resize!(global_anysv_debugmpisharedarray_store, 0)
 
     for w ∈ global_Win_store
         MPI.free(w)

--- a/moment_kinetics/src/electron_kinetic_equation.jl
+++ b/moment_kinetics/src/electron_kinetic_equation.jl
@@ -1885,7 +1885,7 @@ The r-dimension is not parallelised. For 1D runs this makes no difference. In 2D
 or might not be necessary. If r-dimension parallelisation is needed, it would need some
 work. The simplest option would be a non-parallelised outer loop over r, with each
 nonlinear solve being parallelised over {z,vperp,vpa}. More efficient might be to add an
-equivalent to the 'anyv' parallelisation used for the collision operator (e.g. 'anyzv'?)
+equivalent to the 'anysv' parallelisation used for the collision operator (e.g. 'anyzv'?)
 to allow the outer r-loop to be parallelised.
 """
 @timeit global_timer implicit_electron_advance!(

--- a/moment_kinetics/src/fokker_planck.jl
+++ b/moment_kinetics/src/fokker_planck.jl
@@ -21,8 +21,8 @@ supported for the purposes of testing and debugging.
 Lower-level routines are provided by functions from
 [`moment_kinetics.fokker_planck_calculus`](@ref).
 
-Parallelisation of the collision operator uses a special 'anyv' region type, see
-[Collision operator and `anyv` region](@ref).
+Parallelisation of the collision operator uses a special 'anysv' region type, see
+[Collision operator and `anysv` region](@ref).
 """
 module fokker_planck
 
@@ -211,51 +211,51 @@ function init_fokker_planck_collisions_weak_form(vpa,vperp,vpa_spectral,vperp_sp
     # collision operator for a single species at a single spatial point. They are
     # shared-memory arrays. The `comm` argument to `allocate_shared_float()` is used to
     # set up the shared-memory arrays so that they are shared only by the processes on
-    # `comm_anyv_subblock[]` rather than on the full `comm_block[]` (see also the
-    # "Collision operator and anyv region" section of the "Developing" page of the docs.
+    # `comm_anysv_subblock[]` rather than on the full `comm_block[]` (see also the
+    # "Collision operator and anysv region" section of the "Developing" page of the docs.
     # This means that different subblocks that are calculating the collision operator at
     # different spatial points do not interfere with each others' buffer arrays.
     nvpa, nvperp = vpa.n, vperp.n
-    S_dummy = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    Q_dummy = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    rhsvpavperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    rhsvpavperp_copy1 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    rhsvpavperp_copy2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    rhsvpavperp_copy3 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    S_dummy = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    Q_dummy = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    rhsvpavperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    rhsvpavperp_copy1 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    rhsvpavperp_copy2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    rhsvpavperp_copy3 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
     
-    CC = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    GG = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    HH = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dHdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dHdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dGdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2Gdvperp2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2Gdvpa2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2Gdvperpdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    CC = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    GG = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    HH = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dHdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dHdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dGdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2Gdvperp2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2Gdvpa2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2Gdvperpdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
     
-    FF = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dFdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dFdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    FF = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dFdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dFdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
     # preconditioner matrix
     CC2D_sparse, CC2D_sparse_constructor, lu_obj_CC2D = allocate_preconditioner_matrix(vpa,vperp,vpa_spectral,vperp_spectral)
-    rhs_advection = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    rhs_advection = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
     # dummy arrays for JFNK
-    Fnew = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    Fresidual = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    F_delta_x = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    F_rhs_delta = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    Fv = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    Fw = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    Fnew = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    Fresidual = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    F_delta_x = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    F_rhs_delta = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    Fv = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    Fw = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
 
     # Set up indices for shared-memory parallelised 2D loops over elements, rather than the
     # usual loops over grid points. Used for the FP preconditioner matrix calculation.
     # Hacky use of `get_best_ranges()` - the function requires the Dict to contain the
     # sizes of all dimensions even though we only want vperp/vpa here.
-    if anyv_subblock_rank[] < 0
-        # This process does not participate in anyv-parallelised loops
+    if anysv_subblock_rank[] < 0
+        # This process does not participate in anysv-parallelised loops
         parallel_indices = Dict(:vperp=>1:0, :vpa=>1:0)
     else
-        parallel_indices = get_best_ranges(anyv_subblock_rank[], anyv_subblock_size[],
+        parallel_indices = get_best_ranges(anysv_subblock_rank[], anysv_subblock_size[],
                                            (:vperp, :vpa),
                                            Dict(:vperp=>vperp.nelement_local,
                                                 :vpa=>vpa.nelement_local, :s=>1, :sn=>1,
@@ -322,9 +322,10 @@ where the Rosenbluth potentials are specified using analytical results.
     uparsp = [0.0, 0.0]
     vthsp = [sqrt(2.0*fkin.sd_temp/msp[1]), sqrt(2.0*fkin.sd_temp/msp[2])]
     
-    # N.B. parallelisation using special 'anyv' region
-    @begin_s_r_z_anyv_region()
-    @loop_s_r_z is ir iz begin
+    # N.B. parallelisation using special 'anysv' region
+    @begin_r_z_anysv_region()
+    @loop_r_z ir iz begin
+        is = 1
         # computes sum over s' of  C[Fs,Fs'] with Fs' an assumed Maxwellian 
         @views fokker_planck_collision_operator_weak_form_Maxwellian_Fsp!(pdf_in[:,:,iz,ir,is],
                                      nuref,mref,Zs,msp,Zsp,densp,uparsp,vthsp,
@@ -336,7 +337,7 @@ where the Rosenbluth potentials are specified using analytical results.
             density_conserving_correction!(fkpl_arrays.CC, pdf_in[:,:,iz,ir,is], vpa, vperp)
         end
         # advance this part of s,r,z with the resulting sum_s' C[Fs,Fs']
-        @begin_anyv_vperp_vpa_region()
+        @begin_anysv_vperp_vpa_region()
         CC = fkpl_arrays.CC
         @loop_vperp_vpa ivperp ivpa begin
             pdf_out[ivpa,ivperp,iz,ir,is] += dt*CC[ivpa,ivperp]
@@ -379,9 +380,10 @@ Function for advancing with the explicit, weak-form, self-collision operator.
     nuss = nuref*(Zi^4) # include charge number factor for self collisions
     use_conserving_corrections = collisions.fkpl.use_conserving_corrections
     boundary_data_option = collisions.fkpl.boundary_data_option
-    # N.B. parallelisation using special 'anyv' region
-    @begin_s_r_z_anyv_region()
-    @loop_s_r_z is ir iz begin
+    # N.B. parallelisation using special 'anysv' region
+    @begin_r_z_anysv_region()
+    @loop_r_z ir iz begin
+        is = 1
         # first argument is Fs, and second argument is Fs' in C[Fs,Fs'] 
         @views fokker_planck_self_collision_operator_weak_form!(
             pdf_in[:,:,iz,ir,is], ms, nuss, fkpl_arrays,
@@ -389,7 +391,7 @@ Function for advancing with the explicit, weak-form, self-collision operator.
             boundary_data_option = boundary_data_option,
             use_conserving_corrections = use_conserving_corrections)
         # advance this part of s,r,z with the resulting C[Fs,Fs]
-        @begin_anyv_vperp_vpa_region()
+        @begin_anysv_vperp_vpa_region()
         CC = fkpl_arrays.CC
         @loop_vperp_vpa ivperp ivpa begin
             pdf_out[ivpa,ivperp,iz,ir,is] += dt*CC[ivpa,ivperp]
@@ -486,12 +488,12 @@ with \$\\gamma_\\mathrm{ref} = 2 \\pi e^4 \\ln \\Lambda_{ii} / (4 \\pi
     end
     # assemble the RHS of the collision operator matrix eq
     if use_Maxwellian_field_particle_distribution
-        @begin_anyv_region()
+        @begin_anysv_region()
         dens = get_density(ffsp_in,vpa,vperp)
         upar = get_upar(ffsp_in, dens, vpa, vperp, false)
         pressure = get_p(ffsp_in, dens, upar, vpa, vperp, false, false)
         vth = sqrt(2.0*pressure/(dens*msp))
-        @begin_anyv_vperp_vpa_region()
+        @begin_anysv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             FF[ivpa,ivperp] = F_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
             dFdvpa[ivpa,ivperp] = dFdvpa_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
@@ -500,7 +502,7 @@ with \$\\gamma_\\mathrm{ref} = 2 \\pi e^4 \\ln \\Lambda_{ii} / (4 \\pi
         # Need to synchronize as FF, dFdvpa, dFdvperp may be read outside the
         # locally-owned set of ivperp, ivpa indices in
         # assemble_explicit_collision_operator_rhs_parallel_analytical_inputs!()
-        @_anyv_subblock_synchronize()
+        @_anysv_subblock_synchronize()
         assemble_explicit_collision_operator_rhs_parallel_analytical_inputs!(rhsvpavperp,
           FF,dFdvpa,dFdvperp,
           d2Gdvpa2,d2Gdvperpdvpa,d2Gdvperp2,
@@ -512,15 +514,15 @@ with \$\\gamma_\\mathrm{ref} = 2 \\pi e^4 \\ln \\Lambda_{ii} / (4 \\pi
           dHdvpa,dHdvperp,ms,msp,nussp,
           vpa,vperp,YY_arrays)
     else
-        @_anyv_subblock_synchronize()
+        @_anysv_subblock_synchronize()
         assemble_explicit_collision_operator_rhs_parallel!(rhsvpavperp,ffs_in,
           d2Gdvpa2,d2Gdvperpdvpa,d2Gdvperp2,
           dHdvpa,dHdvperp,ms,msp,nussp,
           vpa,vperp,YY_arrays)
     end
     # solve the collision operator matrix eq
-    @begin_anyv_region()
-    @anyv_serial_region begin
+    @begin_anysv_region()
+    @anysv_serial_region begin
         # sc and rhsc are 1D views of the data in CC and rhsc, created so that we can use
         # the 'matrix solve' functionality of ldiv!() from the LinearAlgebra package
         sc = vec(CC)
@@ -572,7 +574,7 @@ are specified using analytical results.
     # number of primed species
     nsp = size(msp,1)
     
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
     # fist set dummy arrays for coefficients to zero
     @loop_vperp_vpa ivperp ivpa begin
         d2Gdvpa2[ivpa,ivperp] = 0.0
@@ -603,15 +605,15 @@ are specified using analytical results.
     # ivperp, ivpa indices in assemble_explicit_collision_operator_rhs_parallel!()
     # assemble the RHS of the collision operator matrix eq
 
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     assemble_explicit_collision_operator_rhs_parallel!(rhsvpavperp,ffs_in,
       d2Gdvpa2,d2Gdvperpdvpa,d2Gdvperp2,
       dHdvpa,dHdvperp,1.0,1.0,nuref,
       vpa,vperp,YY_arrays)
 
     # solve the collision operator matrix eq
-    @begin_anyv_region()
-    @anyv_serial_region begin
+    @begin_anysv_region()
+    @anysv_serial_region begin
         # sc and rhsc are 1D views of the data in CC and rhsc, created so that we can use
         # the 'matrix solve' functionality of ldiv!() from the LinearAlgebra package
         sc = vec(CC)
@@ -699,11 +701,11 @@ and \$x_0,x_1,x_2\$ are parameters that are chosen so that \$C_{ss}\$
 conserves density, parallel velocity and pressure of \$F_s\$.
 """
 function conserving_corrections!(CC,pdf_in,vpa,vperp)
-    @begin_anyv_region()
+    @begin_anysv_region()
     x0, x1, x2, upar = 0.0, 0.0, 0.0, 0.0
-    @anyv_serial_region begin
+    @anysv_serial_region begin
         # In principle the integrations here could be shared among the processes in the
-        # 'anyv' subblock, but this block is not a significant part of the cost of the
+        # 'anysv' subblock, but this block is not a significant part of the cost of the
         # collision operator, so probably not worth the complication.
 
         # compute moments of the input pdf
@@ -730,15 +732,15 @@ function conserving_corrections!(CC,pdf_in,vpa,vperp)
         (x0, x1, x2) = symmetric_matrix_inverse(A00,A02,A11,A12,A22,b0,b1,b2)
     end
 
-    # Broadcast x0, x1, x2 to all processes in the 'anyv' subblock
+    # Broadcast x0, x1, x2 to all processes in the 'anysv' subblock
     param_vec = [x0, x1, x2, upar]
-    if comm_anyv_subblock[] != MPI.COMM_NULL
-        MPI.Bcast!(param_vec, 0, comm_anyv_subblock[])
+    if comm_anysv_subblock[] != MPI.COMM_NULL
+        MPI.Bcast!(param_vec, 0, comm_anysv_subblock[])
     end
     (x0, x1, x2, upar) = param_vec
     
     # correct CC
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         wpar = vpa.grid[ivpa] - upar
         CC[ivpa,ivperp] -= (x0 + x1*wpar + x2*(vperp.grid[ivperp]^2 + wpar^2) )*pdf_in[ivpa,ivperp]
@@ -755,11 +757,11 @@ where \$C^\\ast_{ss}[F_s,F_{s^\\prime}]\$ is the weak-form collision operator co
 the finite-element implementation.
 """
 function density_conserving_correction!(CC,pdf_in,vpa,vperp)
-    @begin_anyv_region()
+    @begin_anysv_region()
     x0 = 0.0
-    @anyv_serial_region begin
+    @anysv_serial_region begin
         # In principle the integrations here could be shared among the processes in the
-        # 'anyv' subblock, but this block is not a significant part of the cost of the
+        # 'anysv' subblock, but this block is not a significant part of the cost of the
         # collision operator, so probably not worth the complication.
 
         # compute density of the input pdf
@@ -772,15 +774,15 @@ function density_conserving_correction!(CC,pdf_in,vpa,vperp)
         x0 = dn/dens
     end
 
-    # Broadcast x0 to all processes in the 'anyv' subblock
+    # Broadcast x0 to all processes in the 'anysv' subblock
     param_vec = [x0]
-    if comm_anyv_subblock[] != MPI.COMM_NULL
-        MPI.Bcast!(param_vec, 0, comm_anyv_subblock[])
+    if comm_anysv_subblock[] != MPI.COMM_NULL
+        MPI.Bcast!(param_vec, 0, comm_anysv_subblock[])
     end
     x0 = param_vec[1]
     
     # correct CC
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         CC[ivpa,ivperp] -= x0*pdf_in[ivpa,ivperp]
     end
@@ -794,7 +796,7 @@ function calculate_entropy_production!(dSdt,pdf,fkpl_arrays,vpa,vperp,
     # Note that we pass spatial indices here to permit
     # use of the shared-memory parallelism to calculate
     # and return a float value in an array
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     CC = fkpl_arrays.CC
     # assign dummy array
@@ -802,8 +804,8 @@ function calculate_entropy_production!(dSdt,pdf,fkpl_arrays,vpa,vperp,
     @loop_vperp_vpa ivperp ivpa begin
         lnfC[ivpa,ivperp] = log(abs(pdf[ivpa,ivperp,iz,ir,is]) + 1.0e-15)*CC[ivpa,ivperp]
     end
-    @begin_anyv_region()
-    @anyv_serial_region begin
+    @begin_anysv_region()
+    @anysv_serial_region begin
         dSdt[iz,ir,is] = -get_density(lnfC,vpa,vperp)
     end
     return nothing
@@ -841,30 +843,30 @@ function allocate_fokkerplanck_arrays_direct_integration(vperp,vpa)
     # collision operator for a single species at a single spatial point. They are
     # shared-memory arrays. The `comm` argument to `allocate_shared_float()` is used to
     # set up the shared-memory arrays so that they are shared only by the processes on
-    # `comm_anyv_subblock[]` rather than on the full `comm_block[]`. This means that
+    # `comm_anysv_subblock[]` rather than on the full `comm_block[]`. This means that
     # different subblocks that are calculating the collision operator at different
     # spatial points do not interfere with each others' buffer arrays.
     # Note that the 'weights' allocated above are read-only and therefore can be used
     # simultaneously by different subblocks. They are shared over the full
     # `comm_block[]` in order to save memory and setup time.
-    GG = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2Gdvpa2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2Gdvperpdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2Gdvperp2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dGdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    HH = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dHdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dHdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    #Cflux_vpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    #Cflux_vperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    GG = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2Gdvpa2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2Gdvperpdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2Gdvperp2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dGdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    HH = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dHdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dHdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    #Cflux_vpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    #Cflux_vperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
     buffer_vpavperp_1 = allocate_float(nvpa,nvperp)
     buffer_vpavperp_2 = allocate_float(nvpa,nvperp)
-    Cssp_result_vpavperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dfdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2fdvpa2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2fdvperpdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    dfdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
-    d2fdvperp2 = allocate_shared_float(nvpa,nvperp; comm=comm_anyv_subblock[])
+    Cssp_result_vpavperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dfdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2fdvpa2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2fdvperpdvpa = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    dfdvperp = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
+    d2fdvperp2 = allocate_shared_float(nvpa,nvperp; comm=comm_anysv_subblock[])
     
     return fokkerplanck_arrays_direct_integration_struct(G0_weights,G1_weights,H0_weights,H1_weights,H2_weights,H3_weights,
                                GG,d2Gdvpa2,d2Gdvperpdvpa,d2Gdvperp2,dGdvperp,
@@ -925,7 +927,7 @@ function setup_fp_nl_solve(implicit_ion_fp_collisions::Bool,
     return setup_nonlinear_solve(
         implicit_ion_fp_collisions,
         input_dict,
-        coords; serial_solve=false, anyv_region=true,
+        coords; serial_solve=false, anysv_region=true,
         section_name = section_name,
         default_atol=default_atol, default_rtol=default_rtol)
 end
@@ -966,9 +968,10 @@ function implicit_ion_fokker_planck_self_collisions!(pdf_out, pdf_in, dSdt,
     test_particle_preconditioner = collisions.fkpl.use_test_particle_preconditioner
     # coords for vperp vpa newton_solve!
     coords = (vperp=vperp,vpa=vpa)
-    # N.B. parallelisation using special 'anyv' region
-    @begin_s_r_z_anyv_region()
-    @loop_s_r_z is ir iz begin
+    # N.B. parallelisation using special 'anysv' region
+    @begin_r_z_anysv_region()
+    @loop_r_z ir iz begin
+        is = 1
         @views Fold = pdf_in[:,:,iz,ir,is]
         local_success = fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, nuss, fkpl_arrays,
                             coords, spectral_objects,
@@ -983,7 +986,7 @@ function implicit_ion_fokker_planck_self_collisions!(pdf_out, pdf_in, dSdt,
         Fnew = fkpl_arrays.Fnew
         if use_conserving_corrections && use_end_of_step_corrections
             # ad-hoc end-of-step corrections
-            @begin_anyv_vperp_vpa_region()
+            @begin_anysv_vperp_vpa_region()
             deltaF = fkpl_arrays.rhsvpavperp
             @loop_vperp_vpa ivperp ivpa begin
                 deltaF[ivpa,ivperp] = Fnew[ivpa,ivperp] - Fold[ivpa,ivperp]
@@ -1000,7 +1003,7 @@ function implicit_ion_fokker_planck_self_collisions!(pdf_out, pdf_in, dSdt,
         end
         
         # store Fnew = F^n+1 in the appropriate distribution function array
-        @begin_anyv_vperp_vpa_region()
+        @begin_anysv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             pdf_out[ivpa,ivperp,iz,ir,is] = Fnew[ivpa,ivperp]
         end
@@ -1035,7 +1038,7 @@ function fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, n
                         boundary_data_option=boundary_data_option,
                         use_conserving_corrections=test_numerical_conserving_terms)
 
-        @begin_anyv_vperp_vpa_region()
+        @begin_anysv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             Fresidual[ivpa,ivperp] = Fnew[ivpa,ivperp] - Fold[ivpa,ivperp] - delta_t * (fkpl_arrays.CC[ivpa,ivperp])
         end
@@ -1068,7 +1071,7 @@ function fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, n
     end
     # initial condition for Fnew for JFNK or linearised advance below
     Fnew = fkpl_arrays.Fnew
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
     @loop_vperp_vpa ivperp ivpa begin
         Fnew[ivpa,ivperp] = Fold[ivpa,ivperp]
     end
@@ -1086,7 +1089,7 @@ function fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, n
         # should only introduce error of order ~ atol
         enforce_vpavperp_BCs!(Fnew,vpa,vperp,vpa_spectral,vperp_spectral)
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     return success
 end
 

--- a/moment_kinetics/src/nonlinear_solvers.jl
+++ b/moment_kinetics/src/nonlinear_solvers.jl
@@ -69,7 +69,7 @@ struct nl_solver_info{TH,TV,Tcsg,Tlig,Tprecon,Tpretype}
     precon_lowerz_vcut_inds::Vector{mk_int}
     precon_upperz_vcut_inds::Vector{mk_int}
     serial_solve::Bool
-    anyv_region::Bool
+    anysv_region::Bool
     max_nonlinear_iterations_this_step::Base.RefValue{mk_int}
     max_linear_iterations_this_step::Base.RefValue{mk_int}
     total_its_soft_limit::mk_int
@@ -89,7 +89,7 @@ for example a preconditioner object for each point in that outer loop.
 """
 function setup_nonlinear_solve(active, input_dict, coords, outer_coords=();
                                section_name="nonlinear_solver", default_rtol=1.0e-5,
-                               default_atol=1.0e-12, serial_solve=false, anyv_region=false,
+                               default_atol=1.0e-12, serial_solve=false, anysv_region=false,
                                electron_p_pdf_solve=false,
                                preconditioner_type=Val(:none), warn_unexpected=false)
     nl_solver_section = set_defaults_and_check_section!(
@@ -153,28 +153,30 @@ function setup_nonlinear_solve(active, input_dict, coords, outer_coords=();
         V = (V_ppar, V_pdf)
 
         n_vcut_inds = prod(outer_coord_sizes)
-    elseif anyv_region
-        H = allocate_shared_float(linear_restart + 1, linear_restart; comm=comm_anyv_subblock[])
-        c = allocate_shared_float(linear_restart + 1; comm=comm_anyv_subblock[])
-        s = allocate_shared_float(linear_restart + 1; comm=comm_anyv_subblock[])
-        g = allocate_shared_float(linear_restart + 1; comm=comm_anyv_subblock[])
-        V = allocate_shared_float(reverse(coord_sizes)..., linear_restart+1; comm=comm_anyv_subblock[])
+    elseif anysv_region
+        H = allocate_shared_float(linear_restart + 1, linear_restart; comm=comm_anysv_subblock[])
+        c = allocate_shared_float(linear_restart + 1; comm=comm_anysv_subblock[])
+        s = allocate_shared_float(linear_restart + 1; comm=comm_anysv_subblock[])
+        g = allocate_shared_float(linear_restart + 1; comm=comm_anysv_subblock[])
+        V = allocate_shared_float(reverse(coord_sizes)..., linear_restart+1; comm=comm_anysv_subblock[])
         # Arrays below appear to need to be initialised to zero on setup.
-        # This is inconvenient for anyv communicators because we need to switch
-        # now into the special "anyv" region for this assignment,
+        # This is inconvenient for anysv communicators because we need to switch
+        # now into the special "anysv" region for this assignment,
         # to make sure that all instances of memory are initialised to zero.
-        @begin_s_r_z_anyv_region()
-        @begin_anyv_region()
-        @anyv_serial_region begin
-            H .= 0.0
-            c .= 0.0
-            s .= 0.0
-            g .= 0.0
-            V .= 0.0
+        @begin_r_z_anysv_region()
+        @begin_anysv_region()
+        if anysv_subblock_rank[] ≥ 0
+            @anysv_serial_region begin
+                H .= 0.0
+                c .= 0.0
+                s .= 0.0
+                g .= 0.0
+                V .= 0.0
+            end
         end
-        # switch out of anyv region to avoid errors on
+        # switch out of anysv region to avoid errors on
         # the next region call in initialisation, which
-        # will not be an "anyv" call.
+        # will not be an "anysv" call.
         @begin_serial_region()
     else
         H = allocate_shared_float(linear_restart + 1, linear_restart)
@@ -305,7 +307,7 @@ function setup_nonlinear_solve(active, input_dict, coords, outer_coords=();
                           Ref(0), Ref(0), Ref(0),
                           Ref(nl_solver_input.preconditioner_update_interval),
                           Ref(mk_float(0.0)), zeros(mk_int, n_vcut_inds),
-                          zeros(mk_int, n_vcut_inds), serial_solve, anyv_region, Ref(0), Ref(0),
+                          zeros(mk_int, n_vcut_inds), serial_solve, anysv_region, Ref(0), Ref(0),
                           nl_solver_input.total_its_soft_limit, preconditioner_type,
                           nl_solver_input.preconditioner_update_interval, preconditioners)
 end
@@ -482,7 +484,7 @@ old_precon_iterations = nl_solver_params.precon_iterations[]
                                    V=nl_solver_params.V, rhs_delta=rhs_delta,
                                    initial_guess=nl_solver_params.linear_initial_guess,
                                    serial_solve=nl_solver_params.serial_solve,
-                                   anyv_region=nl_solver_params.anyv_region,
+                                   anysv_region=nl_solver_params.anysv_region,
                                    initial_delta_x_is_zero=true)
         linear_counter += linear_its
 
@@ -643,27 +645,27 @@ end
                                residual::AbstractArray{mk_float, 2},
                                coords, rtol, atol, x::AbstractArray{mk_float, 2}) = begin
     # no distributed memory paralleism required when solving only in (vperp, vpa)
-    # assumed called inside @begin_s_r_z_anyv_region()
+    # assumed called inside @begin_r_z_anysv_region()
     pdf_residual = residual
     x_pdf = x
     vperp = coords.vperp
     vpa = coords.vpa
 
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
     pdf_norm_square = 0.0
     @loop_vperp_vpa ivperp ivpa begin
         pdf_norm_square += (pdf_residual[ivpa,ivperp] / (rtol * abs(x_pdf[ivpa,ivperp]) + atol))^2
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     global_norm = Ref(pdf_norm_square)
-    @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_norm, +, comm_anyv_subblock[]) # global_norm is the norm_square for the block
+    @timeit_debug global_timer "MPI.Reduce! comm_block" MPI.Reduce!(global_norm, +, comm_anysv_subblock[]) # global_norm is the norm_square for the block
 
-    if anyv_subblock_rank[] == 0
+    if anysv_subblock_rank[] == 0
         global_norm[] = sqrt(global_norm[] / (vperp.n_global * vpa.n_global))
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
 
-    @timeit_debug global_timer "MPI.Bcast! comm_block" MPI.Bcast!(global_norm, comm_anyv_subblock[]; root=0)
+    @timeit_debug global_timer "MPI.Bcast! comm_block" MPI.Bcast!(global_norm, comm_anysv_subblock[]; root=0)
     
     return global_norm[]
 end
@@ -838,16 +840,16 @@ end
     vperp = coords.vperp
     vpa = coords.vpa
 
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     pdf_dot = 0.0
     @loop_vperp_vpa ivperp ivpa begin
         pdf_dot += v_pdf[ivpa,ivperp] * w_pdf[ivpa,ivperp] / (rtol * abs(x_pdf[ivpa,ivperp]) + atol)^2
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     global_dot = Ref(pdf_dot)
-    @timeit_debug global_timer "MPI.Reduce! comm_anyv_subblock" MPI.Reduce!(global_dot, +, comm_anyv_subblock[]) # global_dot is the dot for the block
-    if anyv_subblock_rank[] == 0
+    @timeit_debug global_timer "MPI.Reduce! comm_anysv_subblock" MPI.Reduce!(global_dot, +, comm_anysv_subblock[]) # global_dot is the dot for the block
+    if anysv_subblock_rank[] == 0
         global_dot[] = global_dot[] / (vperp.n_global * vpa.n_global)
     end
     return global_dot[]
@@ -1070,12 +1072,12 @@ end
 
     result_pdf = result
 
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     @loop_vperp_vpa ivperp ivpa begin
         result_pdf[ivpa,ivperp] = func()
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     return nothing
 end
 @timeit_debug global_timer parallel_map(
@@ -1085,12 +1087,12 @@ end
     result_pdf = result
     x1_pdf = x1
 
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     @loop_vperp_vpa ivperp ivpa begin
         result_pdf[ivpa,ivperp] = func(x1_pdf[ivpa,ivperp])
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     return nothing
 end
 @timeit_debug global_timer parallel_map(
@@ -1100,7 +1102,7 @@ end
     result_pdf = result
     x1_pdf = x1
 
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     if isa(x2, AbstractArray)
         x2_pdf = x2
@@ -1113,7 +1115,7 @@ end
             result_pdf[ivpa,ivperp] = func(x1_pdf[ivpa,ivperp], x2)
         end
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     return nothing
 end
 @timeit_debug global_timer parallel_map(
@@ -1123,7 +1125,7 @@ end
     result_pdf = result
     x1_pdf = x1
     x2_pdf = x2
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     if isa(x3, AbstractArray)
         x3_pdf = x3
@@ -1136,7 +1138,7 @@ end
             result_pdf[ivpa,ivperp] = func(x1_pdf[ivpa,ivperp], x2_pdf[ivpa,ivperp], x3)
         end
     end
-    @_anyv_subblock_synchronize()
+    @_anysv_subblock_synchronize()
     return nothing
 end
 
@@ -1349,7 +1351,7 @@ end
 
     ny = length(y)
 
-    @begin_anyv_vperp_vpa_region()
+    @begin_anysv_vperp_vpa_region()
 
     @loop_vperp_vpa ivperp ivpa begin
         for iy ∈ 1:ny
@@ -1424,7 +1426,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                          x, residual_func!, residual0, delta_x, v, w, solver_type::Val,
                          norm_params; coords, rtol, atol, restart, max_restarts,
                          left_preconditioner, right_preconditioner, H, c, s, g, V,
-                         rhs_delta, initial_guess, serial_solve, anyv_region,
+                         rhs_delta, initial_guess, serial_solve, anysv_region,
                          initial_delta_x_is_zero) = begin
     # Solve (approximately?):
     #   J δx = residual0
@@ -1471,9 +1473,9 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
     parallel_map(solver_type, (w,beta) -> w/beta, select_from_V(V, 1), w, beta)
     if serial_solve
         g[1] = beta
-    elseif anyv_region
-        @begin_anyv_region()
-        @anyv_serial_region begin
+    elseif anysv_region
+        @begin_anysv_region()
+        @anysv_serial_region begin
             g[1] = beta
         end
     else
@@ -1508,9 +1510,9 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                 w_dot_Vj = distributed_dot(solver_type, w, v, norm_params...)
                 if serial_solve
                     H[j,i] = w_dot_Vj
-                elseif anyv_region
-                    @begin_anyv_region()
-                    @anyv_serial_region begin
+                elseif anysv_region
+                    @begin_anysv_region()
+                    @anysv_serial_region begin
                         H[j,i] = w_dot_Vj
                     end
                 else
@@ -1524,9 +1526,9 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
             norm_w = distributed_norm(solver_type, w, norm_params...)
             if serial_solve
                 H[i+1,i] = norm_w
-            elseif anyv_region
-                @begin_anyv_region()
-                @anyv_serial_region begin
+            elseif anysv_region
+                @begin_anysv_region()
+                @anysv_serial_region begin
                     H[i+1,i] = norm_w
                 end
             else
@@ -1550,9 +1552,9 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                 H[i+1,i] = 0
                 g[i+1] = -s[i] * g[i]
                 g[i] = c[i] * g[i]
-            elseif anyv_region
-                @begin_anyv_region()
-                @anyv_serial_region begin
+            elseif anysv_region
+                @begin_anysv_region()
+                @anysv_serial_region begin
                     for j ∈ 1:i-1
                         gamma = c[j] * H[j,i] + s[j] * H[j+1,i]
                         H[j+1,i] = -s[j] * H[j,i] + c[j] * H[j+1,i]
@@ -1566,7 +1568,7 @@ MGS-GMRES' in Zou (2023) [https://doi.org/10.1016/j.amc.2023.127869].
                     g[i+1] = -s[i] * g[i]
                     g[i] = c[i] * g[i]
                 end
-                @_anyv_subblock_synchronize()
+                @_anysv_subblock_synchronize()
             else
                 @begin_serial_region()
                 @serial_region begin

--- a/test_scripts/2D_FEM_assembly_test.jl
+++ b/test_scripts/2D_FEM_assembly_test.jl
@@ -251,7 +251,7 @@ end
         end
         rpbd_exact = allocate_rosenbluth_potential_boundary_data(vpa,vperp)
 
-        @begin_s_r_z_anyv_region()
+        @begin_r_z_anysv_region()
 
         # use known test function to provide exact data
         calculate_rosenbluth_potential_boundary_data_exact!(rpbd_exact,
@@ -284,8 +284,8 @@ end
              algebraic_solve_for_d2Gdvperp2=false,calculate_GG=true,calculate_dGdvperp=true,boundary_data_option=boundary_data_option)
         # extract C[Fs,Fs'] result
         # and Rosenbluth potentials for testing
-        @begin_s_r_z_anyv_region()
-        @begin_anyv_vperp_vpa_region()
+        @begin_r_z_anysv_region()
+        @begin_anysv_vperp_vpa_region()
         @loop_vperp_vpa ivperp ivpa begin
             C_M_num[ivpa,ivperp] = fkpl_arrays.CC[ivpa,ivperp]
             G_M_num[ivpa,ivperp] = fkpl_arrays.GG[ivpa,ivperp]

--- a/test_scripts/ImplicitCollisionsTest.jl
+++ b/test_scripts/ImplicitCollisionsTest.jl
@@ -187,7 +187,7 @@ function test_implicit_collisions(; vth0=0.5,vperp0=1.0,vpa0=0.0, ngrid=3,neleme
 
     #println(nl_solver_params.preconditioners)
     for it in 1:ntime
-        @begin_s_r_z_anyv_region()
+        @begin_r_z_anysv_region()
         fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, nuss, fkpl_arrays,
             coords, spectral,
             nl_solver_params,
@@ -416,7 +416,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     Pkg.activate(".")
     
     # test_implicit_collisions(ngrid=3,nelement_vpa=8,nelement_vperp=4,ntime=50,delta_t=1.0,
-    #   serial_solve=false,anyv_region=true,plot_test_output=false,
+    #   serial_solve=false,anysv_region=true,plot_test_output=false,
     #   test_numerical_conserving_terms=true)
     test_implicit_collisions_wrapper(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
     vth0=0.5,vperp0=1.0,vpa0=1.0, nelement_vpa=32,nelement_vperp=16,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",

--- a/test_scripts/fkpl_direct_integration_test.jl
+++ b/test_scripts/fkpl_direct_integration_test.jl
@@ -183,7 +183,7 @@ function test_Lagrange_Rosenbluth_potentials(ngrid,nelement; standalone=true)
     fokkerplanck_arrays = init_fokker_planck_collisions_direct_integration(vperp,vpa; precompute_weights=true)
     fka = fokkerplanck_arrays
 
-    @begin_s_r_z_anyv_region()
+    @begin_r_z_anysv_region()
 
     # calculate the potentials by direct integration
     calculate_rosenbluth_potentials_via_direct_integration!(fka.GG,fka.HH,fka.dHdvpa,fka.dHdvperp,


### PR DESCRIPTION
Anticipate that when calculating multi-species collisions, the collision operators for every species should be calculated together, to be able to re-use parts of the computation. Therefore rather than 'anyv' regions inside an outer loop over species, r, and z, we want to have an outer loop over r and z, containing inner loops over both species and velocity space - call this an 'anysv' region (for any 's'pecies or 'v'elocity).

Resolves #356.