### PR TITLE
Fix version selection when downloading Julia in machine_setup.sh

### DIFF
--- a/machines/generic-pc/get-julia.sh
+++ b/machines/generic-pc/get-julia.sh
@@ -5,11 +5,11 @@
 case "$(uname -s)" in
 
    Darwin*)
-     machines/shared/get-julia-macos.sh
+     machines/shared/get-julia-macos.sh $@
      ;;
 
    Linux*)
-     machines/shared/get-julia-linux-x86_64.sh
+     machines/shared/get-julia-linux-x86_64.sh $@
      ;;
 
    CYGWIN*|MINGW*|MINGW32*|MSYS*)


### PR DESCRIPTION
Bug was caused by failure to pass argument through an intermediate shell script.