### PR TITLE
Multiple-variable version of halo_swap!()

### DIFF
--- a/moment_kinetics/src/electron_fluid_equations.jl
+++ b/moment_kinetics/src/electron_fluid_equations.jl
@@ -174,13 +174,9 @@ function calculate_electron_moments!(scratch, pdf, moments, composition, collisi
     # The anyzv loop over r above skips points in r that are duplicated (i.e. one of the
     # copies of the element boundary points at sub-domain or periodic boundaries). Now
     # fill in the duplicate points.
-    halo_swap!(scratch.electron_density, r, z)
-    halo_swap!(scratch.electron_upar, r, z)
-    halo_swap!(scratch.electron_p, r, z)
-    halo_swap!(moments.electron.vth, r, z)
-    halo_swap!(moments.electron.temp, r, z)
-    halo_swap!(moments.electron.ppar, r, z)
-    halo_swap!(moments.electron.qpar, r, z)
+    halo_swap!(r, z, scratch.electron_density, scratch.electron_upar, scratch.electron_p,
+               moments.electron.vth, moments.electron.temp, moments.electron.ppar,
+               moments.electron.qpar)
 
     return nothing
 end

--- a/moment_kinetics/src/electron_kinetic_equation.jl
+++ b/moment_kinetics/src/electron_kinetic_equation.jl
@@ -489,12 +489,6 @@ function update_electron_pdf_with_time_advance!(scratch, pdf, moments,
     @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
         pdf[ivpa,ivperp,iz,ir] = final_scratch_pdf[ivpa,ivperp,iz,ir]
     end
-    # The anyzv loop over r above skips points in r that are duplicated (i.e. one of the
-    # copies of the element boundary points at sub-domain or periodic boundaries). Now
-    # fill in the duplicate points.
-    halo_swap!(pdf, r, z)
-    halo_swap!(moments.electron.ppar, r, z)
-    halo_swap!(moments.electron.qpar, r, z)
 
     if evolve_p
         # Update `moments.electron.p` with the final electron pressure
@@ -504,10 +498,16 @@ function update_electron_pdf_with_time_advance!(scratch, pdf, moments,
         @loop_r_z ir iz begin
             moments_p[iz,ir] = scratch_p[iz,ir]
         end
-        halo_swap!(moments_p, r, z)
-        halo_swap!(moments.electron.upar, r, z)
-        halo_swap!(moments.electron.vth, r, z)
-        halo_swap!(moments.electron.temp, r, z)
+        # The anyzv loop over r above skips points in r that are duplicated (i.e. one of
+        # the copies of the element boundary points at sub-domain or periodic boundaries).
+        # Now fill in the duplicate points.
+        halo_swap!(r, z, pdf, moments.electron.ppar, moments.electron.qpar, moments_p,
+                   moments.electron.upar, moments.electron.vth, moments.electron.temp)
+    else
+        # The anyzv loop over r above skips points in r that are duplicated (i.e. one of
+        # the copies of the element boundary points at sub-domain or periodic boundaries).
+        # Now fill in the duplicate points.
+        halo_swap!(r, z, pdf, moments.electron.ppar, moments.electron.qpar)
     end
     if !all(all_electron_pdf_converged)
         success = "kinetic-electrons"
@@ -974,12 +974,6 @@ function electron_backward_euler_pseudotimestepping!(scratch, pdf, moments,
     @loop_r_z_vperp_vpa ir iz ivperp ivpa begin
         pdf[ivpa,ivperp,iz,ir] = final_scratch_pdf[ivpa,ivperp,iz,ir]
     end
-    # The anyzv loop over r above skips points in r that are duplicated (i.e. one of the
-    # copies of the element boundary points at sub-domain or periodic boundaries). Now
-    # fill in the duplicate points.
-    halo_swap!(pdf, r, z)
-    halo_swap!(moments.electron.ppar, r, z)
-    halo_swap!(moments.electron.qpar, r, z)
 
     if evolve_p
         # Update `moments.electron.p` with the final electron pressure
@@ -989,10 +983,16 @@ function electron_backward_euler_pseudotimestepping!(scratch, pdf, moments,
         @loop_r_z ir iz begin
             moments_p[iz,ir] = scratch_p[iz,ir]
         end
-        halo_swap!(moments_p, r, z)
-        halo_swap!(moments.electron.upar, r, z)
-        halo_swap!(moments.electron.vth, r, z)
-        halo_swap!(moments.electron.temp, r, z)
+        # The anyzv loop over r above skips points in r that are duplicated (i.e. one of the
+        # copies of the element boundary points at sub-domain or periodic boundaries). Now
+        # fill in the duplicate points.
+        halo_swap!(r, z, pdf, moments.electron.ppar, moments.electron.qpar, moments_p,
+                   moments.electron.upar, moments.electron.vth, moments.electron.temp)
+    else
+        # The anyzv loop over r above skips points in r that are duplicated (i.e. one of the
+        # copies of the element boundary points at sub-domain or periodic boundaries). Now
+        # fill in the duplicate points.
+        halo_swap!(r, z, pdf, moments.electron.ppar, moments.electron.qpar)
     end
 
     if !all(all_electron_pdf_converged)
@@ -2240,13 +2240,9 @@ to allow the outer r-loop to be parallelised.
     # The anyzv loop over r above skips points in r that are duplicated (i.e. one of the
     # copies of the element boundary points at sub-domain or periodic boundaries). Now
     # fill in the duplicate points.
-    halo_swap!(pdf_electron_out, r, z)
-    halo_swap!(electron_p_out, r, z)
-    halo_swap!(moments.electron.ppar, r, z)
-    halo_swap!(moments.electron.qpar, r, z)
-    halo_swap!(mometns.electron.upar, r, z)
-    halo_swap!(moments.electron.vth, r, z)
-    halo_swap!(moments.electron.temp, r, z)
+    halo_swap!(r, z, pdf_electron_out, electron_p_out, moments.electron.ppar,
+               moments.electron.qpar, moments.electron.upar, moments.electron.vth,
+               moments.electron.temp)
 
     # Fill pdf.electron.norm
     non_scratch_pdf = pdf.electron.norm

--- a/moment_kinetics/src/time_advance.jl
+++ b/moment_kinetics/src/time_advance.jl
@@ -990,12 +990,13 @@ function _setup_time_advance_internal!(pdf, fields, vz, vr, vzeta, vpa, vperp, z
                 end
             end
         end
-        @_block_synchronize()
-        halo_swap!(moments.ion.dens, r, z)
+        # halo_swap!() effecively works in a serial region, so no need to synchronize
+        # here.
         if !moments.evolve_density
-            halo_swap!(pdf.ion.norm, r, z)
+            halo_swap!(r, z, moments.ion.dens, pdf.ion.norm)
+        else
+            halo_swap!(r, z, moments.ion.dens)
         end
-        @_block_synchronize()
         @serial_region begin
             @views moments.electron.dens .= moments.ion.dens[:,:,1]
         end


### PR DESCRIPTION
Should be more efficient when needing to halo-swap several variables at the same time. This replaces the single-variable versions, and changes the syntax slightly (r-, z-coordinates are first arguments, so that final argument can be arbitrary-length list).

Also adds some missing `halo_swap!()` calls that will be needed for kinetic electrons to work in 2D.