### PR TITLE
Compilation speedup for makie_post_processing

### DIFF
--- a/makie_post_processing/makie_post_processing/src/chodura_condition.jl
+++ b/makie_post_processing/makie_post_processing/src/chodura_condition.jl
@@ -1,29 +1,29 @@
 using moment_kinetics.analysis: check_Chodura_condition
 
 """
-    Chodura_condition_plots(run_info::Tuple; plot_prefix)
+    Chodura_condition_plots(run_info::Vector{Any}; plot_prefix)
     Chodura_condition_plots(run_info; plot_prefix=nothing, axes=nothing)
 
 Plot the criterion from the Chodura condition at the sheath boundaries.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where line
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where line
 plots from the different runs are overlayed on the same axis, and heatmap plots are
 displayed in a horizontal row.
 
 Settings are read from the `[Chodura_condition]` section of the input.
 
-When `run_info` is a Tuple, `plot_prefix` is required and gives the path and prefix for
+When `run_info` is a Vector, `plot_prefix` is required and gives the path and prefix for
 plots to be saved to. They will be saved with the format
-`plot_prefix<some_identifying_string>.pdf`. When `run_info` is not a Tuple, `plot_prefix`
+`plot_prefix<some_identifying_string>.pdf`. When `run_info` is not a Vector, `plot_prefix`
 is optional - plots will be saved only if it is passed.
 
-When `run_info` is not a Tuple, a Vector of Axis objects can be passed to `axes`, and each
+When `run_info` is not a Vector, a Vector of Axis objects can be passed to `axes`, and each
 plot will be added to one of `axes`.
 """
 function Chodura_condition_plots end
 
-function Chodura_condition_plots(run_info::Tuple; plot_prefix)
+function Chodura_condition_plots(run_info::Vector{Any}; plot_prefix)
     input = Dict_to_NamedTuple(input_dict_dfns["Chodura_condition"])
 
     if !any(v for (k,v) ∈ pairs(input) if startswith(String(k), "plot"))
@@ -48,7 +48,7 @@ function Chodura_condition_plots(run_info::Tuple; plot_prefix)
         end
 
         figs = []
-        axes = Tuple([] for _ ∈ run_info)
+        axes = [[] for _ ∈ run_info]
         if input.plot_vs_t
             fig, ax = get_1d_ax(title="Chodura ratio at z=-L/2", xlabel="time",
                                 ylabel="ratio")

--- a/makie_post_processing/makie_post_processing/src/collisionality.jl
+++ b/makie_post_processing/makie_post_processing/src/collisionality.jl
@@ -7,8 +7,8 @@ comparison of temperature, L_T and dT_dz. They would only be for making sure
 lengthscales and mean free path calculations are sensible.
 """
 function collisionality_plots(run_info, plot_prefix=nothing)
-    if !isa(run_info, Tuple)
-        run_info = (run_info,)
+    if !isa(run_info, AbstractVector)
+        run_info = Any[run_info]
     end
     input = Dict_to_NamedTuple(input_dict["collisionality_plots"])
 

--- a/makie_post_processing/makie_post_processing/src/generic_plot_functions.jl
+++ b/makie_post_processing/makie_post_processing/src/generic_plot_functions.jl
@@ -32,7 +32,7 @@ for dim ∈ one_dimension_combinations
              export $function_name
 
              """
-                 $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
+                 $($function_name_str)(run_info::Vector{Any}, var_name; is=1, data=nothing,
                  $($spaces)input=nothing, outfile=nothing, yscale=nothing,
                  transform=identity, axis_args=Dict{Symbol,Any}(), it=nothing,
                  $($spaces)ir=nothing, iz=nothing, ivperp=nothing, ivpa=nothing,
@@ -47,7 +47,7 @@ for dim ∈ one_dimension_combinations
              Plot `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref)) vs $($dim_str).
 
-             If a Tuple of `run_info` is passed, the plots from each run are overlayed on
+             If a Vector of `run_info` is passed, the plots from each run are overlayed on
              the same axis, and a legend is added.
 
              `it`, `is`, `ir`, `iz`, `ivperp`, `ivpa`, `ivzeta`, `ivr`, and `ivz` can be
@@ -94,14 +94,14 @@ for dim ∈ one_dimension_combinations
              """
              function $function_name end
 
-             function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
+             function $function_name(run_info::Vector{Any}, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, yscale=nothing,
                                      transform=identity, axis_args=Dict{Symbol,Any}(),
                                      $idim=nothing, kwargs...)
 
                  try
                      if data === nothing
-                         data = Tuple(nothing for _ in run_info)
+                         data = [nothing for _ in run_info]
                      end
 
                      if input === nothing
@@ -258,7 +258,7 @@ for (dim1, dim2) ∈ two_dimension_combinations
              export $function_name
 
              """
-                 $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
+                 $($function_name_str)(run_info::Vector{Any}, var_name; is=1, data=nothing,
                  $($spaces)input=nothing, outfile=nothing, colorscale=identity,
                  $($spaces)transform=identity, axis_args=Dict{Symbol,Any}(),
                  $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
@@ -275,7 +275,7 @@ for (dim1, dim2) ∈ two_dimension_combinations
              Plot `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref))vs $($dim1_str) and $($dim2_str).
 
-             If a Tuple of `run_info` is passed, the plots from each run are displayed in
+             If a Vector of `run_info` is passed, the plots from each run are displayed in
              a horizontal row, and the subtitle for each subplot is the 'run name'.
 
              `it`, `is`, `ir`, `iz`, `ivperp`, `ivpa`, `ivzeta`, `ivr`, and `ivz` can be
@@ -322,13 +322,13 @@ for (dim1, dim2) ∈ two_dimension_combinations
              """
              function $function_name end
 
-             function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
+             function $function_name(run_info::Vector{Any}, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, transform=identity,
                                      axis_args=Dict{Symbol,Any}(), kwargs...)
 
                  try
                      if data === nothing
-                         data = Tuple(nothing for _ in run_info)
+                         data = [nothing for _ in run_info]
                      end
                      fig, ax, colorbar_places = get_2d_ax(length(run_info);
                                                           title=get_variable_symbol(var_name),
@@ -459,7 +459,7 @@ for dim ∈ one_dimension_combinations_no_t
              export $function_name
 
              """
-                 $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
+                 $($function_name_str)(run_info::Vector{Any}, var_name; is=1, data=nothing,
                  $($spaces)input=nothing, outfile=nothing, yscale=nothing,
                  $($spaces)transform=identity, ylims=nothing,
                  $($spaces)axis_args=Dict{Symbol,Any}(), it=nothing, ir=nothing, iz=nothing,
@@ -476,7 +476,7 @@ for dim ∈ one_dimension_combinations_no_t
              Animate `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref))vs $($dim_str).
 
-             If a Tuple of `run_info` is passed, the animations from each run are
+             If a Vector of `run_info` is passed, the animations from each run are
              overlayed on the same axis, and a legend is added.
 
              `it`, `is`, `ir`, `iz`, `ivperp`, `ivpa`, `ivzeta`, `ivr`, and `ivz` can be
@@ -527,14 +527,14 @@ for dim ∈ one_dimension_combinations_no_t
              """
              function $function_name end
 
-             function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
+             function $function_name(run_info::Vector{Any}, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, yscale=nothing,
                                      ylims=nothing, axis_args=Dict{Symbol,Any}(),
                                      it=nothing, $idim=nothing, kwargs...)
 
                  try
                      if data === nothing
-                         data = Tuple(nothing for _ in run_info)
+                         data = [nothing for _ in run_info]
                      end
                      if outfile === nothing
                          error("`outfile` is required for $($function_name_str)")
@@ -729,7 +729,7 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
              export $function_name
 
              """
-                 $($function_name_str)(run_info::Tuple, var_name; is=1, data=nothing,
+                 $($function_name_str)(run_info::Vector{Any}, var_name; is=1, data=nothing,
                  $($spaces)input=nothing, outfile=nothing, colorscale=identity,
                  $($spaces)transform=identity, axis_args=Dict{Symbol,Any}(),
                  $($spaces)it=nothing, ir=nothing, iz=nothing, ivperp=nothing,
@@ -747,7 +747,7 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
              Animate `var_name` from the run(s) represented by `run_info` (as returned by
              [`get_run_info`](@ref))vs $($dim1_str) and $($dim2_str).
 
-             If a Tuple of `run_info` is passed, the animations from each run are
+             If a Vector of `run_info` is passed, the animations from each run are
              created in a horizontal row, with each sub-animation having the 'run name' as
              its subtitle.
 
@@ -797,13 +797,13 @@ for (dim1, dim2) ∈ two_dimension_combinations_no_t
              """
              function $function_name end
 
-             function $function_name(run_info::Tuple, var_name; is=1, data=nothing,
+             function $function_name(run_info::Vector{Any}, var_name; is=1, data=nothing,
                                      input=nothing, outfile=nothing, transform=identity,
                                      axis_args=Dict{Symbol,Any}(), it=nothing, kwargs...)
 
                  try
                      if data === nothing
-                         data = Tuple(nothing for _ in run_info)
+                         data = [nothing for _ in run_info]
                      end
                      if outfile === nothing
                          error("`outfile` is required for $($function_name_str)")
@@ -1541,7 +1541,7 @@ This function is only needed for moment-kinetic runs. These are currently only s
 for the 1D1V case.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where plots
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where plots
 from the different runs are overlayed on the same axis.
 
 By default plots the ion distribution function. If `electron=true` is passed, plots the
@@ -1560,7 +1560,7 @@ The data needed will be loaded from file.
 If `outfile` is given, the plot will be saved to a file with that name. The suffix
 determines the file type.
 
-When `run_info` is not a Tuple, an Axis can be passed to `ax` to have the plot added to
+When `run_info` is not a Vector, an Axis can be passed to `ax` to have the plot added to
 `ax`. When `ax` is passed, if `outfile` is passed to save the plot, then the Figure
 containing `ax` must be passed to `fig`.
 
@@ -1578,7 +1578,7 @@ Any extra `kwargs` are passed to [`plot_1d`](@ref).
 """
 function plot_f_unnorm_vs_vpa end
 
-function plot_f_unnorm_vs_vpa(run_info::Tuple; f_over_vpa2=false, electron=false,
+function plot_f_unnorm_vs_vpa(run_info::Vector{Any}; f_over_vpa2=false, electron=false,
                               neutral=false, outfile=nothing,
                               axis_args=Dict{Symbol,Any}(), kwargs...)
     try
@@ -1721,7 +1721,7 @@ This function is only needed for moment-kinetic runs. These are currently only s
 for the 1D1V case.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where plots
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where plots
 from the different runs are displayed in a horizontal row.
 
 By default plots the ion distribution function. If `electron=true` is passed, plots the
@@ -1739,7 +1739,7 @@ The data needed will be loaded from file.
 If `outfile` is given, the plot will be saved to a file with that name. The suffix
 determines the file type.
 
-When `run_info` is not a Tuple, an Axis can be passed to `ax` to have the plot created in
+When `run_info` is not a Vector, an Axis can be passed to `ax` to have the plot created in
 `ax`. When `ax` is passed, if `outfile` is passed to save the plot, then the Figure
 containing `ax` must be passed to `fig`.
 
@@ -1755,7 +1755,7 @@ plots as vectorized plots from `mesh!()` have a very large file size. Pass `fals
 plots vectorized. Pass a number to increase the resolution of the rasterized plot by that
 factor.
 
-When `run_info` is a Tuple, `subtitles` can be passed a Tuple (with the same length as
+When `run_info` is a Vector, `subtitles` can be passed a Vector (with the same length as
 `run_info`) to set the subtitle for each subplot.
 
 `axis_args` are passed as keyword arguments to `get_2d_ax()`, and from there to the `Axis`
@@ -1765,13 +1765,13 @@ Any extra `kwargs` are passed to [`plot_2d`](@ref).
 """
 function plot_f_unnorm_vs_vpa_z end
 
-function plot_f_unnorm_vs_vpa_z(run_info::Tuple; electron=false, neutral=false,
+function plot_f_unnorm_vs_vpa_z(run_info::Vector{Any}; electron=false, neutral=false,
                                 outfile=nothing, axis_args=Dict{Symbol,Any}(),
                                 title=nothing, subtitles=nothing, kwargs...)
     try
         n_runs = length(run_info)
         if subtitles === nothing
-            subtitles = Tuple(nothing for _ ∈ 1:n_runs)
+            subtitles = [nothing for _ ∈ 1:n_runs]
         end
         if title !== nothing
             title = neutral ? L"f_{n,\mathrm{unnormalized}}" : electron ? L"f_{e,\mathrm{unnormalized}}" : L"f_{i,\mathrm{unnormalized}}"
@@ -1892,7 +1892,7 @@ This function is only needed for moment-kinetic runs. These are currently only s
 for the 1D1V case.
 
 The information for the runs to animate is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where plots
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where plots
 from the different runs are overlayed on the same axis.
 
 By default animates the ion distribution function. If `electron=true` is passed, animates
@@ -1913,7 +1913,7 @@ a file named `outfile`.  The suffix determines the file type. If both `outfile` 
 are passed, then the `Figure` containing `ax` must be passed to `fig` to allow the
 animation to be saved.
 
-When `run_info` is not a Tuple, an Axis can be passed to `ax` to have the plot added to
+When `run_info` is not a Vector, an Axis can be passed to `ax` to have the plot added to
 `ax`. When `ax` is passed, if `outfile` is passed to save the plot, then the Figure
 containing `ax` must be passed to `fig`.
 
@@ -1932,7 +1932,7 @@ to handle time-varying coordinates so cannot use [`animate_1d`](@ref)).
 """
 function animate_f_unnorm_vs_vpa end
 
-function animate_f_unnorm_vs_vpa(run_info::Tuple; f_over_vpa2=false, electron=false,
+function animate_f_unnorm_vs_vpa(run_info::Vector{Any}; f_over_vpa2=false, electron=false,
                                  neutral=false, outfile=nothing,
                                  axis_args=Dict{Symbol,Any}(), kwargs...)
     try
@@ -2130,7 +2130,7 @@ This function is only needed for moment-kinetic runs. These are currently only s
 for the 1D1V case.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where plots
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where plots
 from the different runs are displayed in a horizontal row.
 
 By default animates the ion distribution function. If `electron=true` is passed, animates
@@ -2148,7 +2148,7 @@ a file named `outfile`.  The suffix determines the file type. If both `outfile` 
 are passed, then the `Figure` containing `ax` must be passed to `fig` to allow the
 animation to be saved.
 
-When `run_info` is not a Tuple, an Axis can be passed to `ax` to have the animation
+When `run_info` is not a Vector, an Axis can be passed to `ax` to have the animation
 created in `ax`. When `ax` is passed, if `outfile` is passed to save the animation, then
 the Figure containing `ax` must be passed to `fig`.
 
@@ -2167,7 +2167,7 @@ we have to handle time-varying coordinates so cannot use [`animate_2d`](@ref)).
 """
 function animate_f_unnorm_vs_vpa_z end
 
-function animate_f_unnorm_vs_vpa_z(run_info::Tuple; electron=false, neutral=false,
+function animate_f_unnorm_vs_vpa_z(run_info::Vector{Any}; electron=false, neutral=false,
                                    outfile=nothing, axis_args=Dict{Symbol,Any}(),
                                    kwargs...)
     try

--- a/makie_post_processing/makie_post_processing/src/instability2d.jl
+++ b/makie_post_processing/makie_post_processing/src/instability2d.jl
@@ -4,14 +4,14 @@ using moment_kinetics.analysis: get_r_perturbation, get_Fourier_modes_2D,
 using LsqFit
 
 """
-    instability2D_plots(run_info::Tuple, variable_name; plot_prefix, zind=nothing)
+    instability2D_plots(run_info::Vector{Any}, variable_name; plot_prefix, zind=nothing)
     instability2D_plots(run_info, variable_name; plot_prefix, zind=nothing,
                         axes_and_observables=nothing)
 
 Make plots of `variable_name` for analysis of 2D instability.
 
 The information for the runs to analyse and plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, make plots comparing the runs, shown in
+[`get_run_info`](@ref)). If `run_info` is a Vector, make plots comparing the runs, shown in
 a horizontal row..
 
 Settings are read from the `[instability2D]` section of the input.
@@ -20,9 +20,9 @@ Settings are read from the `[instability2D]` section of the input.
 will be saved with the format `plot_prefix<some_identifying_string>.pdf` for plots and
 `plot_prefix<some_identifying_string>.gif`, etc. for animations.
 
-When `run_info` is not a Tuple, `axes_and_observables` can be passed to add plots and
+When `run_info` is not a Vector, `axes_and_observables` can be passed to add plots and
 animations to existing figures, although this is not very convenient - see the use of this
-argument when called from the `run_info::Tuple` method.
+argument when called from the `run_info::Vector{Any}` method.
 
 If `zind` is not passed, it is calculated as the z-index where the mode seems to have
 the maximum growth rate for this variable.
@@ -30,7 +30,8 @@ Returns `zind`.
 """
 function instability2D_plots end
 
-function instability2D_plots(run_info::Tuple, variable_name; plot_prefix, zind=nothing)
+function instability2D_plots(run_info::Vector{Any}, variable_name; plot_prefix,
+                             zind=nothing)
     println("2D instability plots for $variable_name")
     flush(stdout)
 
@@ -39,7 +40,7 @@ function instability2D_plots(run_info::Tuple, variable_name; plot_prefix, zind=n
     instability2D_options = Dict_to_NamedTuple(input_dict["instability2D"])
 
     if zind === nothing
-        zind = Tuple(nothing for _ in 1:n_runs)
+        zind = [nothing for _ in 1:n_runs]
     end
 
     if n_runs == 1
@@ -50,7 +51,7 @@ function instability2D_plots(run_info::Tuple, variable_name; plot_prefix, zind=n
     end
 
     figs = []
-    axes_and_observables = Tuple([] for _ ∈ 1:n_runs)
+    axes_and_observables = [[] for _ ∈ 1:n_runs]
     if instability2D_options.plot_1d
         fig, ax = get_1d_ax(n_runs; title="$var_symbol 1D Fourier components", yscale=log10)
         push!(figs, fig)

--- a/makie_post_processing/makie_post_processing/src/mms.jl
+++ b/makie_post_processing/makie_post_processing/src/mms.jl
@@ -905,7 +905,7 @@ end
 
 """
     manufactured_solutions_analysis(run_info; plot_prefix)
-    manufactured_solutions_analysis(run_info::Tuple; plot_prefix)
+    manufactured_solutions_analysis(run_info::Vector{Any}; plot_prefix)
 
 Compare computed and manufactured solutions for field and moment variables for a 'method
 of manufactured solutions' (MMS) test.
@@ -919,13 +919,13 @@ will be saved with the format `plot_prefix<some_identifying_string>.pdf` for plo
 
 Settings are read from the `[manufactured_solns]` section of the input.
 
-While a Tuple of `run_info` can be passed for compatibility with `makie_post_process()`,
-at present comparison of multiple runs is not supported - passing a Tuple of length
+While a Vector of `run_info` can be passed for compatibility with `makie_post_process()`,
+at present comparison of multiple runs is not supported - passing a Vector of length
 greater than one will result in an error.
 """
 function manufactured_solutions_analysis end
 
-function manufactured_solutions_analysis(run_info::Tuple; plot_prefix, nvperp)
+function manufactured_solutions_analysis(run_info::Vector{Any}; plot_prefix, nvperp)
     if !any(ri !== nothing && ri.manufactured_solns_input.use_for_advance &&
             ri.manufactured_solns_input.use_for_init for ri ∈ run_info)
         # No manufactured solutions tests
@@ -997,7 +997,7 @@ end
 
 """
     manufactured_solutions_analysis_dfns(run_info; plot_prefix)
-    manufactured_solutions_analysis_dfns(run_info::Tuple; plot_prefix)
+    manufactured_solutions_analysis_dfns(run_info::Vector{Any}; plot_prefix)
 
 Compare computed and manufactured solutions for distribution function variables for a
 'method of manufactured solutions' (MMS) test.
@@ -1011,13 +1011,13 @@ will be saved with the format `plot_prefix<some_identifying_string>.pdf` for plo
 
 Settings are read from the `[manufactured_solns]` section of the input.
 
-While a Tuple of `run_info` can be passed for compatibility with `makie_post_process()`,
-at present comparison of multiple runs is not supported - passing a Tuple of length
+While a Vector of `run_info` can be passed for compatibility with `makie_post_process()`,
+at present comparison of multiple runs is not supported - passing a Vector of length
 greater than one will result in an error.
 """
 function manufactured_solutions_analysis_dfns end
 
-function manufactured_solutions_analysis_dfns(run_info::Tuple; plot_prefix)
+function manufactured_solutions_analysis_dfns(run_info::Vector{Any}; plot_prefix)
     if !any(ri !== nothing && ri.manufactured_solns_input.use_for_advance &&
             ri.manufactured_solns_input.use_for_init for ri ∈ run_info)
         # No manufactured solutions tests

--- a/makie_post_processing/makie_post_processing/src/moment_constraints.jl
+++ b/makie_post_processing/makie_post_processing/src/moment_constraints.jl
@@ -7,7 +7,7 @@ Plots to check moment constraints. Comparison plots not currently supported.
 """
 function check_moment_constraints end
 
-function check_moment_constraints(run_info::Tuple, is_neutral; input, plot_prefix)
+function check_moment_constraints(run_info::Vector{Any}, is_neutral; input, plot_prefix)
     if !input.check_moments
         return nothing
     end
@@ -130,8 +130,8 @@ function constraints_plots(run_info; plot_prefix=plot_prefix)
     try
         println("Making plots of moment constraints coefficients")
 
-        if !isa(run_info, Tuple)
-            run_info = (run_info,)
+        if !isa(run_info, AbstractVector)
+            run_info = Any[run_info]
         end
 
         it0 = input.it0

--- a/makie_post_processing/makie_post_processing/src/performance_analysis.jl
+++ b/makie_post_processing/makie_post_processing/src/performance_analysis.jl
@@ -45,7 +45,7 @@ Pass `include_legend=false` to remove legends from the figures. This is mostly u
 interactive figures where hovering over the lines can show what they are, so that the
 legend is not needed.
 """
-function timing_data(run_info::Tuple; plot_prefix=nothing, threshold=nothing,
+function timing_data(run_info::Vector{Any}; plot_prefix=nothing, threshold=nothing,
                      include_patterns=nothing, exclude_patterns=nothing, ranks=nothing,
                      this_input_dict=nothing, figsize=nothing, include_legend=true)
 

--- a/makie_post_processing/makie_post_processing/src/plots_for_variable.jl
+++ b/makie_post_processing/makie_post_processing/src/plots_for_variable.jl
@@ -90,14 +90,6 @@ function plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
             variable_prefix = plot_prefix * variable_name * "_"
             log_variable_prefix = plot_prefix * "log" * variable_name * "_"
         end
-        if variable_name == "Er" && !has_rdim
-            # Skip if there is no r-dimension
-            continue
-        end
-        if variable_name == "Ez" && !has_zdim
-            # Skip if there is no r-dimension
-            continue
-        end
         if has_rdim && input.plot_vs_r_t
             plot_vs_r_t(run_info, variable_name, is=is, data=variable, input=input,
                         outfile=variable_prefix * "vs_r_t.pdf")

--- a/makie_post_processing/makie_post_processing/src/setup_defaults.jl
+++ b/makie_post_processing/makie_post_processing/src/setup_defaults.jl
@@ -67,12 +67,12 @@ function setup_makie_post_processing_input!(new_input_dict::AbstractDict{String,
 
     convert_to_OrderedDicts!(new_input_dict)
 
-    if isa(run_info_moments, Tuple)
+    if isa(run_info_moments, AbstractVector)
         has_moments = any(ri !== nothing for ri ∈ run_info_moments)
     else
         has_moments = run_info_moments !== nothing
     end
-    if isa(run_info_dfns, Tuple)
+    if isa(run_info_dfns, AbstractVector)
         has_dfns = any(ri !== nothing for ri ∈ run_info_dfns)
     else
         has_dfns = run_info_dfns !== nothing
@@ -109,9 +109,9 @@ function _setup_single_input!(this_input_dict::OrderedDict{String,Any},
     # Put entries from new_input_dict into this_input_dict
     merge!(this_input_dict, deepcopy(new_input_dict))
 
-    if !isa(run_info, Tuple)
-        # Make sure run_info is a Tuple
-        run_info= (run_info,)
+    if !isa(run_info, AbstractVector)
+        # Make sure run_info is a Vector
+        run_info= Any[run_info]
     end
     has_run_info = any(ri !== nothing for ri ∈ run_info)
 

--- a/makie_post_processing/makie_post_processing/src/sound_wave.jl
+++ b/makie_post_processing/makie_post_processing/src/sound_wave.jl
@@ -4,31 +4,31 @@ using moment_kinetics.analysis: analyze_fields_data
 using .shared_utils: calculate_and_write_frequencies
 
 """
-    sound_wave_plots(run_info::Tuple; plot_prefix)
+    sound_wave_plots(run_info::Vector{Any}; plot_prefix)
     sound_wave_plots(run_info; outfile=nothing, ax=nothing, phi=nothing)
 
 Calculate decay rate and frequency for the damped 'sound wave' in a 1D1V simulation in a
 periodic box. Plot the mode amplitude vs. time along with the fitted decay rate.
 
 The information for the runs to analyse and plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where line
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where line
 plots from the different runs are overlayed on the same axis.
 
 Settings are read from the `[sound_wave]` section of the input.
 
-When `run_info` is a Tuple, `plot_prefix` is required and gives the path and prefix for
+When `run_info` is a Vector, `plot_prefix` is required and gives the path and prefix for
 plots to be saved to. They will be saved with the format
 `plot_prefix<some_identifying_string>.pdf`.
-When `run_info` is not a Tuple, `outfile` can be passed, to save the plot to `outfile`.
+When `run_info` is not a Vector, `outfile` can be passed, to save the plot to `outfile`.
 
-When `run_info` is not a Tuple, ax can be passed to add the plot to an existing `Axis`.
+When `run_info` is not a Vector, ax can be passed to add the plot to an existing `Axis`.
 
-When `run_info` is not a Tuple, the array containing data for phi can be passed to `phi` -
+When `run_info` is not a Vector, the array containing data for phi can be passed to `phi` -
 by default this data is loaded from the output file.
 """
 function sound_wave_plots end
 
-function sound_wave_plots(run_info::Tuple; plot_prefix)
+function sound_wave_plots(run_info::Vector{Any}; plot_prefix)
     input = Dict_to_NamedTuple(input_dict["sound_wave_fit"])
 
     if !input.calculate_frequency && !input.plot

--- a/makie_post_processing/makie_post_processing/src/steady_state_residual.jl
+++ b/makie_post_processing/makie_post_processing/src/steady_state_residual.jl
@@ -48,32 +48,32 @@ calculate_steady_state_residual(run_info, variable_name; is=1, data=nothing,
 Calculate and plot the 'residuals' for `variable_name`.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where plots
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where plots
 from the different runs are displayed in a horizontal row.
 
 If the variable has a species dimension, `is` selects which species to analyse.
 
 By default the variable will be loaded from file. If the data has already been loaded, it
-can be passed to `data` instead. `data` should be a Tuple of the same length as `run_info`
-if `run_info` is a Tuple.
+can be passed to `data` instead. `data` should be a Vector of the same length as `run_info`
+if `run_info` is a Vector.
 
 If `plot_prefix` is passed, it gives the path and prefix for plots to be saved to. They
 will be saved with the format `plot_prefix<some_identifying_string>.pdf`.
 
 `fig_axes` can be passed an OrderedDict of Tuples as returned by
 [`_get_steady_state_residual_fig_axes`](@ref) - each tuple contains the Figure `fig` and
-Axis or Tuple{Axis} `ax` to which to add the plot corresponding to its key. If `run_info`
-is a Tuple, `ax` for each entry must be a Tuple of the same length.
+Axis or Vector{Axis} `ax` to which to add the plot corresponding to its key. If `run_info`
+is a Vector, `ax` for each entry must be a Vector of the same length.
 """
 function calculate_steady_state_residual end
 
-function calculate_steady_state_residual(run_info::Tuple, variable_name; is=1,
+function calculate_steady_state_residual(run_info::Vector{Any}, variable_name; is=1,
                                          data=nothing, plot_prefix=nothing,
                                          fig_axes=nothing)
     try
         n_runs = length(run_info)
         if data === nothing
-            data = Tuple(nothing for _ ∈ 1:n_runs)
+            data = [nothing for _ ∈ 1:n_runs]
         end
         if fig_axes === nothing
             fig_axes = _get_steady_state_residual_fig_axes(length(run_info))

--- a/makie_post_processing/makie_post_processing/src/timestep_diagnostics.jl
+++ b/makie_post_processing/makie_post_processing/src/timestep_diagnostics.jl
@@ -12,8 +12,8 @@ will be saved with the format `plot_prefix_timestep_diagnostics.pdf`.
 """
 function timestep_diagnostics(run_info, run_info_dfns; plot_prefix=nothing, it=nothing,
                               electron=false)
-    if !isa(run_info, Tuple)
-        run_info = (run_info,)
+    if !isa(run_info, AbstractVector)
+        run_info = Any[run_info]
     end
 
     input = Dict_to_NamedTuple(input_dict["timestep_diagnostics"])

--- a/makie_post_processing/makie_post_processing/src/wall_plots.jl
+++ b/makie_post_processing/makie_post_processing/src/wall_plots.jl
@@ -4,7 +4,7 @@
 Make plots/animations of the ion distribution function at wall boundaries.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where line
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where line
 plots/animations from the different runs are overlayed on the same axis, and heatmap
 plots/animations are displayed in a horizontal row.
 
@@ -12,7 +12,7 @@ Settings are read from the `[wall_pdf]` section of the input.
 
 `plot_prefix` is required and gives the path and prefix for plots to be saved to. They
 will be saved with the format `plot_prefix<some_identifying_string>.pdf`. When `run_info`
-is not a Tuple, `plot_prefix` is optional - plots/animations will be saved only if it is
+is not a Vector, `plot_prefix` is optional - plots/animations will be saved only if it is
 passed.
 
 If `electron=true` is passed, plot electron distribution function instead of ion
@@ -311,7 +311,7 @@ end
 Make plots/animations of the neutral particle distribution function at wall boundaries.
 
 The information for the runs to plot is passed in `run_info` (as returned by
-[`get_run_info`](@ref)). If `run_info` is a Tuple, comparison plots are made where line
+[`get_run_info`](@ref)). If `run_info` is a Vector, comparison plots are made where line
 plots/animations from the different runs are overlayed on the same axis, and heatmap
 plots/animations are displayed in a horizontal row.
 
@@ -319,7 +319,7 @@ Settings are read from the `[wall_pdf_neutral]` section of the input.
 
 `plot_prefix` is required and gives the path and prefix for plots to be saved to. They
 will be saved with the format `plot_prefix<some_identifying_string>.pdf`. When `run_info`
-is not a Tuple, `plot_prefix` is optional - plots/animations will be saved only if it is
+is not a Vector, `plot_prefix` is optional - plots/animations will be saved only if it is
 passed.
 """
 function plot_neutral_pdf_2D_at_wall(run_info; plot_prefix)

--- a/moment_kinetics/src/load_data.jl
+++ b/moment_kinetics/src/load_data.jl
@@ -3438,12 +3438,12 @@ function get_run_info_no_setup(run_dir::Union{AbstractString,Tuple{AbstractStrin
         error("When `electron_debug=true` is passed, `dfns=true` must also be passed")
     end
     if length(run_dir) > 1
-        run_info = Tuple(get_run_info_no_setup(r; itime_min=itime_min,
-                                               itime_max=itime_max, itime_skip=itime_skip,
-                                               dfns=dfns,
-                                               initial_electron=initial_electron,
-                                               electron_debug=electron_debug)
-                         for r ∈ run_dir)
+        run_info = Any[get_run_info_no_setup(r; itime_min=itime_min,
+                                             itime_max=itime_max, itime_skip=itime_skip,
+                                             dfns=dfns,
+                                             initial_electron=initial_electron,
+                                             electron_debug=electron_debug)
+                       for r ∈ run_dir]
         return run_info
     end
 
@@ -4250,8 +4250,8 @@ handles the case where `run_info` is a Tuple (which `postproc_load_data` does no
 """
 function get_variable end
 
-function get_variable(run_info::Tuple, variable_name; kwargs...)
-    return Tuple(get_variable(ri, variable_name; kwargs...) for ri ∈ run_info)
+function get_variable(run_info::Vector{Any}, variable_name; kwargs...)
+    return [get_variable(ri, variable_name; kwargs...) for ri ∈ run_info]
 end
 
 function get_variable(run_info, variable_name; normalize_advection_speed_shape=true,

--- a/test_scripts/check-makie_post_processing.jl
+++ b/test_scripts/check-makie_post_processing.jl
@@ -98,3 +98,7 @@ run_moment_kinetics(test_input)
 example_output_directory = joinpath("runs", test_input["output"]["run_name"])
 
 makie_post_process(example_output_directory; input_file=postproc_input_filename)
+
+# Also check comparing multiple outputs.
+makie_post_process(example_output_directory, example_output_directory; input_file=postproc_input_filename)
+makie_post_process(example_output_directory, example_output_directory, example_output_directory; input_file=postproc_input_filename)


### PR DESCRIPTION
Using a Vector of `run_info` NamedTuples instead of a Tuple of them seems to speed up compilation times and reduce recompilation times when calling `makie_post_process()` for a different number of runs. Compilation time still pretty slow, but maybe ~2x faster with this PR.