### PR TITLE
1st order IMEX method - forward/backward Euler

### DIFF
--- a/moment_kinetics/src/runge_kutta.jl
+++ b/moment_kinetics/src/runge_kutta.jl
@@ -264,6 +264,17 @@ function setup_runge_kutta_coefficients!(type, input_CFL_prefactor, split_operat
         adaptive = false
         low_storage = false
         CFL_prefactor = NaN
+    elseif type == "EulerIMEX"
+        # 1st-order, 1-stage IMEX method, combination of forward and backward Euler steps.
+        rk_coefs = mk_float[0;
+                            1;;]
+        rk_coefs_implicit = mk_float[1 0]
+        implicit_coefficient_is_zero = Bool[false]
+        n_rk_stages = 1
+        rk_order = 1
+        adaptive = false
+        low_storage = false
+        CFL_prefactor = NaN
     elseif type == "SSPRK4"
         n_rk_stages = 4
         rk_coefs = allocate_float(3, n_rk_stages)
@@ -331,25 +342,25 @@ function setup_runge_kutta_coefficients!(type, input_CFL_prefactor, split_operat
         correct_size = (3, n_rk_stages + adaptive)
         if size(rk_coefs) != correct_size
             error("Size of rk_coefs, $(size(rk_coefs)) is not "
-                  * "(n_rk_stages+1, n_rk_stages+1)=$correct_size")
+                  * "(n_rk_stages+1, n_rk_stages+adaptive)=$correct_size")
         end
 
         correct_size_implicit = (3, n_rk_stages + 1 + adaptive)
         if rk_coefs_implicit !== nothing && size(rk_coefs_implicit) != correct_size_implicit
             error("Size of rk_coefs_implicit, $(size(rk_coefs_implicit)) is not "
-                  * "(3, n_rk_stages+2)=$correct_size_implicit")
+                  * "(3, n_rk_stages+1+adaptive)=$correct_size_implicit")
         end
     else
         correct_size = (n_rk_stages + 1, n_rk_stages + adaptive)
         if size(rk_coefs) != correct_size
             error("Size of rk_coefs, $(size(rk_coefs)) is not "
-                  * "(n_rk_stages+1, n_rk_stages+1)=$correct_size")
+                  * "(n_rk_stages+1, n_rk_stages+adaptive)=$correct_size")
         end
 
         correct_size_implicit = (n_rk_stages, n_rk_stages + 1 + adaptive)
         if rk_coefs_implicit !== nothing && size(rk_coefs_implicit) != correct_size_implicit
             error("Size of rk_coefs_implicit, $(size(rk_coefs_implicit)) is not "
-                  * "(n_rk_stages, n_rk_stages+2)=$correct_size_implicit")
+                  * "(n_rk_stages, n_rk_stages+1+adaptive)=$correct_size_implicit")
         end
     end
 

--- a/moment_kinetics/test/fokker_planck_time_evolution_tests.jl
+++ b/moment_kinetics/test/fokker_planck_time_evolution_tests.jl
@@ -549,7 +549,7 @@ function runtests(; highres=false)
                          vpa=OptionsDict("bc" => vpa_bc, "L" => Lvpa),
                          evolve_moments=OptionsDict("density" => evolve_density, "parallel_flow" => evolve_upar, "pressure" => evolve_p))
             end
-            @testset "Gauss Legendre no (explicitly) enforced boundary conditions: IMEX timestepping" begin
+            @testset "Gauss Legendre no (explicitly) enforced boundary conditions: IMEX timestepping PareschiRusso3(4,3,3)" begin
                 run_name = "gausslegendre_pseudospectral_none_bc"
                 vperp_bc = "none"
                 vpa_bc = "none"
@@ -570,6 +570,28 @@ function runtests(; highres=false)
                                                                                "nonlinear_max_iterations" => 20,),
                          timestepping=OptionsDict("kinetic_ion_solver" => "implicit_ion_fp_collisions",
                                                   "type" => "PareschiRusso3(4,3,3)",))
+            end
+            @testset "Gauss Legendre no (explicitly) enforced boundary conditions: IMEX timestepping EulerIMEX" begin
+                run_name = "gausslegendre_pseudospectral_none_bc"
+                vperp_bc = "none"
+                vpa_bc = "none"
+                if highres
+                    this_expected = expected_none_bc_highres
+                    this_input = test_input_gauss_legendre_highres
+                else
+                    this_expected = expected_none_bc[(evolve_density, evolve_upar, evolve_p)]
+                    this_input = test_input_gauss_legendre
+                end
+                run_test(this_input, this_expected, 10.0 * tol3, tol4;
+                         interp_to_expected=highres,
+                         vperp=OptionsDict("bc" => vperp_bc, "L" => Lvperp),
+                         vpa=OptionsDict("bc" => vpa_bc, "L" => Lvpa),
+                         evolve_moments=OptionsDict("density" => evolve_density, "parallel_flow" => evolve_upar, "pressure" => evolve_p),
+                         fokker_planck_collisions_nonlinear_solver=OptionsDict("rtol" => 0.0,
+                                                                               "atol" => 1.0e-14,
+                                                                               "nonlinear_max_iterations" => 20,),
+                         timestepping=OptionsDict("kinetic_ion_solver" => "implicit_ion_fp_collisions",
+                                                  "type" => "EulerIMEX",))
             end
         end
     end

--- a/util/calculate_rk_coeffs.jl
+++ b/util/calculate_rk_coeffs.jl
@@ -1135,6 +1135,17 @@ function calculate_all_coeffs()
                      ],
         typeof(alpha)[0 1//6 1//6 2//3],
         ; low_storage=false)
+
+    # 1st-order, 1-stage IMEX method, combination of forward and backward Euler steps.
+    convert_and_check_butcher_tableau(
+        "EulerIMEX",
+        Rational{Int64}[0;
+                       ],
+        Rational{Int64}[1],
+        Rational{Int64}[1;
+                       ],
+        Rational{Int64}[1],
+        ; low_storage=false)
 end
 
 end # CalculateRKCoeffs

--- a/util/test-rk-timestep.jl
+++ b/util/test-rk-timestep.jl
@@ -1,4 +1,7 @@
 include("calculate_rk_coeffs.jl")
+using .CalculateRKCoeffs: convert_rk_coefs_to_butcher_tableau
+
+using OrderedCollections: OrderedDict
 
 multiplier = 1
 dt = 1.0e-2 / multiplier
@@ -238,7 +241,7 @@ function rk4_by_hand(y0, dt, nsteps)
     return result
 end
 
-methods = Dict(
+methods = OrderedDict(
     "SSPRK3" => (rk_coefs=Float64[0 3//4 1//3; 1 0 0; 0 1//4 0; 0 0 2//3],
                  a=Float64[0 0 0; 1 0 0; 1//4 1//4 0],
                  b=Float64[1//6 1//6 2//3]),

--- a/util/test-rk-timestep.jl
+++ b/util/test-rk-timestep.jl
@@ -41,7 +41,7 @@ function rk_advance_explicit(rk_coefs, y0, dt, nsteps)
     result = zeros(nsteps+1)
     result[1] = y0
 
-    error = zeros(nsteps+1)
+    error = fill(NaN, nsteps+1)
 
     for it ∈ 1:nsteps
         for istage ∈ 1:n_rk_stages
@@ -83,7 +83,7 @@ function rk_advance(rk_coefs, y0, dt, nsteps, rk_coefs_implicit=nothing, implici
     result = zeros(nsteps+1)
     result[1] = y0
 
-    error = zeros(nsteps+1)
+    error = fill(NaN, nsteps+1)
 
     for it ∈ 1:nsteps
         for istage ∈ 1:n_rk_stages
@@ -155,7 +155,7 @@ function rk_advance_butcher_explicit(a, b, y0, dt, nsteps)
     result = zeros(nsteps+1)
     result[1] = y0
 
-    error = zeros(nsteps+1)
+    error = fill(NaN, nsteps+1)
 
     for it ∈ 1:nsteps
         kscratch[1] = dt*f(y)
@@ -194,7 +194,7 @@ function rk_advance_butcher(a, b, y0, dt, nsteps, a_implicit=nothing, b_implicit
     result = zeros(nsteps+1)
     result[1] = y0
 
-    error = zeros(nsteps+1)
+    error = fill(NaN, nsteps+1)
 
     for it ∈ 1:nsteps
         kscratch_implicit[1] = dt*f_implicit(y, a_implicit[1,1] * dt)
@@ -364,6 +364,15 @@ methods = OrderedDict(
                                 rk_coefs_implicit=Float64[0.24169426078821 -1.0 3.13745860881766 1.0436096431476471e-14 0.16666666666665975; -0.0 0.24169426078821 2.13745860881766 -0.24999999999997924 0.3333333333333193; -0.0 -0.0 0.24169426078821 0.034364652204404655 0.500000000000007; -0.0 -0.0 -0.0 0.24169426078821 2.0916390725451066],
                                 implicit_coefficient_is_zero=Bool[0, 0, 0, 0],
                                ),
+
+    "EulerIMEX" => (a=Rational{Int64}[0],
+                    b=Rational{Int64}[1],
+                    a_implicit=Rational{Int64}[1],
+                    b_implicit=Rational{Int64}[1],
+                    rk_coefs=Rational{BigInt}[0; 1;;],
+                    rk_coefs_implicit=Rational{BigInt}[1 0],
+                    implicit_coefficient_is_zero=Bool[0],
+                   ),
   )
 
 a, b = convert_rk_coefs_to_butcher_tableau(methods["RKF45"].rk_coefs, true, false)


### PR DESCRIPTION
Maybe useful for testing, etc. Backward Euler should be 'dissipative' in some sense, so this method might be useful for reaching close to steady state quickly?

Closes #347 - if all the terms included (e.g. the Fokker-Planck collision operator in a 0D simulation) are included in the implicit part of the timestep, then this is the backward Euler method.