### PR TITLE
Fix typo in longtest.yml CI job, and set fail-fast to false

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -49,6 +49,7 @@ jobs:
             soimage: ""
           - numprocs: 4
             soimage: "-J moment_kinetics.so"
+      fail-fast: false
 
     # Only run 3 and 4 proc tests when merging to master.
     steps:
@@ -66,7 +67,7 @@ jobs:
           julia --project -O3 -e 'import Pkg; Pkg.precompile()'
       - if: ${{ matrix.numprocs == 4 }}
         run: |
-          julia --project -O3 -e 'import Pkg; Pkg.add(["PackageCompiler")'
+          julia --project -O3 -e 'import Pkg; Pkg.add(["PackageCompiler"])'
           julia --project -O3 precompile.jl
       - run: |
           # Need to use openmpi so that we can use `--oversubscribe` to allow using more MPI ranks than physical cores


### PR DESCRIPTION
fail-fast had not been set previously for the parallel jobs.