### PR TITLE
Save source temperature; 'sinusoid' source profile option

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
-    timeout-minutes: 35
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
-    timeout-minutes: 210
+    timeout-minutes: 240
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4

--- a/moment_kinetics/src/external_sources.jl
+++ b/moment_kinetics/src/external_sources.jl
@@ -569,6 +569,10 @@ function get_source_profile(profile_type, width, relative_minimum, coord)
     elseif profile_type == "super_gaussian_4"
         x = coord.grid
         return @. (1.0 - relative_minimum) * exp(-(x / width)^4) + relative_minimum
+    elseif profile_type == "sinusoid"
+        # Set so that profile can be 1 on the inner/lower boundary
+        x = coord.grid
+        return @. (1.0 - relative_minimum) * 0.5 * (1.0 - sinpi(x / width)) + relative_minimum
     else
         error("Unrecognised source profile type '$profile_type'.")
     end

--- a/moment_kinetics/src/external_sources.jl
+++ b/moment_kinetics/src/external_sources.jl
@@ -609,6 +609,8 @@ function initialize_external_source_amplitude!(moments, external_source_settings
                         ion_source_settings[index].source_strength *
                         ion_source_settings[index].r_amplitude[ir] *
                         ion_source_settings[index].z_amplitude[iz]
+                    moments.ion.external_source_T_array[iz,ir,index] =
+                        ion_source_settings[index].source_T_array[iz,ir]
                 end
                 if moments.evolve_density
                     @loop_r_z ir iz begin
@@ -653,6 +655,8 @@ function initialize_external_source_amplitude!(moments, external_source_settings
                         ion_source_settings[index].source_strength *
                         ion_source_settings[index].r_amplitude[ir] *
                         ion_source_settings[index].z_amplitude[iz]
+                    moments.ion.external_source_T_array[iz,ir,index] =
+                        ion_source_settings[index].source_T_array[iz,ir]
                 end
                 if moments.evolve_density
                     @loop_r_z ir iz begin
@@ -701,6 +705,8 @@ function initialize_external_source_amplitude!(moments, external_source_settings
                         electron_source_settings[index].source_strength *
                         electron_source_settings[index].r_amplitude[ir] *
                         electron_source_settings[index].z_amplitude[iz]
+                    moments.electron.external_source_T_array[iz,ir,index] =
+                        electron_source_settings[index].source_T_array[iz,ir]
                 end
                 @loop_r_z ir iz begin
                     moments.electron.external_source_density_amplitude[iz,ir,index] = 0.0
@@ -737,6 +743,8 @@ function initialize_external_source_amplitude!(moments, external_source_settings
                 @loop_r_z ir iz begin
                     moments.electron.external_source_amplitude[iz,ir,index] =
                         moments.ion.external_source_amplitude[iz,ir,index]
+                    moments.electron.external_source_T_array[iz,ir,index] =
+                        electron_source_settings[index].source_T_array[iz,ir]
                 end
                 if moments.evolve_density
                     @loop_r_z ir iz begin
@@ -791,6 +799,8 @@ function initialize_external_source_amplitude!(moments, external_source_settings
                             neutral_source_settings[index].source_strength *
                             neutral_source_settings[index].r_amplitude[ir] *
                             neutral_source_settings[index].z_amplitude[iz]
+                        moments.neutral.external_source_T_array[iz,ir,index] =
+                            neutral_source_settings[index].source_T_array[iz,ir]
                     end
                     if moments.evolve_density
                         @loop_r_z ir iz begin
@@ -835,6 +845,8 @@ function initialize_external_source_amplitude!(moments, external_source_settings
                             neutral_source_settings[index].source_strength *
                             neutral_source_settings[index].r_amplitude[ir] *
                             neutral_source_settings[index].z_amplitude[iz]
+                        moments.neutral.external_source_T_array[iz,ir,index] =
+                            neutral_source_settings[index].source_T_array[iz,ir]
                     end
                     if moments.evolve_density
                         @loop_r_z ir iz begin

--- a/moment_kinetics/src/load_data.jl
+++ b/moment_kinetics/src/load_data.jl
@@ -97,16 +97,19 @@ const neutral_moment_ddt_variables = ("neutral_ddens_dt", "neutral_dnupar_dt",
                                       "neutral_dupar_dt", "neutral_dp_dt",
                                       "neutral_dvth_dt")
 const ion_source_variables = ("external_source_amplitude",
+                              "external_source_T_array",
                               "external_source_density_amplitude",
                               "external_source_momentum_amplitude",
                               "external_source_pressure_amplitude",
                               "external_source_controller_integral")
 const neutral_source_variables = ("external_source_neutral_amplitude",
+                                  "external_source_neutral_T_array",
                                   "external_source_neutral_density_amplitude",
                                   "external_source_neutral_momentum_amplitude",
                                   "external_source_neutral_pressure_amplitude",
                                   "external_source_neutral_controller_integral")
 const electron_source_variables = ("external_source_electron_amplitude",
+                                   "external_source_electron_T_array",
                                    "external_source_electron_density_amplitude",
                                    "external_source_electron_momentum_amplitude",
                                    "external_source_electron_pressure_amplitude")

--- a/moment_kinetics/src/moment_kinetics_structs.jl
+++ b/moment_kinetics/src/moment_kinetics_structs.jl
@@ -192,6 +192,8 @@ struct moments_ion_substruct{ndim_moment_wall}
     dSdt::MPISharedArray{mk_float,ndim_moment}
     # Spatially varying amplitude of the external source term (third index is for different sources)
     external_source_amplitude::MPISharedArray{mk_float,ndim_moment}
+    # Spatially varying temperature of the external source term (third index is for different sources)
+    external_source_T_array::MPISharedArray{mk_float,ndim_moment}
     # Spatially varying amplitude of the density moment of the external source term
     external_source_density_amplitude::MPISharedArray{mk_float,ndim_moment}
     # Spatially varying amplitude of the parallel momentum moment of the external source
@@ -247,6 +249,8 @@ struct moments_electron_substruct{ndim_moment_electron_source}
     parallel_friction::MPISharedArray{mk_float,ndim_moment_electron}
     # Spatially varying amplitude of the external source term
     external_source_amplitude::MPISharedArray{mk_float,ndim_moment_electron_source}
+    # Spatially varying Temperature of the external source term
+    external_source_T_array::MPISharedArray{mk_float,ndim_moment_electron_source}
     # Spatially varying amplitude of the density moment of the external source term
     external_source_density_amplitude::MPISharedArray{mk_float,ndim_moment_electron_source}
     # Spatially varying amplitude of the parallel momentum moment of the external source
@@ -380,6 +384,8 @@ struct moments_neutral_substruct
     dvth_dt::Union{MPISharedArray{mk_float,ndim_moment},Nothing}
     # Spatially varying amplitude of the external source term
     external_source_amplitude::MPISharedArray{mk_float,ndim_moment}
+    # Spatially varying Temperature of the external source term
+    external_source_T_array::MPISharedArray{mk_float,ndim_moment}
     # Spatially varying amplitude of the density moment of the external source term
     external_source_density_amplitude::MPISharedArray{mk_float,ndim_moment}
     # Spatially varying amplitude of the parallel momentum moment of the external source

--- a/moment_kinetics/src/velocity_moments.jl
+++ b/moment_kinetics/src/velocity_moments.jl
@@ -206,6 +206,7 @@ function create_moments_ion(nz, nr, n_species, evolve_density, evolve_upar,
     n_sources = length(ion_source_settings)
     if any(x -> x.active, ion_source_settings)
         external_source_amplitude = allocate_shared_float(nz, nr, n_sources)
+        external_source_T_array = allocate_shared_float(nz, nr, n_sources)
         if evolve_density
             external_source_density_amplitude = allocate_shared_float(nz, nr, n_sources)
         else
@@ -233,6 +234,7 @@ function create_moments_ion(nz, nr, n_species, evolve_density, evolve_upar,
         end
     else
         external_source_amplitude = allocate_shared_float(1, 1, n_sources)
+        external_source_T_array = allocate_shared_float(1, 1, n_sources)
         external_source_density_amplitude = allocate_shared_float(1, 1, n_sources)
         external_source_momentum_amplitude = allocate_shared_float(1, 1, n_sources)
         external_source_pressure_amplitude = allocate_shared_float(1, 1, n_sources)
@@ -264,10 +266,10 @@ function create_moments_ion(nz, nr, n_species, evolve_density, evolve_upar,
         dupar_dr, dupar_dr_upwind, dupar_dz, dupar_dz_upwind, d2upar_dz2, dp_dr_upwind,
         dp_dz, dp_dz_upwind, d2p_dz2, dppar_dz, dqpar_dz, dvth_dr, dvth_dz, dT_dz,
         ddens_dt, dupar_dt, dnupar_dt, dp_dt, dvth_dt, entropy_production,
-        external_source_amplitude, external_source_density_amplitude,
-        external_source_momentum_amplitude, external_source_pressure_amplitude,
-        external_source_controller_integral, constraints_A_coefficient,
-        constraints_B_coefficient, constraints_C_coefficient)
+        external_source_amplitude, external_source_T_array,
+        external_source_density_amplitude, external_source_momentum_amplitude,
+        external_source_pressure_amplitude, external_source_controller_integral,
+        constraints_A_coefficient, constraints_B_coefficient, constraints_C_coefficient)
 end
 
 """
@@ -302,6 +304,7 @@ function create_moments_electron(nz, nr, electron_model, num_diss_params, n_sour
     parallel_friction_force = allocate_shared_float(nz, nr)
     # allocate arrays used for external sources (third index is for the different sources)
     external_source_amplitude = allocate_shared_float(nz, nr, n_sources)
+    external_source_T_array = allocate_shared_float(nz, nr, n_sources)
     external_source_density_amplitude = allocate_shared_float(nz, nr, n_sources)
     external_source_momentum_amplitude = allocate_shared_float(nz, nr, n_sources)
     external_source_pressure_amplitude = allocate_shared_float(nz, nr, n_sources)
@@ -373,11 +376,11 @@ function create_moments_electron(nz, nr, electron_model, num_diss_params, n_sour
         parallel_flow_updated, pressure, pressure_updated, parallel_pressure,
         perpendicular_pressure, temperature, temperature_updated, parallel_heat_flux,
         parallel_heat_flux_updated, thermal_speed, parallel_friction_force,
-        external_source_amplitude, external_source_density_amplitude,
-        external_source_momentum_amplitude, external_source_pressure_amplitude,
-        v_norm_fac, ddens_dz, dupar_dz, dp_dz, d2p_dz2, dppar_dz, dqpar_dz, dT_dz,
-        dT_dz_upwind, dvth_dz, dp_dt, dT_dt, dvth_dt, constraints_A_coefficient,
-        constraints_B_coefficient, constraints_C_coefficient)
+        external_source_amplitude, external_source_T_array,
+        external_source_density_amplitude, external_source_momentum_amplitude,
+        external_source_pressure_amplitude, v_norm_fac, ddens_dz, dupar_dz, dp_dz,
+        d2p_dz2, dppar_dz, dqpar_dz, dT_dz, dT_dz_upwind, dvth_dz, dp_dt, dT_dt, dvth_dt,
+        constraints_A_coefficient, constraints_B_coefficient, constraints_C_coefficient)
 end
 
 # neutral particles have natural mean velocities 
@@ -505,6 +508,7 @@ function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
     n_sources = length(neutral_source_settings)
     if any(x -> x.active, neutral_source_settings)
         external_source_amplitude = allocate_shared_float(nz, nr, n_sources)
+        external_source_T_array = allocate_shared_float(nz, nr, n_sources)
         if evolve_density
             external_source_density_amplitude = allocate_shared_float(nz, nr, n_sources)
         else
@@ -532,6 +536,7 @@ function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
         end
     else
         external_source_amplitude = allocate_shared_float(1, 1, n_sources)
+        external_source_T_array = allocate_shared_float(1, 1, n_sources)
         external_source_density_amplitude = allocate_shared_float(1, 1, n_sources)
         external_source_momentum_amplitude = allocate_shared_float(1, 1, n_sources)
         external_source_pressure_amplitude = allocate_shared_float(1, 1, n_sources)
@@ -560,10 +565,10 @@ function create_moments_neutral(nz, nr, n_species, evolve_density, evolve_upar,
         pzeta, pzeta_updated, qz, qz_updated, vth, v_norm_fac, ddens_dz, ddens_dz_upwind,
         d2dens_dz2, duz_dz, duz_dz_upwind, d2uz_dz2, dp_dz, dp_dz_upwind, d2p_dz2, dpz_dz,
         dqz_dz, dvth_dz, ddens_dt, duz_dt, dnuz_dt, dp_dt, dvth_dt,
-        external_source_amplitude, external_source_density_amplitude,
-        external_source_momentum_amplitude, external_source_pressure_amplitude,
-        external_source_controller_integral, constraints_A_coefficient,
-        constraints_B_coefficient, constraints_C_coefficient)
+        external_source_amplitude, external_source_T_array,
+        external_source_density_amplitude, external_source_momentum_amplitude,
+        external_source_pressure_amplitude, external_source_controller_integral,
+        constraints_A_coefficient, constraints_B_coefficient, constraints_C_coefficient)
 end
 
 """


### PR DESCRIPTION
* Write the `source_T` arrays to output, since #380 allowed the external source temperature to be a spatially varying quantity.
* `'sinusoid'` option for external source profiles. Useful for periodic dimensions.