### PR TITLE
Moment kinetic Fokker Planck collisions

### DIFF
--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -3906,8 +3906,9 @@ implementation), a call needs to be made with `dt` scaled by some coefficient.
             update_entropy_diagnostic = (istage == 1)
             if collisions.fkpl.self_collisions
                 # self collisions for each species
-                explicit_fokker_planck_collisions_weak_form!(fvec_out.pdf,fvec_in.pdf,moments.ion.dSdt,composition,
-                                    collisions,dt,fp_arrays,r,z,vperp,vpa,vperp_spectral,vpa_spectral,scratch_dummy,
+                explicit_fokker_planck_collisions_weak_form!(fvec_out.pdf,fvec_in.pdf,moments.ion.dSdt,
+                                    fvec_in.density,moments.ion.vth,moments.evolve_p,moments.evolve_density,
+                                    composition,collisions,dt,fp_arrays,r,z,vperp,vpa,vperp_spectral,vpa_spectral,scratch_dummy,
                                                         diagnose_entropy_production = update_entropy_diagnostic)
                 write_debug_IO("explicit_fokker_planck_collisions_weak_form!")
             end
@@ -4051,9 +4052,10 @@ end
     elseif t_params.kinetic_ion_solver == implicit_ion_fp_collisions
         # backward Euler advance d F / d t = C[F, F]
         ion_success = implicit_ion_fokker_planck_self_collisions!(fvec_out.pdf, fvec_in.pdf, moments.ion.dSdt, 
-        composition, collisions, fp_arrays, 
-        vpa, vperp, z, r, dt, spectral_objects,
-        nl_solver_params.ion_fp_collisions; diagnose_entropy_production=true)
+                                fvec_in.density,moments.ion.vth,moments.evolve_p,moments.evolve_density,
+                                composition, collisions, fp_arrays,
+                                vpa, vperp, z, r, dt, spectral_objects,
+                                nl_solver_params.ion_fp_collisions; diagnose_entropy_production=true)
         success = success && ion_success
     end
     return success


### PR DESCRIPTION
This PR aims to bring support for Fokker-Planck collisions when moments are evolved separately from the pdf.

According to the documentation, the forms for the collision operator appearing in the kinetic equation when splitting the moments are as follows:
 - `evolve_density=true` https://mabarnes.github.io/moment_kinetics/dev/moment_kinetic_equations/#Separate-n_i 
```math
\frac{1}{n_i} C_ii[n_i F_i, n_i F_i] = n_i C_ii[ F_i,  F_i]
```
 - `evolve_upar=true` and  `evolve_density=true` https://mabarnes.github.io/moment_kinetics/dev/moment_kinetic_equations/#Separate-n_i-and-u_{i\\parallel} -- same as  `evolve_density=true` above.
 - `evolve_p = true` and `evolve_upar=true` and  `evolve_density=true` https://mabarnes.github.io/moment_kinetics/dev/moment_kinetic_equations/#ion_full_moment_kinetic_equation
 ```math
\frac{v_{Ti}^3}{n_i} C_ii[\frac{n_i}{v_{Ti}^3} F_i, \frac{n_i}{v_{Ti}^3} F_i] = \frac{n_i}{v_{Ti}^3} C_ii[ F_i,  F_i]
```
We include these factors for in the function https://github.com/mabarnes/moment_kinetics/blob/0e761f6260dfa4b5bf42bac3dc675be8cfa40e2b/moment_kinetics/src/fokker_planck.jl#L818-L836.

We do not support moment kinetic features in cross collisions or in https://github.com/mabarnes/moment_kinetics/blob/0e761f6260dfa4b5bf42bac3dc675be8cfa40e2b/moment_kinetics/src/fokker_planck.jl#L280-L290.

To do:
 - [] Add tests of moment-kinetic normalisation factors.