### PR TITLE
Post-processing option to plot difference between two or more runs

### DIFF
--- a/makie_post_processing/makie_post_processing/src/chodura_condition.jl
+++ b/makie_post_processing/makie_post_processing/src/chodura_condition.jl
@@ -226,7 +226,6 @@ function Chodura_condition_plots(run_info::Vector{Any}; plot_prefix)
         end
         if input.plot_f_over_vpa2
             fig = figs[7]
-            println("check axes ", axes)
             ax = axes[1][7]
             put_legend_below(fig, ax)
             # Ensure the first row width is 3/4 of the column width so that

--- a/makie_post_processing/makie_post_processing/src/compare_runs.jl
+++ b/makie_post_processing/makie_post_processing/src/compare_runs.jl
@@ -1,0 +1,68 @@
+"""
+    compare_runs(run_info)
+
+Plot/animate the differences between several runs, comparing each run to the first one in
+`run_info`. Where different grids are used for (some of) the runs, all results will be
+interpolated onto the grid of the first run.
+"""
+function compare_runs(run_info, run_info_dfns=run_info; plot_prefix, has_rdim=true,
+                      has_zdim=true, is_1V=false, has_electrons=true, has_neutrals=true,
+                      has_dfns=true)
+    if isa(run_info, NamedTuple)
+        # Single 'run_info' was passed. Nothing to compare.
+        return nothing
+    elseif length(run_info) ≤ 1
+        # Single 'run_info' was passed. Nothing to compare.
+        return nothing
+    end
+
+    input = Dict_to_NamedTuple(input_dict_dfns["compare_runs"])
+
+    if !input.enable
+        return nothing
+    end
+
+    println("Making comparison plots:")
+
+    base_run = run_info[1]
+    other_runs = run_info[2:end]
+
+    difference_plot_prefix = plot_prefix * "difference_"
+    plot_title = "difference from " * base_run.run_name
+
+    for variable_name ∈ all_moment_variables
+        if variable_name ∈ all_source_variables
+            continue
+        end
+        plots_for_variable(other_runs, variable_name; plot_prefix=difference_plot_prefix,
+                           has_rdim=has_rdim, has_zdim=has_zdim, is_1V=is_1V,
+                           subtract_from_info=base_run,
+                           interpolate_to_other_grid=input.interpolate_to_other_grid,
+                           axis_args=(title=plot_title,))
+    end
+
+    # Plots from distribution function variables
+    ############################################
+    if has_dfns
+        base_run_dfns = run_info_dfns[1]
+        other_runs_dfns = run_info_dfns[2:end]
+
+        dfn_variable_list = ion_dfn_variables
+        if has_electrons
+            dfn_variable_list = tuple(dfn_variable_list..., electron_dfn_variables...)
+        end
+        if has_neutrals
+            dfn_variable_list = tuple(dfn_variable_list..., neutral_dfn_variables...)
+        end
+        for variable_name ∈ dfn_variable_list
+            plots_for_dfn_variable(other_runs_dfns, variable_name;
+                                   plot_prefix=difference_plot_prefix, has_rdim=has_rdim,
+                                   has_zdim=has_zdim, is_1V=is_1V,
+                                   subtract_from_info=base_run_dfns,
+                                   interpolate_to_other_grid=input.interpolate_to_other_grid,
+                                   axis_args=(title=plot_title,))
+        end
+    end
+
+    return nothing
+end

--- a/makie_post_processing/makie_post_processing/src/high_level_interface.jl
+++ b/makie_post_processing/makie_post_processing/src/high_level_interface.jl
@@ -239,6 +239,10 @@ function makie_post_process(run_dir::Union{String,Vector{String}},
         end
     end
 
+    compare_runs(run_info, run_info_dfns; has_electrons, has_neutrals,
+                 plot_prefix=plot_prefix, has_rdim=has_rdim, has_zdim=has_zdim,
+                 is_1V=is_1V, has_dfns=has_dfns)
+
     plot_charged_pdf_2D_at_wall(run_info_dfns; plot_prefix=plot_prefix)
     if has_electrons
         plot_charged_pdf_2D_at_wall(run_info_dfns; plot_prefix=plot_prefix, electron=true)

--- a/makie_post_processing/makie_post_processing/src/makie_post_processing.jl
+++ b/makie_post_processing/makie_post_processing/src/makie_post_processing.jl
@@ -25,10 +25,10 @@ using moment_kinetics.looping: all_dimensions, ion_dimensions, neutral_dimension
 using moment_kinetics.load_data: get_variable, timestep_diagnostic_variables,
                                  em_variables, ion_moment_variables,
                                  electron_moment_variables, neutral_moment_variables,
-                                 all_moment_variables, ion_dfn_variables,
-                                 electron_dfn_variables, neutral_dfn_variables,
-                                 all_dfn_variables, ion_variables, neutral_variables,
-                                 all_variables, ion_source_variables,
+                                 all_source_variables, all_moment_variables,
+                                 ion_dfn_variables, electron_dfn_variables,
+                                 neutral_dfn_variables, all_dfn_variables, ion_variables,
+                                 neutral_variables, all_variables, ion_source_variables,
                                  neutral_source_variables, electron_source_variables
 using moment_kinetics.type_definitions
 
@@ -68,6 +68,7 @@ include("generic_plot_functions.jl")
 include("slicing.jl")
 include("error_handler.jl")
 
+include("compare_runs.jl")
 include("moment_constraints.jl")
 include("steady_state_residual.jl")
 include("wall_plots.jl")

--- a/makie_post_processing/makie_post_processing/src/plots_for_variable.jl
+++ b/makie_post_processing/makie_post_processing/src/plots_for_variable.jl
@@ -1,3 +1,6 @@
+using moment_kinetics.array_allocation: allocate_float
+using moment_kinetics.load_data: regrid_variable
+
 """
     plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
                        has_zdim=true, is_1V=false,
@@ -25,6 +28,7 @@ state residual plots.
 function plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
                             has_zdim=true, is_1V=false,
                             steady_state_residual_fig_axes=nothing,
+                            subtract_from_info=nothing, interpolate_to_other_grid=false,
                             kwargs...)
     input = Dict_to_NamedTuple(input_dict[variable_name])
 
@@ -64,6 +68,45 @@ function plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
             return makie_post_processing_error_handler(
                        e,
                        "plots_for_variable() failed for $variable_name - could not load data.")
+        end
+    end
+    if subtract_from_info !== nothing
+        subtract_from = nothing
+        try
+            subtract_from = get_variable(subtract_from_info, variable_name)
+
+        catch e
+            if isa(e, KeyError)
+                println("Key $(e.key) not found when loading $variable_name to subtract "
+                        * "- probably not present in output")
+                return nothing
+            else
+                return makie_post_processing_error_handler(
+                           e,
+                           "plots_for_variable() failed when loading $variable_name to subtract.")
+            end
+        end
+        # Here we can pass 'run_info' objects as the 'moments' argument of
+        # regrid_time_evolving because they contain the necessary
+        # `evolve_density`/`evolve_upar`/`evolve_p` flags.
+        if interpolate_to_other_grid
+            variable = [v .- regrid_time_evolving(subtract_from, _run_info_to_coords(ri),
+                                                  _run_info_to_coords(subtract_from_info),
+                                                  ri, subtract_from_info.evolve_density,
+                                                  subtract_from_info.evolve_upar,
+                                                  subtract_from_info.evolve_p)
+                        for (ri, v) ∈ zip(run_info, variable)]
+        else
+            variable = [regrid_time_evolving(v, _run_info_to_coords(subtract_from_info),
+                                             _run_info_to_coords(ri), subtract_from_info,
+                                             ri.evolve_density, ri.evolve_upar,
+                                             ri.evolve_p) .- subtract_from
+                        for (ri, v) ∈ zip(run_info, variable)]
+
+            # Override run_info so that we plot against the coordinates from
+            # `subtract_from_info` for all plots.
+            run_info = Any[(_run_info_to_coords(subtract_from_info)...,
+                            run_name=ri.run_name) for ri ∈ run_info]
         end
     end
 
@@ -161,7 +204,8 @@ plots that do not make sense for 0D/1D or 1V simulations (regardless of the sett
 and `animate_*_unnorm_vs_*()`.
 """
 function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=true,
-                                has_zdim=true, is_1V=false, kwargs...)
+                                has_zdim=true, is_1V=false, subtract_from_info=nothing,
+                                interpolate_to_other_grid=false, kwargs...)
     input = Dict_to_NamedTuple(input_dict_dfns[variable_name])
 
     is_neutral = variable_name ∈ neutral_dfn_variables
@@ -204,6 +248,113 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
     else
         species_indices = 1:maximum(ri.n_ion_species for ri ∈ run_info)
     end
+
+    variable = nothing
+    if subtract_from_info !== nothing
+        # When using subtract_from_info, it is generally necessary to interpolate,
+        # which requires the full array to be loaded. For animations, it would be
+        # possible to load the arrays one time point at a time, but it is not
+        # convenient to do this with the current setup of `generic_plot_functions.jl`,
+        # so we leave that as a future optimisation.
+        subtract_from = nothing
+        try
+            variable = get_variable(run_info, variable_name)
+            subtract_from = get_variable(subtract_from_info, variable_name)
+        catch e
+            if isa(e, KeyError)
+                println("Key $(e.key) not found when loading $variable_name - probably not "
+                        * "present in output")
+                return nothing
+            else
+                return makie_post_processing_error_handler(
+                           e,
+                           "plots_for_dfn_variable() failed for $variable_name - could not load data.")
+            end
+        end
+        # Here we can pass 'run_info' objects as the 'moments' argument of
+        # regrid_time_evolving because they contain the necessary
+        # `evolve_density`/`evolve_upar`/`evolve_p` flags.
+        if interpolate_to_other_grid
+            if variable_name == "f"
+                moments = ((evolve_density=ri.evolve_density,
+                            evolve_upar=ri.evolve_upar,
+                            evolve_p=ri.evolve_p,
+                            ion=(dens=get_variable(ri, "density"),
+                                 upar=get_variable(ri, "parallel_flow"),
+                                 vth=get_variable(ri, "thermal_speed"),
+                                )
+                           ) for ri ∈ run_info)
+            elseif variable_name == "f_electron"
+                moments = ((evolve_density=ri.evolve_density,
+                            evolve_upar=ri.evolve_upar,
+                            evolve_p=ri.evolve_p,
+                            electron=(dens=get_variable(ri, "electron_density"),
+                                      upar=get_variable(ri, "electron_parallel_flow"),
+                                      vth=get_variable(ri, "electron_thermal_speed"),
+                                     )
+                           ) for ri ∈ run_info)
+            elseif variable_name == "f_neutral"
+                moments = ((evolve_density=ri.evolve_density,
+                            evolve_upar=ri.evolve_upar,
+                            evolve_p=ri.evolve_p,
+                            neutral=(dens=get_variable(ri, "density_neutral"),
+                                     uz=get_variable(ri, "uz_neutral"),
+                                     vth=get_variable(ri, "thermal_speed_neutral"),
+                                    )
+                           ) for ri ∈ run_info)
+            else
+                error("Unsupported variable '$variable_name'")
+            end
+            variable = [v .- regrid_time_evolving(subtract_from, _run_info_to_coords(ri),
+                                                  _run_info_to_coords(subtract_from_info),
+                                                  m, subtract_from_info.evolve_density,
+                                                  subtract_from_info.evolve_upar,
+                                                  subtract_from_info.evolve_p)
+                        for (ri, v, m) ∈ zip(run_info, variable, moments)]
+        else
+            if variable_name == "f"
+                moments = (evolve_density=subtract_from_info.evolve_density,
+                           evolve_upar=subtract_from_info.evolve_upar,
+                           evolve_p=subtract_from_info.evolve_p,
+                           ion=(dens=get_variable(subtract_from_info, "density"),
+                                upar=get_variable(subtract_from_info, "parallel_flow"),
+                                vth=get_variable(subtract_from_info, "thermal_speed"),
+                               )
+                          )
+            elseif variable_name == "f_electron"
+                moments = (evolve_density=subtract_from_info.evolve_density,
+                           evolve_upar=subtract_from_info.evolve_upar,
+                           evolve_p=subtract_from_info.evolve_p,
+                           electron=(dens=get_variable(subtract_from_info, "electron_density"),
+                                     upar=get_variable(subtract_from_info, "electron_parallel_flow"),
+                                     vth=get_variable(subtract_from_info, "electron_thermal_speed"),
+                                    )
+                          )
+            elseif variable_name == "f_neutral"
+                moments = (evolve_density=subtract_from_info.evolve_density,
+                           evolve_upar=subtract_from_info.evolve_upar,
+                           evolve_p=subtract_from_info.evolve_p,
+                           neutral=(dens=get_variable(subtract_from_info, "density_neutral"),
+                                    uz=get_variable(subtract_from_info, "uz_neutral"),
+                                    vth=get_variable(subtract_from_info, "thermal_speed_neutral"),
+                                   )
+                          )
+            else
+                error("Unsupported variable '$variable_name'")
+            end
+            variable = [regrid_time_evolving(v, _run_info_to_coords(subtract_from_info),
+                                             _run_info_to_coords(ri), moments,
+                                             ri.evolve_density, ri.evolve_upar,
+                                             ri.evolve_p) .- subtract_from
+                        for (ri, v) ∈ zip(run_info, variable)]
+
+            # Override run_info so that we plot against the coordinates from
+            # `subtract_from_info` for all plots.
+            run_info = Any[(_run_info_to_coords(subtract_from_info)...,
+                            run_name=ri.run_name) for ri ∈ run_info]
+        end
+    end
+
     for is ∈ species_indices
         variable_prefix = plot_prefix * variable_name * "_"
         log_variable_prefix = plot_prefix * "log" * variable_name * "_"
@@ -223,8 +374,8 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                 if input[Symbol(:plot, log, :_vs_, dim)]
                     func = getfield(makie_post_processing, Symbol(:plot_vs_, dim))
                     outfile = var_prefix * "vs_$dim.pdf"
-                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
-                         yscale=yscale, transform=transform, kwargs...)
+                    func(run_info, variable_name; data=variable, is=is, input=input,
+                         outfile=outfile, yscale=yscale, transform=transform, kwargs...)
                 end
             end
             for (dim1, dim2) ∈ combinations(plot_dims, 2)
@@ -232,8 +383,8 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                     func = getfield(makie_post_processing,
                                     Symbol(:plot_vs_, dim2, :_, dim1))
                     outfile = var_prefix * "vs_$(dim2)_$(dim1).pdf"
-                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
-                         colorscale=yscale, transform=transform,
+                    func(run_info, variable_name; data=variable, is=is, input=input,
+                         outfile=outfile, colorscale=yscale, transform=transform,
                          kwargs...)
                 end
             end
@@ -241,8 +392,8 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                 if input[Symbol(:animate, log, :_vs_, dim)]
                     func = getfield(makie_post_processing, Symbol(:animate_vs_, dim))
                     outfile = var_prefix * "vs_$dim." * input.animation_ext
-                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
-                         yscale=yscale, transform=transform, kwargs...)
+                    func(run_info, variable_name; data=variable, is=is, input=input,
+                         outfile=outfile, yscale=yscale, transform=transform, kwargs...)
                 end
             end
             for (dim1, dim2) ∈ combinations(animate_dims, 2)
@@ -250,18 +401,22 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                     func = getfield(makie_post_processing,
                                     Symbol(:animate_vs_, dim2, :_, dim1))
                     outfile = var_prefix * "vs_$(dim2)_$(dim1)." * input.animation_ext
-                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
-                         colorscale=yscale, transform=transform,
+                    func(run_info, variable_name; data=variable, is=is, input=input,
+                         outfile=outfile, colorscale=yscale, transform=transform,
                          kwargs...)
                 end
             end
 
-            if moment_kinetic
+            # At present, plot_f_unnorm_vs_*() and animate_f_unnorm_vs_*() do not support
+            # passing in a `data` array, so we cannot make these plots when using
+            # `subtract_from_info`.
+            if moment_kinetic && subtract_from_info === nothing
                 if is_neutral
                     if input[Symbol(:plot, log, :_unnorm_vs_vz)]
                         outfile = var_prefix * "unnorm_vs_vz.pdf"
                         plot_f_unnorm_vs_vpa(run_info; input=input, neutral=true, is=is,
-                                             outfile=outfile, yscale=yscale, transform=transform, kwargs...)
+                                             outfile=outfile, yscale=yscale,
+                                             transform=transform, kwargs...)
                     end
                     if has_zdim && input[Symbol(:plot, log, :_unnorm_vs_vz_z)]
                         outfile = var_prefix * "unnorm_vs_vz_z.pdf"
@@ -271,15 +426,15 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                     end
                     if input[Symbol(:animate, log, :_unnorm_vs_vz)]
                         outfile = var_prefix * "unnorm_vs_vz." * input.animation_ext
-                        animate_f_unnorm_vs_vpa(run_info; input=input, neutral=true, is=is,
-                                                outfile=outfile, yscale=yscale,
+                        animate_f_unnorm_vs_vpa(run_info; input=input, neutral=true,
+                                                is=is, outfile=outfile, yscale=yscale,
                                                 transform=transform, kwargs...)
                     end
                     if has_zdim && input[Symbol(:animate, log, :_unnorm_vs_vz_z)]
                         outfile = var_prefix * "unnorm_vs_vz_z." * input.animation_ext
-                        animate_f_unnorm_vs_vpa_z(run_info; input=input, neutral=true, is=is,
-                                                  outfile=outfile, colorscale=yscale,
-                                                  transform=transform,
+                        animate_f_unnorm_vs_vpa_z(run_info; input=input, neutral=true,
+                                                  is=is, outfile=outfile,
+                                                  colorscale=yscale, transform=transform,
                                                   kwargs...)
                     end
                 else
@@ -311,10 +466,43 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                                                   transform=transform, kwargs...)
                     end
                 end
-                check_moment_constraints(run_info, is_neutral; input=input, plot_prefix)
+                if subtract_from_info === nothing
+                    check_moment_constraints(run_info, is_neutral; input=input, plot_prefix)
+                end
             end
         end
     end
 
     return nothing
+end
+
+function _run_info_to_coords(ri)
+    return (n_ion_species=ri.n_ion_species, n_neutral_species=ri.n_neutral_species,
+            time=ri.time, r=ri.r, r_spectral=ri.r_spectral, z=ri.z,
+            z_spectral=ri.z_spectral, vperp=ri.vperp, vperp_spectral=ri.vperp_spectral,
+            vpa=ri.vpa, vpa_spectral=ri.vpa_spectral, vzeta=ri.vzeta,
+            vzeta_spectral=ri.vzeta_spectral, vr=ri.vr, vr_spectral=ri.vr_spectral,
+            vz=ri.vz, vz_spectral=ri.vz_spectral)
+end
+
+function regrid_time_evolving(variable, new_coords, old_coords, moments,
+                              old_evolve_density, old_evolve_upar, old_evolve_p)
+    tdim = ndims(variable)
+    nt = size(variable, tdim)
+
+    first_regridded = regrid_variable(selectdim(variable, tdim, 1), new_coords,
+                                      old_coords, moments, old_evolve_density,
+                                      old_evolve_upar, old_evolve_p)
+
+    result = allocate_float(size(first_regridded)..., nt)
+    selectdim(result, tdim, 1) .= first_regridded
+
+    for it ∈ 2:nt
+        selectdim(result, tdim, it) .= regrid_variable(selectdim(variable, tdim, it),
+                                                       new_coords, old_coords, moments,
+                                                       old_evolve_density,
+                                                       old_evolve_upar, old_evolve_p)
+    end
+
+    return result
 end

--- a/makie_post_processing/makie_post_processing/src/plots_for_variable.jl
+++ b/makie_post_processing/makie_post_processing/src/plots_for_variable.jl
@@ -1,7 +1,7 @@
 """
     plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
                        has_zdim=true, is_1V=false,
-                       steady_state_residual_fig_axes=nothing)
+                       steady_state_residual_fig_axes=nothing, kwargs...)
 
 Make plots for the EM field or moment variable `variable_name`.
 
@@ -19,10 +19,13 @@ plots that do not make sense for 0D/1D or 1V simulations (regardless of the sett
 
 `steady_state_residual_fig_axes` contains the figure, axes and legend places for steady
 state residual plots.
+
+`kwargs...` are passed through to `plot_vs_*()` and `animate_vs_*()`.
 """
 function plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
                             has_zdim=true, is_1V=false,
-                            steady_state_residual_fig_axes=nothing)
+                            steady_state_residual_fig_axes=nothing,
+                            kwargs...)
     input = Dict_to_NamedTuple(input_dict[variable_name])
 
     # test if any plot is needed
@@ -91,36 +94,39 @@ function plots_for_variable(run_info, variable_name; plot_prefix, has_rdim=true,
             log_variable_prefix = plot_prefix * "log" * variable_name * "_"
         end
         if has_rdim && input.plot_vs_r_t
-            plot_vs_r_t(run_info, variable_name, is=is, data=variable, input=input,
-                        outfile=variable_prefix * "vs_r_t.pdf")
+            plot_vs_r_t(run_info, variable_name; is=is, data=variable, input=input,
+                        outfile=variable_prefix * "vs_r_t.pdf", kwargs...)
         end
         if has_zdim && input.plot_vs_z_t
-            plot_vs_z_t(run_info, variable_name, is=is, data=variable, input=input,
-                        outfile=variable_prefix * "vs_z_t.pdf")
+            plot_vs_z_t(run_info, variable_name; is=is, data=variable, input=input,
+                        outfile=variable_prefix * "vs_z_t.pdf", kwargs...)
         end
         if has_rdim && input.plot_vs_r
-            plot_vs_r(run_info, variable_name, is=is, data=variable, input=input,
-                      outfile=variable_prefix * "vs_r.pdf")
+            plot_vs_r(run_info, variable_name; is=is, data=variable, input=input,
+                      outfile=variable_prefix * "vs_r.pdf", kwargs...)
         end
         if has_zdim && input.plot_vs_z
-            plot_vs_z(run_info, variable_name, is=is, data=variable, input=input,
-                      outfile=variable_prefix * "vs_z.pdf")
+            plot_vs_z(run_info, variable_name; is=is, data=variable, input=input,
+                      outfile=variable_prefix * "vs_z.pdf", kwargs...)
         end
         if has_rdim && has_zdim && input.plot_vs_z_r
-            plot_vs_z_r(run_info, variable_name, is=is, data=variable, input=input,
-                        outfile=variable_prefix * "vs_z_r.pdf")
+            plot_vs_z_r(run_info, variable_name; is=is, data=variable, input=input,
+                        outfile=variable_prefix * "vs_z_r.pdf", kwargs...)
         end
         if has_zdim && input.animate_vs_z
-            animate_vs_z(run_info, variable_name, is=is, data=variable, input=input,
-                         outfile=variable_prefix * "vs_z." * input.animation_ext)
+            animate_vs_z(run_info, variable_name; is=is, data=variable, input=input,
+                         outfile=variable_prefix * "vs_z." * input.animation_ext,
+                         kwargs...)
         end
         if has_rdim && input.animate_vs_r
-            animate_vs_r(run_info, variable_name, is=is, data=variable, input=input,
-                         outfile=variable_prefix * "vs_r." * input.animation_ext)
+            animate_vs_r(run_info, variable_name; is=is, data=variable, input=input,
+                         outfile=variable_prefix * "vs_r." * input.animation_ext,
+                         kwargs...)
         end
         if has_rdim && has_zdim && input.animate_vs_z_r
-            animate_vs_z_r(run_info, variable_name, is=is, data=variable, input=input,
-                           outfile=variable_prefix * "vs_r." * input.animation_ext)
+            animate_vs_z_r(run_info, variable_name; is=is, data=variable, input=input,
+                           outfile=variable_prefix * "vs_r." * input.animation_ext,
+                           kwargs...)
         end
         if input.steady_state_residual
             calculate_steady_state_residual(run_info, variable_name; is=is, data=variable,
@@ -133,7 +139,7 @@ end
 
 """
     plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=true,
-                           has_zdim=true, is_1V=false)
+                           has_zdim=true, is_1V=false, kwargs...)
 
 Make plots for the distribution function variable `variable_name`.
 
@@ -150,9 +156,12 @@ will be saved with the format `plot_prefix<some_identifying_string>.pdf` for plo
 
 `has_rdim`, `has_zdim` and/or `is_1V` can be passed to allow the function to skip some
 plots that do not make sense for 0D/1D or 1V simulations (regardless of the settings).
+
+`kwargs...` are passed through to `plot_vs_*()`, `plot_*_unnorm_vs_*()`, `animate_vs_*()`,
+and `animate_*_unnorm_vs_*()`.
 """
 function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=true,
-                                has_zdim=true, is_1V=false)
+                                has_zdim=true, is_1V=false, kwargs...)
     input = Dict_to_NamedTuple(input_dict_dfns[variable_name])
 
     is_neutral = variable_name ∈ neutral_dfn_variables
@@ -214,8 +223,8 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                 if input[Symbol(:plot, log, :_vs_, dim)]
                     func = getfield(makie_post_processing, Symbol(:plot_vs_, dim))
                     outfile = var_prefix * "vs_$dim.pdf"
-                    func(run_info, variable_name, is=is, input=input, outfile=outfile,
-                         yscale=yscale, transform=transform)
+                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
+                         yscale=yscale, transform=transform, kwargs...)
                 end
             end
             for (dim1, dim2) ∈ combinations(plot_dims, 2)
@@ -223,16 +232,17 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                     func = getfield(makie_post_processing,
                                     Symbol(:plot_vs_, dim2, :_, dim1))
                     outfile = var_prefix * "vs_$(dim2)_$(dim1).pdf"
-                    func(run_info, variable_name, is=is, input=input, outfile=outfile,
-                         colorscale=yscale, transform=transform)
+                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
+                         colorscale=yscale, transform=transform,
+                         kwargs...)
                 end
             end
             for dim ∈ animate_dims
                 if input[Symbol(:animate, log, :_vs_, dim)]
                     func = getfield(makie_post_processing, Symbol(:animate_vs_, dim))
                     outfile = var_prefix * "vs_$dim." * input.animation_ext
-                    func(run_info, variable_name, is=is, input=input, outfile=outfile,
-                         yscale=yscale, transform=transform)
+                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
+                         yscale=yscale, transform=transform, kwargs...)
                 end
             end
             for (dim1, dim2) ∈ combinations(animate_dims, 2)
@@ -240,8 +250,9 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                     func = getfield(makie_post_processing,
                                     Symbol(:animate_vs_, dim2, :_, dim1))
                     outfile = var_prefix * "vs_$(dim2)_$(dim1)." * input.animation_ext
-                    func(run_info, variable_name, is=is, input=input, outfile=outfile,
-                         colorscale=yscale, transform=transform)
+                    func(run_info, variable_name; is=is, input=input, outfile=outfile,
+                         colorscale=yscale, transform=transform,
+                         kwargs...)
                 end
             end
 
@@ -250,53 +261,54 @@ function plots_for_dfn_variable(run_info, variable_name; plot_prefix, has_rdim=t
                     if input[Symbol(:plot, log, :_unnorm_vs_vz)]
                         outfile = var_prefix * "unnorm_vs_vz.pdf"
                         plot_f_unnorm_vs_vpa(run_info; input=input, neutral=true, is=is,
-                                             outfile=outfile, yscale=yscale, transform=transform)
+                                             outfile=outfile, yscale=yscale, transform=transform, kwargs...)
                     end
                     if has_zdim && input[Symbol(:plot, log, :_unnorm_vs_vz_z)]
                         outfile = var_prefix * "unnorm_vs_vz_z.pdf"
                         plot_f_unnorm_vs_vpa_z(run_info; input=input, neutral=true, is=is,
                                                outfile=outfile, colorscale=yscale,
-                                               transform=transform)
+                                               transform=transform, kwargs...)
                     end
                     if input[Symbol(:animate, log, :_unnorm_vs_vz)]
                         outfile = var_prefix * "unnorm_vs_vz." * input.animation_ext
                         animate_f_unnorm_vs_vpa(run_info; input=input, neutral=true, is=is,
                                                 outfile=outfile, yscale=yscale,
-                                                transform=transform)
+                                                transform=transform, kwargs...)
                     end
                     if has_zdim && input[Symbol(:animate, log, :_unnorm_vs_vz_z)]
                         outfile = var_prefix * "unnorm_vs_vz_z." * input.animation_ext
                         animate_f_unnorm_vs_vpa_z(run_info; input=input, neutral=true, is=is,
                                                   outfile=outfile, colorscale=yscale,
-                                                  transform=transform)
+                                                  transform=transform,
+                                                  kwargs...)
                     end
                 else
                     if input[Symbol(:plot, log, :_unnorm_vs_vpa)]
                         outfile = var_prefix * "unnorm_vs_vpa.pdf"
                         plot_f_unnorm_vs_vpa(run_info; input=input, electron=is_electron,
                                              is=is, outfile=outfile, yscale=yscale,
-                                             transform=transform)
+                                             transform=transform, kwargs...)
                     end
                     if has_zdim && input[Symbol(:plot, log, :_unnorm_vs_vpa_z)]
                         outfile = var_prefix * "unnorm_vs_vpa_z.pdf"
                         plot_f_unnorm_vs_vpa_z(run_info; input=input,
                                                electron=is_electron, is=is,
                                                outfile=outfile, colorscale=yscale,
-                                               transform=transform)
+                                               transform=transform, kwargs...)
                     end
                     if input[Symbol(:animate, log, :_unnorm_vs_vpa)]
                         outfile = var_prefix * "unnorm_vs_vpa." * input.animation_ext
                         animate_f_unnorm_vs_vpa(run_info; input=input,
                                                 electron=is_electron, is=is,
                                                 outfile=outfile, yscale=yscale,
-                                                transform=transform)
+                                                transform=transform, kwargs...)
                     end
                     if has_zdim && input[Symbol(:animate, log, :_unnorm_vs_vpa_z)]
                         outfile = var_prefix * "unnorm_vs_vpa_z." * input.animation_ext
                         animate_f_unnorm_vs_vpa_z(run_info; input=input,
                                                   electron=is_electron, is=is,
                                                   outfile=outfile, colorscale=yscale,
-                                                  transform=transform)
+                                                  transform=transform, kwargs...)
                     end
                 end
                 check_moment_constraints(run_info, is_neutral; input=input, plot_prefix)

--- a/makie_post_processing/makie_post_processing/src/setup_defaults.jl
+++ b/makie_post_processing/makie_post_processing/src/setup_defaults.jl
@@ -280,6 +280,12 @@ function _setup_single_input!(this_input_dict::OrderedDict{String,Any},
     end
 
     set_defaults_and_check_section!(
+        this_input_dict, "compare_runs", warn_unexpected;
+        enable=false,
+        interpolate_to_other_grid=false,
+       )
+
+    set_defaults_and_check_section!(
         this_input_dict, "wall_pdf", warn_unexpected;
         plot=false,
         animate=false,

--- a/moment_kinetics/src/load_data.jl
+++ b/moment_kinetics/src/load_data.jl
@@ -85,14 +85,22 @@ const neutral_moment_gradient_variables = ("neutral_ddens_dz", "neutral_ddens_dz
                                            "neutral_dp_dz", "neutral_dp_dz_upwind",
                                            "neutral_dpz_dz", "neutral_dvth_dz",
                                            "neutral_dT_dz", "neutral_dqz_dz")
-const ion_source_variables = ("external_source_amplitude", "external_source_density_amplitude",
-                                "external_source_momentum_amplitude", "external_source_pressure_amplitude",
-                                "external_source_controller_integral")
-const neutral_source_variables = ("external_source_neutral_amplitude", "external_source_neutral_density_amplitude",
-                                "external_source_neutral_momentum_amplitude", "external_source_neutral_pressure_amplitude",
-                                "external_source_neutral_controller_integral")
-const electron_source_variables = ("external_source_electron_amplitude", "external_source_electron_density_amplitude",
-                                "external_source_electron_momentum_amplitude", "external_source_electron_pressure_amplitude")
+const ion_source_variables = ("external_source_amplitude",
+                              "external_source_density_amplitude",
+                              "external_source_momentum_amplitude",
+                              "external_source_pressure_amplitude",
+                              "external_source_controller_integral")
+const neutral_source_variables = ("external_source_neutral_amplitude",
+                                  "external_source_neutral_density_amplitude",
+                                  "external_source_neutral_momentum_amplitude",
+                                  "external_source_neutral_pressure_amplitude",
+                                  "external_source_neutral_controller_integral")
+const electron_source_variables = ("external_source_electron_amplitude",
+                                   "external_source_electron_density_amplitude",
+                                   "external_source_electron_momentum_amplitude",
+                                   "external_source_electron_pressure_amplitude")
+const all_source_variables = tuple(ion_source_variables..., electron_source_variables...,
+                                   neutral_source_variables...)
 const all_moment_variables = tuple(em_variables..., ion_moment_variables...,
                                    electron_moment_variables...,
                                    neutral_moment_variables...,

--- a/moment_kinetics/test/recycling_fraction_tests.jl
+++ b/moment_kinetics/test/recycling_fraction_tests.jl
@@ -120,6 +120,11 @@ test_input_split3["timestepping"] = recursive_merge(test_input_split3["timestepp
                                                     OptionsDict("dt" => 7.0710678118654756e-6,
                                                                 "write_error_diagnostics" => true,
                                                                 "write_steady_state_diagnostics" => true))
+if global_size[] > 2 && global_size[] % 2 == 0
+    # Test using distributed-memory
+    test_input_split3["z"]["nelement_local"] = test_input_split3["z"]["nelement"] ÷ 2
+end
+
 
 # default inputs for adaptive timestepping tests
 test_input_adaptive = recursive_merge(test_input,
@@ -147,6 +152,10 @@ test_input_adaptive["timestepping"] = recursive_merge(test_input_adaptive["times
                                                                   "nwrite" => 1000,
                                                                   "split_operators" => false),
                                                      )
+if global_size[] > 2 && global_size[] % 2 == 0
+    # Test using distributed-memory
+    test_input_adaptive["z"]["nelement_local"] = test_input_adaptive["z"]["nelement"] ÷ 2
+end
 
 test_input_adaptive_split1 = recursive_merge(test_input_adaptive,
                                              OptionsDict("output" => OptionsDict("run_name" => "adaptive split1"),


### PR DESCRIPTION
The runs may be on different grids, and several different runs may be compared to a given 'base' run.

To provide the interpolation between different grids, updated `load_data` to: simplify arguments to 'reload' functions by packing ranges and coordinates into NamedTuples; split interpolation out from 'reload' functions into 'regrid' functions that can then be reused in post-processing.