### PR TITLE
Allow launching multiple consecutive runs with `run_moment_kinetics.jl`

### DIFF
--- a/machines/archer/jobscript-restart.template
+++ b/machines/archer/jobscript-restart.template
@@ -22,6 +22,6 @@ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 echo "running INPUTFILE $(date)"
 
-srun --distribution=block:block --hint=nomultithread --ntasks=$SLURM_NTASKS bin/julia -Jmoment_kinetics.so --project -O3 run_moment_kinetics.jl --restart INPUTFILE RESTARTFROM
+srun --distribution=block:block --hint=nomultithread --ntasks=$SLURM_NTASKS bin/julia -Jmoment_kinetics.so --project -O3 run_moment_kinetics.jl --restart RESTARTFROM INPUTFILE
 
 echo "finished INPUTFILE $(date)"

--- a/machines/generic-batch-template/jobscript-restart.template
+++ b/machines/generic-batch-template/jobscript-restart.template
@@ -19,6 +19,6 @@ source julia.env
 echo "running INPUTFILE $(date)"
 
 # May need to change this if mpirun` is not what should be used on your system
-mpirun -np $SLURM_NTASKS bin/julia -Jmoment_kinetics.so --project -O3 run_moment_kinetics.jl --restart INPUTFILE RESTARTFROM
+mpirun -np $SLURM_NTASKS bin/julia -Jmoment_kinetics.so --project -O3 run_moment_kinetics.jl --restart RESTARTFROM INPUTFILE
 
 echo "finished INPUTFILE $(date)"

--- a/machines/marconi/jobscript-restart.template
+++ b/machines/marconi/jobscript-restart.template
@@ -18,6 +18,6 @@ source julia.env
 
 echo "running INPUTFILE $(date)"
 
-mpirun -np $SLURM_NTASKS bin/julia -Jmoment_kinetics.so --project -O3 run_moment_kinetics.jl --restart INPUTFILE RESTARTFROM
+mpirun -np $SLURM_NTASKS bin/julia -Jmoment_kinetics.so --project -O3 run_moment_kinetics.jl --restart RESTARTFROM INPUTFILE
 
 echo "finished INPUTFILE $(date)"

--- a/machines/shared/submit-restart.sh
+++ b/machines/shared/submit-restart.sh
@@ -119,6 +119,9 @@ fi
 
 # Create a submission script for the run
 RESTARTJOBSCRIPT=${RUNDIR}$RUNNAME-restart.job
+if [ x$RESTARTFROM != x ]; then
+  RESTARTFROM="--restartfile $RESTARTFROM"
+fi
 sed -e "s|NODES|$NODES|" -e "s|RUNTIME|$RUNTIME|" -e "s|ACCOUNT|$ACCOUNT|" -e "s|PARTITION|$PARTITION|" -e "s|QOS|$QOS|" -e "s|RUNDIR|$RUNDIR|" -e "s|INPUTFILE|$INPUTFILE|" -e "s|RESTARTFROM|$RESTARTFROM|" machines/$MACHINE/jobscript-restart.template > $RESTARTJOBSCRIPT
 
 if [[ "$WARN_OLD_SYSIMAGE" -eq 0 ]]; then

--- a/moment_kinetics/src/command_line_options.jl
+++ b/moment_kinetics/src/command_line_options.jl
@@ -12,13 +12,16 @@ using ArgParse
 const s = ArgParseSettings()
 @add_arg_table! s begin
     "inputfile"
-        help = "Name of TOML input file."
+        help = "Name of TOML input file(s). If more than one input is given, the input " *
+               "files will be run one after the other. When multiple input files are " *
+               "passed all the runs will restart from the same restart file if one is " *
+               "given."
         arg_type = String
-        default = nothing
-    "restartfile"
+        nargs = '*'
+    "--restartfile"
         help = "Name of output file (HDF5 or NetCDF) to restart from"
         arg_type = String
-        default = nothing
+        nargs = 1
     "--debug", "-d"
         help = "Set debugging level, default is 0 (no extra debugging). Higher " *
                "integer values activate more checks (and increase run time)"
@@ -26,7 +29,7 @@ const s = ArgParseSettings()
         default = 0
     "--restart"
         help = "Restart from latest output file in run directory (ignored if " *
-               "`restartfile` is passed)"
+               "`--restartfile` is passed)"
         action = :store_true
     "--restart-time-index"
         help = "Time index in output file to restart from, defaults to final time point"

--- a/moment_kinetics/src/moment_kinetics.jl
+++ b/moment_kinetics/src/moment_kinetics.jl
@@ -189,13 +189,14 @@ function run_moment_kinetics()
         restart = options["restartfile"]
     end
     restart_time_index = options["restart-time-index"]
-    if inputfile === nothing
-        this_input = OptionsDict()
+    if length(inputfile) == 0
+        this_input = [OptionsDict()]
     else
         this_input = inputfile
     end
-    run_moment_kinetics(this_input; restart=restart,
-                        restart_time_index=restart_time_index)
+    for i ∈ this_input
+        run_moment_kinetics(i; restart=restart, restart_time_index=restart_time_index)
+    end
 end
 
 """


### PR DESCRIPTION
Modifies the handling of command line arguments so that multiple input files can be passed to the `run_moment_kinetics.jl` script, to be run one after the other. The motivation is to avoid some setup/compile time when running MPI runs on a local machine, as it is inconvenient to run MPI runs interactively. I.e. you can now do something like
```bash
mpirun -np 32 bin/julia -O3 --project run_moment_kinetics examples/foo/input1.toml examples/foo/input2.toml examples/foo/input3.toml
```

Changes the syntax for restarting using `run_moment_kinetics.jl` - now the file to restart from has to be passed as the argument of the `--restartfile` flag, rather than as the second positional argument, because now the second positional argument might be another input file.