### PR TITLE
Revert removal of NCDatasets from CI, accidentally merged in #383

### DIFF
--- a/moment_kinetics/Project.toml
+++ b/moment_kinetics/Project.toml
@@ -59,5 +59,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-#test = ["Random", "Test", "NCDatasets"]
-test = ["Random", "Test"]
+test = ["Random", "Test", "NCDatasets"]


### PR DESCRIPTION
This came from #327 originally, which turned out not to be needed.