### PR TITLE
Work around slow parallel test CI job

### DIFF
--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -10,8 +10,26 @@ permissions:
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 180
 
+    strategy:
+      matrix:
+        numprocs: [2, 3, 4]
+        isMaster:
+          - ${{ github.ref == 'master' }}
+        include:
+          # Default to no "--long" flag
+          - long: ""
+          # Add "--long" flag when running with numprocs=2
+          - long: "--long"
+            numprocs: 2
+        exclude:
+          - isMaster: false
+            numprocs: 3
+          - isMaster: false
+            numprocs: 4
+
+    # Only run 3 and 4 proc tests when merging to master.
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
@@ -27,9 +45,7 @@ jobs:
           julia --project -O3 -e 'import Pkg; Pkg.precompile()'
           julia --project -O3 precompile.jl
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores
-          ./mpiexecjl -np 2 --oversubscribe julia -J moment_kinetics.so --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1 --long
-          ./mpiexecjl -np 4 --oversubscribe julia -J moment_kinetics.so --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1
-          ./mpiexecjl -np 3 --oversubscribe julia -J moment_kinetics.so --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1
+          ./mpiexecjl -np ${{ matrix.numprocs }} --oversubscribe julia -J moment_kinetics.so --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1 ${{ matrix.long }}
           # Note: MPI.jl's default implementation is mpich, which has a similar option
           # `--with-device=ch3:sock`, but that needs to be set when compiling mpich.
         shell: bash
@@ -37,7 +53,7 @@ jobs:
   # macOS is slow at the moment, so only run one set of parallel tests
   test-macOS:
     runs-on: macOS-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -43,9 +43,8 @@ jobs:
           julia --project -O3 -e 'using MPI; MPI.install_mpiexecjl(; destdir=".")'
           julia --project -O3 -e 'import Pkg; Pkg.add(["NCDatasets", "Random", "SpecialFunctions", "StatsBase", "Test"]); Pkg.develop(path="moment_kinetics/")'
           julia --project -O3 -e 'import Pkg; Pkg.precompile()'
-          julia --project -O3 precompile.jl
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores
-          ./mpiexecjl -np ${{ matrix.numprocs }} --oversubscribe julia -J moment_kinetics.so --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1 ${{ matrix.long }}
+          ./mpiexecjl -np ${{ matrix.numprocs }} --oversubscribe julia --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1 ${{ matrix.long }}
           # Note: MPI.jl's default implementation is mpich, which has a similar option
           # `--with-device=ch3:sock`, but that needs to be set when compiling mpich.
         shell: bash
@@ -71,9 +70,8 @@ jobs:
           julia --project -O3 -e 'using MPI; MPI.install_mpiexecjl(; destdir=".")'
           julia --project -O3 -e 'import Pkg; Pkg.add(["NCDatasets", "Random", "SpecialFunctions", "StatsBase", "Test"]); Pkg.develop(path="moment_kinetics/")'
           julia --project -O3 -e 'import Pkg; Pkg.precompile()'
-          julia --project -O3 precompile.jl
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores
-          ./mpiexecjl -np 4 --oversubscribe julia -J moment_kinetics.so --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1
+          ./mpiexecjl -np 4 --oversubscribe julia --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1
           # Note: MPI.jl's default implementation is mpich, which has a similar option
           # `--with-device=ch3:sock`, but that needs to be set when compiling mpich.
         shell: bash

--- a/.github/workflows/parallel_test.yml
+++ b/.github/workflows/parallel_test.yml
@@ -71,7 +71,7 @@ jobs:
           julia --project -O3 -e 'import Pkg; Pkg.add(["NCDatasets", "Random", "SpecialFunctions", "StatsBase", "Test"]); Pkg.develop(path="moment_kinetics/")'
           julia --project -O3 -e 'import Pkg; Pkg.precompile()'
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores
-          ./mpiexecjl -np 4 --oversubscribe julia --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1
+          ./mpiexecjl -np 2 --oversubscribe julia --project -O3 moment_kinetics/test/runtests.jl --ci --debug 1
           # Note: MPI.jl's default implementation is mpich, which has a similar option
           # `--with-device=ch3:sock`, but that needs to be set when compiling mpich.
         shell: bash


### PR DESCRIPTION
* Split runs for different numbers of processes into different jobs.
* Only run 3 and 4 proc runs on merge to master.
* Don't build the `.so` system image. Seems to slow things down rather than speed them up (at the moment?).