### PR TITLE
Remove uses of Base.get_extension()

### DIFF
--- a/moment_kinetics/debug_test/sound_wave_inputs.jl
+++ b/moment_kinetics/debug_test/sound_wave_inputs.jl
@@ -231,7 +231,7 @@ recursive_merge(test_input_chebyshev_1D1V_split_2_moments,
                             "evolve_moments" => OptionsDict("pressure" => true)))
 
 # Use "netcdf" for a few tests to test the NetCDF I/O if it is available.
-const binary_format = io_has_implementation(netcdf) ? "netcdf" : "hdf5"
+const binary_format = io_has_implementation(Val(netcdf)) ? "netcdf" : "hdf5"
 
 test_input_chebyshev_cx0_1D1V =
 recursive_merge(test_input_chebyshev_1D1V,

--- a/moment_kinetics/ext/file_io_netcdf.jl
+++ b/moment_kinetics/ext/file_io_netcdf.jl
@@ -6,16 +6,20 @@
 # `using Pkg; Pkg.precompile(strict=true)`.
 module file_io_netcdf
 
-import moment_kinetics.file_io: io_has_parallel, open_output_file_implementation,
-                                create_io_group, get_group, is_group, get_subgroup_keys,
-                                get_variable_keys, add_attribute!, modify_attribute!,
-                                write_single_value!, create_dynamic_variable!,
-                                append_to_dynamic_var
+import moment_kinetics.file_io: io_has_implementation, io_has_parallel,
+                                open_output_file_implementation, create_io_group,
+                                get_group, is_group, get_subgroup_keys, get_variable_keys,
+                                add_attribute!, modify_attribute!, write_single_value!,
+                                create_dynamic_variable!, append_to_dynamic_var
 import moment_kinetics.load_data: open_file_to_read, get_attribute, load_variable, load_slice
 using moment_kinetics.coordinates: coordinate
 using moment_kinetics.input_structs: netcdf
 
 using NCDatasets
+
+function io_has_implementation(::Val{netcdf})
+    return true
+end
 
 function io_has_parallel(::Val{netcdf})
     # NCDatasets.jl does not support parallel I/O yet

--- a/moment_kinetics/ext/manufactured_solns_ext.jl
+++ b/moment_kinetics/ext/manufactured_solns_ext.jl
@@ -11,11 +11,19 @@ using moment_kinetics.looping
 using moment_kinetics.moment_kinetics_structs
 using moment_kinetics.type_definitions: mk_int, mk_float
 
-import moment_kinetics.manufactured_solns: manufactured_solutions, manufactured_sources_setup,
-                                           manufactured_electric_fields, manufactured_geometry
+import moment_kinetics.manufactured_solns: manufactured_solutions_extension_loadable,
+                                           manufactured_solutions,
+                                           manufactured_sources_setup,
+                                           manufactured_electric_fields,
+                                           manufactured_geometry
 
 using Symbolics
 using IfElse
+
+    function manufactured_solutions_extension_loadable()
+        # Used to check whether this extension is loaded.
+        return true
+    end
 
     @variables r z vpa vperp t vz vr vzeta
     const typed_zero(vz) = zero(vz)

--- a/moment_kinetics/src/file_io.jl
+++ b/moment_kinetics/src/file_io.jl
@@ -400,15 +400,10 @@ Test if the backend supports parallel I/O.
 """
 function io_has_parallel end
 
-function io_has_implementation(binary_format::binary_format_type)
-    if binary_format == hdf5
-        return true
-    elseif binary_format == netcdf
-        netcdf_ext = Base.get_extension(@__MODULE__, :file_io_netcdf)
-        return netcdf_ext !== nothing
-    else
-        error("Unrecognised binary format $binary_format")
-    end
+function io_has_implementation(::Val)
+    # This method will be overridden by more specific versions (some only if an extension
+    # is loaded).
+    return false
 end
 
 """
@@ -417,7 +412,7 @@ end
 Check that an implementation is available for `binary_format`, raising an error if not.
 """
 function check_io_implementation(binary_format)
-    if !io_has_implementation(binary_format)
+    if !io_has_implementation(Val(binary_format))
         if binary_format == netcdf
             error("NCDatasets is not installed, cannot use NetCDF I/O. Re-run "
                   * "machines/machine-setup.sh and activate NetCDF, or install "

--- a/moment_kinetics/src/file_io_hdf5.jl
+++ b/moment_kinetics/src/file_io_hdf5.jl
@@ -8,6 +8,10 @@ using MPI
 # when using parallel I/O (as of version 0.17.2).
 const string_array_size = 256
 
+function io_has_implementation(::Val{hdf5})
+    return true
+end
+
 function io_has_parallel(::Val{hdf5})
     return HDF5.has_parallel()
 end

--- a/moment_kinetics/test/sound_wave_tests.jl
+++ b/moment_kinetics/test/sound_wave_tests.jl
@@ -21,7 +21,7 @@ const regression_range = 5:10
 
 # Use "netcdf" to test the NetCDF I/O if it is available (or if we are forcing optional
 # dependencies to be used, e.g. for CI tests), otherwise fall back to "hdf5".
-const binary_format = (force_optional_dependencies || io_has_implementation(netcdf)) ?
+const binary_format = (force_optional_dependencies || io_has_implementation(Val(netcdf))) ?
                       "netcdf" : "hdf5"
 
 # default inputs for tests


### PR DESCRIPTION
Apparently using `Base.get_extension()` is a bad thing (https://github.com/JuliaLang/julia/pull/59593), so avoid it, by defining a couple of extra functions to be overloaded by the extensions.